### PR TITLE
 Initialize fork graph in program cache during bank_forks creation

### DIFF
--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -334,7 +334,7 @@ fn main() {
 
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let bank0 = Bank::new_for_benches(&genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+    let bank_forks = BankForks::new(bank0);
     let mut bank = bank_forks.read().unwrap().working_bank();
 
     // set cost tracker limits to MAX so it will not filter out TXs

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -334,7 +334,7 @@ fn main() {
 
     let (replay_vote_sender, _replay_vote_receiver) = unbounded();
     let bank0 = Bank::new_for_benches(&genesis_config);
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
     let mut bank = bank_forks.read().unwrap().working_bank();
 
     // set cost tracker limits to MAX so it will not filter out TXs

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -587,7 +587,7 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let mint_pubkey = genesis.mint_keypair.pubkey();
@@ -626,7 +626,7 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let mint_pubkey = &genesis.mint_keypair.pubkey();
         let bob_pubkey = solana_sdk::pubkey::new_rand();

--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -587,7 +587,7 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let mint_pubkey = genesis.mint_keypair.pubkey();
@@ -626,7 +626,7 @@ mod tests {
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let mint_pubkey = &genesis.mint_keypair.pubkey();
         let bob_pubkey = solana_sdk::pubkey::new_rand();

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -132,7 +132,7 @@ fn test_account_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -230,7 +230,7 @@ fn test_block_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
 
     // setup Blockstore
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -338,7 +338,7 @@ fn test_program_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -425,7 +425,7 @@ fn test_root_subscription() {
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -477,7 +477,7 @@ fn test_slot_subscription() {
     let exit = Arc::new(AtomicBool::new(false));
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
     let optimistically_confirmed_bank =
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -553,7 +553,7 @@ async fn test_slot_subscription_async() {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());

--- a/client-test/tests/client.rs
+++ b/client-test/tests/client.rs
@@ -132,7 +132,7 @@ fn test_account_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -230,7 +230,7 @@ fn test_block_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
 
     // setup Blockstore
     let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -338,7 +338,7 @@ fn test_program_subscription() {
     } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
     let blockhash = bank.last_blockhash();
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -425,7 +425,7 @@ fn test_root_subscription() {
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
     let bank0 = bank_forks.read().unwrap().get(0).unwrap();
     let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
     bank_forks.write().unwrap().insert(bank1);
@@ -477,7 +477,7 @@ fn test_slot_subscription() {
     let exit = Arc::new(AtomicBool::new(false));
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_tests(&genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
     let optimistically_confirmed_bank =
         OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
     let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -553,7 +553,7 @@ async fn test_slot_subscription_async() {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -56,7 +56,7 @@ use {
     },
     std::{
         iter::repeat_with,
-        sync::{atomic::Ordering, Arc, RwLock},
+        sync::{atomic::Ordering, Arc},
         time::{Duration, Instant},
     },
     test::Bencher,

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -217,7 +217,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     let mut bank = Bank::new_for_benches(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench
     bank.ns_per_slot = u128::MAX;
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
     let bank = bank_forks.read().unwrap().get(0).unwrap();
 
     // set cost tracker limits to MAX so it will not filter out TXs

--- a/core/benches/banking_stage.rs
+++ b/core/benches/banking_stage.rs
@@ -217,7 +217,7 @@ fn bench_banking(bencher: &mut Bencher, tx_type: TransactionType) {
     let mut bank = Bank::new_for_benches(&genesis_config);
     // Allow arbitrary transaction processing time for the purposes of this bench
     bank.ns_per_slot = u128::MAX;
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
     let bank = bank_forks.read().unwrap().get(0).unwrap();
 
     // set cost tracker limits to MAX so it will not filter out TXs

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -28,7 +28,7 @@ fn bench_save_tower(bench: &mut Bencher) {
 
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new(Bank::default_for_tests()).working_bank();
+    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests()).working_bank();
     let tower_storage = FileTowerStorage::new(dir.path().to_path_buf());
     let tower = Tower::new(
         &node_keypair.pubkey(),
@@ -47,7 +47,7 @@ fn bench_save_tower(bench: &mut Bencher) {
 fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new(Bank::default_for_tests()).working_bank();
+    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests()).working_bank();
     let mut tower = Tower::new(
         &node_keypair.pubkey(),
         vote_account_pubkey,

--- a/core/benches/consensus.rs
+++ b/core/benches/consensus.rs
@@ -28,7 +28,10 @@ fn bench_save_tower(bench: &mut Bencher) {
 
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests()).working_bank();
+    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests())
+        .read()
+        .unwrap()
+        .working_bank();
     let tower_storage = FileTowerStorage::new(dir.path().to_path_buf());
     let tower = Tower::new(
         &node_keypair.pubkey(),
@@ -47,7 +50,10 @@ fn bench_save_tower(bench: &mut Bencher) {
 fn bench_generate_ancestors_descendants(bench: &mut Bencher) {
     let vote_account_pubkey = &Pubkey::default();
     let node_keypair = Arc::new(Keypair::new());
-    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests()).working_bank();
+    let heaviest_bank = BankForks::new_rw_arc(Bank::default_for_tests())
+        .read()
+        .unwrap()
+        .working_bank();
     let mut tower = Tower::new(
         &node_keypair.pubkey(),
         vote_account_pubkey,

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -670,7 +670,7 @@ mod tests {
     fn test_banking_stage_shutdown1() {
         let genesis_config = create_genesis_config(2).genesis_config;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
@@ -722,7 +722,7 @@ mod tests {
         genesis_config.ticks_per_slot = 4;
         let num_extra_ticks = 2;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
@@ -802,7 +802,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
@@ -974,7 +974,7 @@ mod tests {
             let entry_receiver = {
                 // start a banking_stage to eat verified receiver
                 let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-                let bank_forks = BankForks::new(bank);
+                let bank_forks = BankForks::new_rw_arc(bank);
                 let bank = bank_forks.read().unwrap().get(0).unwrap();
                 let blockstore = Arc::new(
                     Blockstore::open(ledger_path.path())
@@ -1158,7 +1158,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -670,7 +670,7 @@ mod tests {
     fn test_banking_stage_shutdown1() {
         let genesis_config = create_genesis_config(2).genesis_config;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let banking_tracer = BankingTracer::new_disabled();
         let (non_vote_sender, non_vote_receiver) = banking_tracer.create_channel_non_vote();
@@ -722,7 +722,7 @@ mod tests {
         genesis_config.ticks_per_slot = 4;
         let num_extra_ticks = 2;
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
@@ -802,7 +802,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();
@@ -974,7 +974,7 @@ mod tests {
             let entry_receiver = {
                 // start a banking_stage to eat verified receiver
                 let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-                let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+                let bank_forks = BankForks::new(bank);
                 let bank = bank_forks.read().unwrap().get(0).unwrap();
                 let blockstore = Arc::new(
                     Blockstore::open(ledger_path.path())
@@ -1158,7 +1158,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let start_hash = bank.last_blockhash();
         let banking_tracer = BankingTracer::new_disabled();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -174,7 +174,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -174,7 +174,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/banking_stage/forward_worker.rs
+++ b/core/src/banking_stage/forward_worker.rs
@@ -129,7 +129,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/banking_stage/forward_worker.rs
+++ b/core/src/banking_stage/forward_worker.rs
@@ -129,7 +129,7 @@ mod tests {
             ..
         } = create_slow_genesis_config(10_000);
         let bank = Bank::new_no_wallclock_throttle_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = get_tmp_ledger_path_auto_delete!();

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -307,7 +307,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = &genesis_config_info;
 
         let bank: Bank = Bank::new_no_wallclock_throttle_for_tests(genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = TempDir::new().unwrap();

--- a/core/src/banking_stage/forwarder.rs
+++ b/core/src/banking_stage/forwarder.rs
@@ -307,7 +307,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = &genesis_config_info;
 
         let bank: Bank = Bank::new_no_wallclock_throttle_for_tests(genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().working_bank();
 
         let ledger_path = TempDir::new().unwrap();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1439,7 +1439,7 @@ mod tests {
             );
         let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let vote_tracker = VoteTracker::default();
         let optimistically_confirmed_bank =
@@ -1556,7 +1556,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let vote_tracker = VoteTracker::default();
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1584,7 +1584,7 @@ mod tests {
         solana_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let votes = vec![];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, &bank_forks);
         assert!(vote_txs.is_empty());
@@ -1629,7 +1629,7 @@ mod tests {
                 vec![100; voting_keypairs.len()], // stakes
             );
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let vote_tx = test_vote_tx(voting_keypairs.first(), hash);
         let votes = vec![vote_tx];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, &bank_forks);
@@ -1654,7 +1654,7 @@ mod tests {
                 vec![100; voting_keypairs.len()], // stakes
             );
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let vote_tx = test_vote_tx(voting_keypairs.first(), hash);
         let mut bad_vote = vote_tx.clone();
         bad_vote.signatures[0] = Signature::default();

--- a/core/src/cluster_info_vote_listener.rs
+++ b/core/src/cluster_info_vote_listener.rs
@@ -1439,7 +1439,7 @@ mod tests {
             );
         let bank = Bank::new_for_tests(&genesis_config);
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let vote_tracker = VoteTracker::default();
         let optimistically_confirmed_bank =
@@ -1556,7 +1556,7 @@ mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let vote_tracker = VoteTracker::default();
         let exit = Arc::new(AtomicBool::new(false));
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().get(0).unwrap();
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
@@ -1584,7 +1584,7 @@ mod tests {
         solana_logger::setup();
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = RwLock::new(BankForks::new(bank));
+        let bank_forks = BankForks::new(bank);
         let votes = vec![];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, &bank_forks);
         assert!(vote_txs.is_empty());
@@ -1629,7 +1629,7 @@ mod tests {
                 vec![100; voting_keypairs.len()], // stakes
             );
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = RwLock::new(BankForks::new(bank));
+        let bank_forks = BankForks::new(bank);
         let vote_tx = test_vote_tx(voting_keypairs.first(), hash);
         let votes = vec![vote_tx];
         let (vote_txs, packets) = ClusterInfoVoteListener::verify_votes(votes, &bank_forks);
@@ -1654,7 +1654,7 @@ mod tests {
                 vec![100; voting_keypairs.len()], // stakes
             );
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = RwLock::new(BankForks::new(bank));
+        let bank_forks = BankForks::new(bank);
         let vote_tx = test_vote_tx(voting_keypairs.first(), hash);
         let mut bad_vote = vote_tx.clone();
         bad_vote.signatures[0] = Signature::default();

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -509,7 +509,7 @@ mod tests {
         );
 
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
         let mut bank_forks = bank_forks.write().unwrap();
 
         // Fill bank_forks with banks with votes landing in the next slot

--- a/core/src/commitment_service.rs
+++ b/core/src/commitment_service.rs
@@ -509,7 +509,8 @@ mod tests {
         );
 
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let mut bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new(bank0);
+        let mut bank_forks = bank_forks.write().unwrap();
 
         // Fill bank_forks with banks with votes landing in the next slot
         // Create enough banks such that vote account will root slots 0 and 1

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -244,7 +244,8 @@ impl HeaviestSubtreeForkChoice {
         heaviest_subtree_fork_choice
     }
 
-    pub fn new_from_bank_forks(bank_forks: &BankForks) -> Self {
+    pub fn new_from_bank_forks(bank_forks: Arc<RwLock<BankForks>>) -> Self {
+        let bank_forks = bank_forks.read().unwrap();
         let mut frozen_banks: Vec<_> = bank_forks.frozen_banks().values().cloned().collect();
 
         frozen_banks.sort_by_key(|bank| bank.slot());

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1931,7 +1931,7 @@ mod test {
     #[test]
     fn test_verify_and_process_ancestor_responses_invalid_packet() {
         let bank0 = Bank::default_for_tests();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+        let bank_forks = BankForks::new(bank0);
 
         let ManageAncestorHashesState {
             ancestor_hashes_request_statuses,

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -1931,7 +1931,7 @@ mod test {
     #[test]
     fn test_verify_and_process_ancestor_responses_invalid_packet() {
         let bank0 = Bank::default_for_tests();
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
 
         let ManageAncestorHashesState {
             ancestor_hashes_request_statuses,

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -736,7 +736,7 @@ mod tests {
             let GenesisConfigInfo { genesis_config, .. } =
                 create_genesis_config(/*mint_lamports:*/ 100_000);
             let bank = Bank::new_for_tests(&genesis_config);
-            Arc::new(RwLock::new(BankForks::new(bank)))
+            BankForks::new(bank)
         };
         let (endpoints, senders, tasks): (Vec<_>, Vec<_>, Vec<_>) = multiunzip(
             keypairs

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -736,7 +736,7 @@ mod tests {
             let GenesisConfigInfo { genesis_config, .. } =
                 create_genesis_config(/*mint_lamports:*/ 100_000);
             let bank = Bank::new_for_tests(&genesis_config);
-            BankForks::new(bank)
+            BankForks::new_rw_arc(bank)
         };
         let (endpoints, senders, tasks): (Vec<_>, Vec<_>, Vec<_>) = multiunzip(
             keypairs

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1183,7 +1183,7 @@ mod test {
     pub fn test_generate_and_send_duplicate_repairs() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let cluster_slots = ClusterSlots::default();
@@ -1282,7 +1282,7 @@ mod test {
     pub fn test_update_duplicate_slot_repair_addr() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let dummy_addr = Some((
             Pubkey::default(),
             UdpSocket::bind("0.0.0.0:0").unwrap().local_addr().unwrap(),

--- a/core/src/repair/repair_service.rs
+++ b/core/src/repair/repair_service.rs
@@ -1183,7 +1183,7 @@ mod test {
     pub fn test_generate_and_send_duplicate_repairs() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let cluster_slots = ClusterSlots::default();
@@ -1282,7 +1282,7 @@ mod test {
     pub fn test_update_duplicate_slot_repair_addr() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let dummy_addr = Some((
             Pubkey::default(),
             UdpSocket::bind("0.0.0.0:0").unwrap().local_addr().unwrap(),

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1561,7 +1561,7 @@ mod tests {
     fn test_serialize_deserialize_signed_request() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
             cluster_info.clone(),
@@ -1611,7 +1611,7 @@ mod tests {
 
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.feature_set = Arc::new(FeatureSet::all_enabled());
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let serve_repair = ServeRepair::new(
             cluster_info,
             bank_forks,
@@ -1647,7 +1647,7 @@ mod tests {
     fn test_map_requests_signed() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
             cluster_info.clone(),
@@ -1968,7 +1968,7 @@ mod tests {
     fn window_index_request() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
@@ -2299,7 +2299,7 @@ mod tests {
     fn test_repair_with_repair_validators() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
         let me = cluster_info.my_contact_info();

--- a/core/src/repair/serve_repair.rs
+++ b/core/src/repair/serve_repair.rs
@@ -1561,7 +1561,7 @@ mod tests {
     fn test_serialize_deserialize_signed_request() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
             cluster_info.clone(),
@@ -1611,7 +1611,7 @@ mod tests {
 
         let mut bank = Bank::new_for_tests(&genesis_config);
         bank.feature_set = Arc::new(FeatureSet::all_enabled());
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let serve_repair = ServeRepair::new(
             cluster_info,
             bank_forks,
@@ -1647,7 +1647,7 @@ mod tests {
     fn test_map_requests_signed() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
             cluster_info.clone(),
@@ -1968,7 +1968,7 @@ mod tests {
     fn window_index_request() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
         let serve_repair = ServeRepair::new(
@@ -2299,7 +2299,7 @@ mod tests {
     fn test_repair_with_repair_validators() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let cluster_slots = ClusterSlots::default();
         let cluster_info = Arc::new(new_test_cluster_info());
         let me = cluster_info.my_contact_info();

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4365,7 +4365,7 @@ pub(crate) mod tests {
     fn test_handle_new_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+        let bank_forks = BankForks::new(bank0);
 
         let root = 3;
         let root_bank = Bank::new_from_parent(
@@ -4451,7 +4451,7 @@ pub(crate) mod tests {
     fn test_handle_new_root_ahead_of_highest_super_majority_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+        let bank_forks = BankForks::new(bank0);
         let confirmed_root = 1;
         let fork = 2;
         let bank1 = Bank::new_from_parent(
@@ -4854,7 +4854,7 @@ pub(crate) mod tests {
         }
         bank0.freeze();
         let arc_bank0 = Arc::new(bank0);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(&[arc_bank0], 0)));
+        let bank_forks = BankForks::new_from_banks(&[arc_bank0], 0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
@@ -5033,7 +5033,7 @@ pub(crate) mod tests {
             vote_simulator::initialize_state(&keypairs, 10_000);
         let mut latest_validator_votes_for_frozen_banks =
             LatestValidatorVotesForFrozenBanks::default();
-        let bank0 = bank_forks.get(0).unwrap();
+        let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let my_keypairs = keypairs.get(&my_node_pubkey).unwrap();
         let vote_tx = vote_transaction::new_vote_transaction(
             vec![0],
@@ -5045,7 +5045,6 @@ pub(crate) mod tests {
             None,
         );
 
-        let bank_forks = RwLock::new(bank_forks);
         let bank1 = Bank::new_from_parent(bank0.clone(), &my_node_pubkey, 1);
         bank1.process_transaction(&vote_tx).unwrap();
         bank1.freeze();
@@ -5378,7 +5377,7 @@ pub(crate) mod tests {
     ) {
         let stake = 10_000;
         let (bank_forks, _, _) = vote_simulator::initialize_state(all_keypairs, stake);
-        let root_bank = bank_forks.root_bank();
+        let root_bank = bank_forks.read().unwrap().root_bank();
         let mut propagated_stats = PropagatedStats {
             total_epoch_stake: stake * all_keypairs.len() as u64,
             ..PropagatedStats::default()
@@ -5492,8 +5491,9 @@ pub(crate) mod tests {
         let vote_pubkey = vote_keypairs.vote_keypair.pubkey();
         let keypairs: HashMap<_, _> = vec![(node_pubkey, vote_keypairs)].into_iter().collect();
         let stake = 10_000;
-        let (mut bank_forks, mut progress_map, _) =
+        let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake);
+        let mut bank_forks = bank_forks_arc.write().unwrap();
 
         let bank0 = bank_forks.get(0).unwrap();
         bank_forks.insert(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 9));
@@ -5535,12 +5535,14 @@ pub(crate) mod tests {
         // runs in `update_propagation_status`
         assert!(!progress_map.get_leader_propagation_slot_must_exist(10).0);
 
+        drop(bank_forks);
+
         let vote_tracker = VoteTracker::default();
         vote_tracker.insert_vote(10, vote_pubkey);
         ReplayStage::update_propagation_status(
             &mut progress_map,
             10,
-            &RwLock::new(bank_forks),
+            &bank_forks_arc,
             &vote_tracker,
             &ClusterSlots::default(),
         );
@@ -5584,8 +5586,9 @@ pub(crate) mod tests {
             .collect();
 
         let stake_per_validator = 10_000;
-        let (mut bank_forks, mut progress_map, _) =
+        let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake_per_validator);
+        let mut bank_forks = bank_forks_arc.write().unwrap();
         progress_map
             .get_propagated_stats_mut(0)
             .unwrap()
@@ -5626,12 +5629,14 @@ pub(crate) mod tests {
             vote_tracker.insert_vote(10, *vote_pubkey);
         }
 
+        drop(bank_forks);
+
         // The last bank should reach propagation threshold, and propagate it all
         // the way back through earlier leader banks
         ReplayStage::update_propagation_status(
             &mut progress_map,
             10,
-            &RwLock::new(bank_forks),
+            &bank_forks_arc,
             &vote_tracker,
             &ClusterSlots::default(),
         );
@@ -5664,8 +5669,9 @@ pub(crate) mod tests {
             .collect();
 
         let stake_per_validator = 10_000;
-        let (mut bank_forks, mut progress_map, _) =
+        let (bank_forks_arc, mut progress_map, _) =
             vote_simulator::initialize_state(&keypairs, stake_per_validator);
+        let mut bank_forks = bank_forks_arc.write().unwrap();
         progress_map
             .get_propagated_stats_mut(0)
             .unwrap()
@@ -5711,12 +5717,13 @@ pub(crate) mod tests {
         // Insert a new vote
         vote_tracker.insert_vote(10, vote_pubkeys[2]);
 
+        drop(bank_forks);
         // The last bank should reach propagation threshold, and propagate it all
         // the way back through earlier leader banks
         ReplayStage::update_propagation_status(
             &mut progress_map,
             10,
-            &RwLock::new(bank_forks),
+            &bank_forks_arc,
             &vote_tracker,
             &ClusterSlots::default(),
         );
@@ -5822,7 +5829,8 @@ pub(crate) mod tests {
         let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
         let parent_slot_bank =
             Bank::new_from_parent(Arc::new(bank0), &Pubkey::default(), parent_slot);
-        let mut bank_forks = BankForks::new(parent_slot_bank);
+        let bank_forks = BankForks::new(parent_slot_bank);
+        let mut bank_forks = bank_forks.write().unwrap();
         let bank5 =
             Bank::new_from_parent(bank_forks.get(parent_slot).unwrap(), &Pubkey::default(), 5);
         bank_forks.insert(bank5);
@@ -6372,7 +6380,7 @@ pub(crate) mod tests {
             &vote_tracker,
             &ClusterSlots::default(),
             &bank_forks,
-            &mut HeaviestSubtreeForkChoice::new_from_bank_forks(&bank_forks.read().unwrap()),
+            &mut HeaviestSubtreeForkChoice::new_from_bank_forks(bank_forks.clone()),
             &mut LatestValidatorVotesForFrozenBanks::default(),
         );
 
@@ -8140,7 +8148,7 @@ pub(crate) mod tests {
         let in_vote_only_mode = AtomicBool::new(false);
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = RwLock::new(BankForks::new(bank0));
+        let bank_forks = BankForks::new(bank0);
         ReplayStage::check_for_vote_only_mode(1000, 0, &in_vote_only_mode, &bank_forks);
         assert!(in_vote_only_mode.load(Ordering::Relaxed));
         ReplayStage::check_for_vote_only_mode(10, 0, &in_vote_only_mode, &bank_forks);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4365,7 +4365,7 @@ pub(crate) mod tests {
     fn test_handle_new_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
 
         let root = 3;
         let root_bank = Bank::new_from_parent(
@@ -4451,7 +4451,7 @@ pub(crate) mod tests {
     fn test_handle_new_root_ahead_of_highest_super_majority_root() {
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
         let confirmed_root = 1;
         let fork = 2;
         let bank1 = Bank::new_from_parent(
@@ -5829,7 +5829,7 @@ pub(crate) mod tests {
         let bank0 = Bank::new_for_tests(&genesis_config::create_genesis_config(10000).0);
         let parent_slot_bank =
             Bank::new_from_parent(Arc::new(bank0), &Pubkey::default(), parent_slot);
-        let bank_forks = BankForks::new(parent_slot_bank);
+        let bank_forks = BankForks::new_rw_arc(parent_slot_bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank5 =
             Bank::new_from_parent(bank_forks.get(parent_slot).unwrap(), &Pubkey::default(), 5);
@@ -8148,7 +8148,7 @@ pub(crate) mod tests {
         let in_vote_only_mode = AtomicBool::new(false);
         let genesis_config = create_genesis_config(10_000).genesis_config;
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
         ReplayStage::check_for_vote_only_mode(1000, 0, &in_vote_only_mode, &bank_forks);
         assert!(in_vote_only_mode.load(Ordering::Relaxed));
         ReplayStage::check_for_vote_only_mode(10, 0, &in_vote_only_mode, &bank_forks);

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -400,7 +400,7 @@ pub mod tests {
         let starting_balance = 10_000;
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(starting_balance);
 
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
 
         let keypair = Arc::new(Keypair::new());
         let (turbine_quic_endpoint_sender, _turbine_quic_endpoint_receiver) =

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -422,7 +422,7 @@ pub mod tests {
         } = Blockstore::open_with_signal(&blockstore_path, BlockstoreOptions::default())
             .expect("Expected to successfully open ledger");
         let blockstore = Arc::new(blockstore);
-        let bank = bank_forks.working_bank();
+        let bank = bank_forks.read().unwrap().working_bank();
         let (exit, poh_recorder, poh_service, _entry_receiver) =
             create_test_recorder(bank.clone(), blockstore.clone(), None, None);
         let vote_keypair = Keypair::new();
@@ -434,7 +434,6 @@ pub mod tests {
         let (replay_vote_sender, _replay_vote_receiver) = unbounded();
         let (completed_data_sets_sender, _completed_data_sets_receiver) = unbounded();
         let (_, gossip_confirmed_slots_receiver) = unbounded();
-        let bank_forks = Arc::new(RwLock::new(bank_forks));
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2619,7 +2619,7 @@ mod tests {
         );
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
-        let bank_forks = RwLock::new(BankForks::new(Bank::new_for_tests(&genesis_config)));
+        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
         let mut config = ValidatorConfig::default_for_test();
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
@@ -2649,11 +2649,11 @@ mod tests {
         );
 
         // bank=1, wait=0, should pass, bank is past the wait slot
-        let bank_forks = RwLock::new(BankForks::new(Bank::new_from_parent(
+        let bank_forks = BankForks::new(Bank::new_from_parent(
             bank_forks.read().unwrap().root_bank(),
             &Pubkey::default(),
             1,
-        )));
+        ));
         config.wait_for_supermajority = Some(0);
         assert!(!wait_for_supermajority(
             &config,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -2619,7 +2619,7 @@ mod tests {
         );
 
         let (genesis_config, _mint_keypair) = create_genesis_config(1);
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let mut config = ValidatorConfig::default_for_test();
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
         let start_progress = Arc::new(RwLock::new(ValidatorStartProgress::default()));
@@ -2649,7 +2649,7 @@ mod tests {
         );
 
         // bank=1, wait=0, should pass, bank is past the wait slot
-        let bank_forks = BankForks::new(Bank::new_from_parent(
+        let bank_forks = BankForks::new_rw_arc(Bank::new_from_parent(
             bank_forks.read().unwrap().root_bank(),
             &Pubkey::default(),
             1,

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -58,7 +58,7 @@ impl VoteSimulator {
             validator_keypairs,
             node_pubkeys,
             vote_pubkeys,
-            bank_forks: Arc::new(RwLock::new(bank_forks)),
+            bank_forks: bank_forks,
             progress,
             heaviest_subtree_fork_choice,
             latest_validator_votes_for_frozen_banks: LatestValidatorVotesForFrozenBanks::default(),
@@ -303,7 +303,7 @@ impl VoteSimulator {
         HashMap<Pubkey, ValidatorVoteKeypairs>,
         Vec<Pubkey>,
         Vec<Pubkey>,
-        BankForks,
+        Arc<RwLock<BankForks>>,
         ProgressMap,
         HeaviestSubtreeForkChoice,
     ) {
@@ -339,7 +339,11 @@ impl VoteSimulator {
 pub fn initialize_state(
     validator_keypairs_map: &HashMap<Pubkey, ValidatorVoteKeypairs>,
     stake: u64,
-) -> (BankForks, ProgressMap, HeaviestSubtreeForkChoice) {
+) -> (
+    Arc<RwLock<BankForks>>,
+    ProgressMap,
+    HeaviestSubtreeForkChoice,
+) {
     let validator_keypairs: Vec<_> = validator_keypairs_map.values().collect();
     let GenesisConfigInfo {
         mut genesis_config,
@@ -368,6 +372,7 @@ pub fn initialize_state(
         ForkProgress::new_from_bank(&bank0, bank0.collector_id(), &Pubkey::default(), None, 0, 0),
     );
     let bank_forks = BankForks::new(bank0);
-    let heaviest_subtree_fork_choice = HeaviestSubtreeForkChoice::new_from_bank_forks(&bank_forks);
+    let heaviest_subtree_fork_choice =
+        HeaviestSubtreeForkChoice::new_from_bank_forks(bank_forks.clone());
     (bank_forks, progress, heaviest_subtree_fork_choice)
 }

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -371,7 +371,7 @@ pub fn initialize_state(
         0,
         ForkProgress::new_from_bank(&bank0, bank0.collector_id(), &Pubkey::default(), None, 0, 0),
     );
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
     let heaviest_subtree_fork_choice =
         HeaviestSubtreeForkChoice::new_from_bank_forks(bank_forks.clone());
     (bank_forks, progress, heaviest_subtree_fork_choice)

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -58,7 +58,7 @@ impl VoteSimulator {
             validator_keypairs,
             node_pubkeys,
             vote_pubkeys,
-            bank_forks: bank_forks,
+            bank_forks,
             progress,
             heaviest_subtree_fork_choice,
             latest_validator_votes_for_frozen_banks: LatestValidatorVotesForFrozenBanks::default(),
@@ -297,6 +297,7 @@ impl VoteSimulator {
         false
     }
 
+    #[allow(clippy::type_complexity)]
     fn init_state(
         num_keypairs: usize,
     ) -> (

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -116,14 +116,18 @@ impl TestEnvironment {
             ..snapshot_config
         };
 
-        let bank_forks_arc = BankForks::new_rw_arc(Bank::new_for_tests_with_config(
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests_with_config(
             &genesis_config_info.genesis_config,
             BankTestConfig::default(),
         ));
-        let mut bank_forks = bank_forks_arc.write().unwrap();
-        bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
-        bank_forks.set_accounts_hash_interval_slots(Self::ACCOUNTS_HASH_INTERVAL);
-        let bank_forks = bank_forks_arc.clone();
+        bank_forks
+            .write()
+            .unwrap()
+            .set_snapshot_config(Some(snapshot_config.clone()));
+        bank_forks
+            .write()
+            .unwrap()
+            .set_accounts_hash_interval_slots(Self::ACCOUNTS_HASH_INTERVAL);
 
         let exit = Arc::new(AtomicBool::new(false));
         let node_id = Arc::new(Keypair::new());
@@ -265,7 +269,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
     const NUM_EPOCHS_TO_TEST: u64 = 2;
     const SET_ROOT_INTERVAL: Slot = 3;
 
-    let bank_forks = &test_environment.bank_forks;
+    let bank_forks = test_environment.bank_forks.clone();
 
     let mut expected_epoch_accounts_hash = None;
 
@@ -300,6 +304,7 @@ fn test_epoch_accounts_hash_basic(test_environment: TestEnvironment) {
         // Set roots so that ABS requests are sent (this is what requests EAH calculations)
         if bank.slot().checked_rem(SET_ROOT_INTERVAL).unwrap() == 0 {
             trace!("rooting bank {}", bank.slot());
+            bank_forks.read().unwrap().prune_program_cache(bank.slot());
             bank_forks.write().unwrap().set_root(
                 bank.slot(),
                 &test_environment
@@ -380,7 +385,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
 
     let test_environment =
         TestEnvironment::new_with_snapshots(FULL_SNAPSHOT_INTERVAL, FULL_SNAPSHOT_INTERVAL);
-    let bank_forks = &test_environment.bank_forks;
+    let bank_forks = test_environment.bank_forks.clone();
 
     let slots_per_epoch = test_environment
         .genesis_config_info
@@ -412,6 +417,7 @@ fn test_snapshots_have_expected_epoch_accounts_hash() {
 
         // Root every bank.  This is what a normal validator does as well.
         // `set_root()` is also what requests snapshots and EAH calculations.
+        bank_forks.read().unwrap().prune_program_cache(bank.slot());
         bank_forks.write().unwrap().set_root(
             bank.slot(),
             &test_environment
@@ -497,7 +503,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
 
     let test_environment =
         TestEnvironment::new_with_snapshots(FULL_SNAPSHOT_INTERVAL, FULL_SNAPSHOT_INTERVAL);
-    let bank_forks = &test_environment.bank_forks;
+    let bank_forks = test_environment.bank_forks.clone();
     let snapshot_config = &test_environment.snapshot_config;
 
     let slots_per_epoch = test_environment
@@ -535,6 +541,7 @@ fn test_background_services_request_handling_for_epoch_accounts_hash() {
 
         if bank.block_height() == set_root_slot {
             info!("Calling set_root() on bank {}...", bank.slot());
+            bank_forks.read().unwrap().prune_program_cache(bank.slot());
             bank_forks.write().unwrap().set_root(
                 bank.slot(),
                 &test_environment
@@ -578,7 +585,7 @@ fn test_epoch_accounts_hash_and_warping() {
     solana_logger::setup();
 
     let test_environment = TestEnvironment::new();
-    let bank_forks = &test_environment.bank_forks;
+    let bank_forks = test_environment.bank_forks.clone();
     let bank = bank_forks.read().unwrap().working_bank();
     let epoch_schedule = test_environment
         .genesis_config_info
@@ -591,6 +598,7 @@ fn test_epoch_accounts_hash_and_warping() {
     let eah_stop_slot_in_next_epoch =
         epoch_schedule.get_first_slot_in_epoch(bank.epoch() + 1) + eah_stop_offset;
     // have to set root here so that we can flush the write cache
+    bank_forks.read().unwrap().prune_program_cache(bank.slot());
     bank_forks.write().unwrap().set_root(
         bank.slot(),
         &test_environment
@@ -616,6 +624,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .insert(Bank::new_from_parent(bank, &Pubkey::default(), slot))
         .clone_without_scheduler();
+    bank_forks.read().unwrap().prune_program_cache(bank.slot());
     bank_forks.write().unwrap().set_root(
         bank.slot(),
         &test_environment
@@ -655,6 +664,7 @@ fn test_epoch_accounts_hash_and_warping() {
         .unwrap()
         .insert(Bank::new_from_parent(bank, &Pubkey::default(), slot))
         .clone_without_scheduler();
+    bank_forks.read().unwrap().prune_program_cache(bank.slot());
     bank_forks.write().unwrap().set_root(
         bank.slot(),
         &test_environment

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -116,13 +116,14 @@ impl TestEnvironment {
             ..snapshot_config
         };
 
-        let mut bank_forks = BankForks::new(Bank::new_for_tests_with_config(
+        let bank_forks_arc = BankForks::new(Bank::new_for_tests_with_config(
             &genesis_config_info.genesis_config,
             BankTestConfig::default(),
         ));
+        let mut bank_forks = bank_forks_arc.write().unwrap();
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
         bank_forks.set_accounts_hash_interval_slots(Self::ACCOUNTS_HASH_INTERVAL);
-        let bank_forks = Arc::new(RwLock::new(bank_forks));
+        let bank_forks = bank_forks_arc.clone();
 
         let exit = Arc::new(AtomicBool::new(false));
         let node_id = Arc::new(Keypair::new());

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -116,7 +116,7 @@ impl TestEnvironment {
             ..snapshot_config
         };
 
-        let bank_forks_arc = BankForks::new(Bank::new_for_tests_with_config(
+        let bank_forks_arc = BankForks::new_rw_arc(Bank::new_for_tests_with_config(
             &genesis_config_info.genesis_config,
             BankTestConfig::default(),
         ));

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -109,7 +109,7 @@ impl SnapshotTestConfig {
         );
         bank0.freeze();
         bank0.set_startup_verification_complete();
-        let bank_forks_arc = BankForks::new(bank0);
+        let bank_forks_arc = BankForks::new_rw_arc(bank0);
         let mut bank_forks = bank_forks_arc.write().unwrap();
         bank_forks.accounts_hash_interval_slots = accounts_hash_interval_slots;
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -66,7 +66,7 @@ use {
 };
 
 struct SnapshotTestConfig {
-    bank_forks: BankForks,
+    bank_forks: Arc<RwLock<BankForks>>,
     genesis_config_info: GenesisConfigInfo,
     snapshot_config: SnapshotConfig,
     incremental_snapshot_archives_dir: TempDir,
@@ -109,7 +109,8 @@ impl SnapshotTestConfig {
         );
         bank0.freeze();
         bank0.set_startup_verification_complete();
-        let mut bank_forks = BankForks::new(bank0);
+        let bank_forks_arc = BankForks::new(bank0);
+        let mut bank_forks = bank_forks_arc.write().unwrap();
         bank_forks.accounts_hash_interval_slots = accounts_hash_interval_slots;
 
         let snapshot_config = SnapshotConfig {
@@ -125,7 +126,7 @@ impl SnapshotTestConfig {
         };
         bank_forks.set_snapshot_config(Some(snapshot_config.clone()));
         SnapshotTestConfig {
-            bank_forks,
+            bank_forks: bank_forks_arc.clone(),
             genesis_config_info,
             snapshot_config,
             incremental_snapshot_archives_dir,
@@ -138,11 +139,12 @@ impl SnapshotTestConfig {
 }
 
 fn restore_from_snapshot(
-    old_bank_forks: &BankForks,
+    old_bank_forks: Arc<RwLock<BankForks>>,
     old_last_slot: Slot,
     old_genesis_config: &GenesisConfig,
     account_paths: &[PathBuf],
 ) {
+    let old_bank_forks = old_bank_forks.read().unwrap();
     let snapshot_config = old_bank_forks.snapshot_config.as_ref().unwrap();
     let old_last_bank = old_bank_forks.get(old_last_slot).unwrap();
 
@@ -198,7 +200,7 @@ fn run_bank_forks_snapshot_n<F>(
 {
     solana_logger::setup();
     // Set up snapshotting config
-    let mut snapshot_test_config = SnapshotTestConfig::new(
+    let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
         cluster_type,
         set_root_interval,
@@ -206,7 +208,7 @@ fn run_bank_forks_snapshot_n<F>(
         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
     );
 
-    let bank_forks = &mut snapshot_test_config.bank_forks;
+    let mut bank_forks = snapshot_test_config.bank_forks.write().unwrap();
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
     let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
@@ -274,11 +276,17 @@ fn run_bank_forks_snapshot_n<F>(
     )
     .unwrap();
 
+    drop(bank_forks);
     // Restore bank from snapshot
     let (_tmp_dir, temporary_accounts_dir) = create_tmp_accounts_dir_for_tests();
     let account_paths = &[temporary_accounts_dir];
     let genesis_config = &snapshot_test_config.genesis_config_info.genesis_config;
-    restore_from_snapshot(bank_forks, last_slot, genesis_config, account_paths);
+    restore_from_snapshot(
+        snapshot_test_config.bank_forks.clone(),
+        last_slot,
+        genesis_config,
+        account_paths,
+    );
 }
 
 #[test_case(V1_2_0, Development)]
@@ -331,7 +339,7 @@ fn test_concurrent_snapshot_packaging(
     const MAX_BANK_SNAPSHOTS_TO_RETAIN: usize = 8;
 
     // Set up snapshotting config
-    let mut snapshot_test_config = SnapshotTestConfig::new(
+    let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
         cluster_type,
         1,
@@ -339,7 +347,7 @@ fn test_concurrent_snapshot_packaging(
         DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
     );
 
-    let bank_forks = &mut snapshot_test_config.bank_forks;
+    let mut bank_forks = snapshot_test_config.bank_forks.write().unwrap();
     let snapshot_config = &snapshot_test_config.snapshot_config;
     let bank_snapshots_dir = &snapshot_config.bank_snapshots_dir;
     let full_snapshot_archives_dir = &snapshot_config.full_snapshot_archives_dir;
@@ -586,25 +594,24 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
     for add_root_interval in &[1, 3, 9] {
         let (snapshot_sender, _snapshot_receiver) = unbounded();
         // Make sure this test never clears bank.slots_since_snapshot
-        let mut snapshot_test_config = SnapshotTestConfig::new(
+        let snapshot_test_config = SnapshotTestConfig::new(
             snapshot_version,
             cluster_type,
             (*add_root_interval * num_set_roots * 2) as Slot,
             (*add_root_interval * num_set_roots * 2) as Slot,
             DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         );
-        let mut current_bank = snapshot_test_config.bank_forks[0].clone();
+        let mut bank_forks = snapshot_test_config.bank_forks.write().unwrap();
+        let mut current_bank = bank_forks[0].clone();
         let request_sender = AbsRequestSender::new(snapshot_sender);
         for _ in 0..num_set_roots {
             for _ in 0..*add_root_interval {
                 let new_slot = current_bank.slot() + 1;
                 let new_bank = Bank::new_from_parent(current_bank, &Pubkey::default(), new_slot);
-                snapshot_test_config.bank_forks.insert(new_bank);
-                current_bank = snapshot_test_config.bank_forks[new_slot].clone();
+                bank_forks.insert(new_bank);
+                current_bank = bank_forks[new_slot].clone();
             }
-            snapshot_test_config
-                .bank_forks
-                .set_root(current_bank.slot(), &request_sender, None);
+            bank_forks.set_root(current_bank.slot(), &request_sender, None);
 
             // Since the accounts background services are not runnning, EpochAccountsHash
             // calculation requests will not be handled. To prevent banks from hanging during
@@ -629,9 +636,8 @@ fn test_slots_to_snapshot(snapshot_version: SnapshotVersion, cluster_type: Clust
         let expected_slots_to_snapshot =
             num_old_slots as u64..=num_set_roots as u64 * *add_root_interval as u64;
 
-        let slots_to_snapshot = snapshot_test_config
-            .bank_forks
-            .get(snapshot_test_config.bank_forks.root())
+        let slots_to_snapshot = bank_forks
+            .get(bank_forks.root())
             .unwrap()
             .status_cache
             .read()
@@ -704,7 +710,7 @@ fn test_bank_forks_incremental_snapshot(
     info!("Running bank forks incremental snapshot test, full snapshot interval: {} slots, incremental snapshot interval: {} slots, last slot: {}, set root interval: {} slots",
               FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS, INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS, LAST_SLOT, SET_ROOT_INTERVAL);
 
-    let mut snapshot_test_config = SnapshotTestConfig::new(
+    let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
         cluster_type,
         SET_ROOT_INTERVAL,
@@ -714,7 +720,7 @@ fn test_bank_forks_incremental_snapshot(
     trace!("SnapshotTestConfig:\naccounts_dir: {}\nbank_snapshots_dir: {}\nfull_snapshot_archives_dir: {}\nincremental_snapshot_archives_dir: {}",
             snapshot_test_config.accounts_dir.display(), snapshot_test_config.bank_snapshots_dir.path().display(), snapshot_test_config.full_snapshot_archives_dir.path().display(), snapshot_test_config.incremental_snapshot_archives_dir.path().display());
 
-    let bank_forks = &mut snapshot_test_config.bank_forks;
+    let mut bank_forks = snapshot_test_config.bank_forks.write().unwrap();
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
 
     let (accounts_package_sender, _accounts_package_receiver) = crossbeam_channel::unbounded();
@@ -964,7 +970,7 @@ fn test_snapshots_with_background_services(
     let (accounts_package_sender, accounts_package_receiver) = unbounded();
     let (snapshot_package_sender, snapshot_package_receiver) = unbounded();
 
-    let bank_forks = Arc::new(RwLock::new(snapshot_test_config.bank_forks));
+    let bank_forks = snapshot_test_config.bank_forks.clone();
     bank_forks
         .read()
         .unwrap()

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -273,13 +273,10 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
         let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
-            &bank_forks.working_bank(),
+            &bank_forks.read().unwrap().working_bank(),
         ));
-        let mut duplicate_shred_handler = DuplicateShredHandler::new(
-            blockstore.clone(),
-            leader_schedule_cache,
-            Arc::new(RwLock::new(bank_forks)),
-        );
+        let mut duplicate_shred_handler =
+            DuplicateShredHandler::new(blockstore.clone(), leader_schedule_cache, bank_forks);
         let chunks = create_duplicate_proof(
             my_keypair.clone(),
             None,
@@ -342,11 +339,10 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
         let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
-            &bank_forks.working_bank(),
+            &bank_forks.read().unwrap().working_bank(),
         ));
-        let bank_forks_ptr = Arc::new(RwLock::new(bank_forks));
         let mut duplicate_shred_handler =
-            DuplicateShredHandler::new(blockstore.clone(), leader_schedule_cache, bank_forks_ptr);
+            DuplicateShredHandler::new(blockstore.clone(), leader_schedule_cache, bank_forks);
         let start_slot: Slot = 1;
 
         // This proof will not be accepted because num_chunks is too large.

--- a/gossip/src/duplicate_shred_handler.rs
+++ b/gossip/src/duplicate_shred_handler.rs
@@ -271,7 +271,7 @@ mod tests {
         let my_pubkey = my_keypair.pubkey();
         let genesis_config_info = create_genesis_config_with_leader(10_000, &my_pubkey, 10_000);
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
             &bank_forks.read().unwrap().working_bank(),
         ));
@@ -337,7 +337,7 @@ mod tests {
         let my_pubkey = my_keypair.pubkey();
         let genesis_config_info = create_genesis_config_with_leader(10_000, &my_pubkey, 10_000);
         let GenesisConfigInfo { genesis_config, .. } = genesis_config_info;
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let leader_schedule_cache = Arc::new(LeaderScheduleCache::new_from_bank(
             &bank_forks.read().unwrap().working_bank(),
         ));

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -309,7 +309,7 @@ pub fn cluster_info_scale() {
         vec![100; vote_keypairs.len()],
     );
     let bank0 = Bank::new_for_tests(&genesis_config_info.genesis_config);
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
 
     let nodes: Vec<_> = vote_keypairs
         .into_iter()

--- a/gossip/tests/gossip.rs
+++ b/gossip/tests/gossip.rs
@@ -309,7 +309,7 @@ pub fn cluster_info_scale() {
         vec![100; vote_keypairs.len()],
     );
     let bank0 = Bank::new_for_tests(&genesis_config_info.genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+    let bank_forks = BankForks::new(bank0);
 
     let nodes: Vec<_> = vote_keypairs
         .into_iter()

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -189,15 +189,6 @@ pub fn load_bank_forks(
             (bank_forks, None)
         };
 
-    bank_forks
-        .read()
-        .expect("Failed to read lock the bank forks")
-        .root_bank()
-        .loaded_programs_cache
-        .write()
-        .expect("Failed to write lock the program cache")
-        .set_fork_graph(bank_forks.clone());
-
     let mut leader_schedule_cache =
         LeaderScheduleCache::new_from_bank(&bank_forks.read().unwrap().root_bank());
     if process_options.full_leader_cache {
@@ -367,8 +358,5 @@ fn bank_forks_from_snapshot(
         incremental: incremental_snapshot_hash,
     };
 
-    (
-        Arc::new(RwLock::new(BankForks::new(bank))),
-        starting_snapshot_hashes,
-    )
+    (BankForks::new(bank), starting_snapshot_hashes)
 }

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -358,5 +358,5 @@ fn bank_forks_from_snapshot(
         incremental: incremental_snapshot_hash,
     };
 
-    (BankForks::new(bank), starting_snapshot_hashes)
+    (BankForks::new_rw_arc(bank), starting_snapshot_hashes)
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -717,7 +717,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         exit,
     );
     let bank0_slot = bank0.slot();
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
 
     info!("Processing ledger for slot 0...");
     process_bank_0(
@@ -3574,7 +3574,7 @@ pub mod tests {
         blockstore.set_roots([3, 5].iter()).unwrap();
 
         // Set up bank1
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
         let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
         let opts = ProcessOptions {
             run_verification: true,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -717,7 +717,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         exit,
     );
     let bank0_slot = bank0.slot();
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank0)));
+    let bank_forks = BankForks::new(bank0);
 
     info!("Processing ledger for slot 0...");
     process_bank_0(
@@ -3574,8 +3574,8 @@ pub mod tests {
         blockstore.set_roots([3, 5].iter()).unwrap();
 
         // Set up bank1
-        let mut bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
-        let bank0 = bank_forks.get_with_scheduler(0).unwrap();
+        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank0 = bank_forks.read().unwrap().get_with_scheduler(0).unwrap();
         let opts = ProcessOptions {
             run_verification: true,
             accounts_db_test_hash_calculation: true,
@@ -3584,7 +3584,7 @@ pub mod tests {
         let recyclers = VerifyRecyclers::default();
         process_bank_0(&bank0, &blockstore, &opts, &recyclers, None, None);
         let bank0_last_blockhash = bank0.last_blockhash();
-        let bank1 = bank_forks.insert(Bank::new_from_parent(
+        let bank1 = bank_forks.write().unwrap().insert(Bank::new_from_parent(
             bank0.clone_without_scheduler(),
             &Pubkey::default(),
             1,
@@ -3601,7 +3601,7 @@ pub mod tests {
             &mut ExecuteTimings::default(),
         )
         .unwrap();
-        bank_forks.set_root(
+        bank_forks.write().unwrap().set_root(
             1,
             &solana_runtime::accounts_background_service::AbsRequestSender::default(),
             None,
@@ -3610,7 +3610,6 @@ pub mod tests {
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank1);
 
         // Test process_blockstore_from_root() from slot 1 onwards
-        let bank_forks = RwLock::new(bank_forks);
         process_blockstore_from_root(
             &blockstore,
             &bank_forks,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -455,7 +455,7 @@ pub struct LoadedPrograms<FG: ForkGraph> {
     /// Environments of the current epoch
     pub environments: ProgramRuntimeEnvironments,
     pub stats: Stats,
-    fork_graph: Option<Arc<RwLock<FG>>>,
+    pub fork_graph: Option<Arc<RwLock<FG>>>,
 }
 
 impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -846,7 +846,7 @@ impl ProgramTest {
         };
         let slot = bank.slot();
         let last_blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -846,7 +846,7 @@ impl ProgramTest {
         };
         let slot = bank.slot();
         let last_blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let block_commitment_cache = Arc::new(RwLock::new(
             BlockCommitmentCache::new_for_tests_with_slots(slot, slot),
         ));

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -424,7 +424,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);

--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -424,7 +424,7 @@ mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -347,10 +347,7 @@ impl JsonRpcRequestProcessor {
         connection_cache: Arc<ConnectionCache>,
     ) -> Self {
         let genesis_hash = bank.hash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new_from_banks(
-            &[bank.clone()],
-            bank.slot(),
-        )));
+        let bank_forks = BankForks::new_from_banks(&[bank.clone()], bank.slot());
         let blockstore = Arc::new(Blockstore::open(&get_tmp_ledger_path!()).unwrap());
         let exit = Arc::new(AtomicBool::new(false));
         let cluster_info = Arc::new({
@@ -6633,11 +6630,7 @@ pub mod tests {
         genesis_config.fee_rate_governor = FeeRateGovernor::new(TEST_SIGNATURE_FEE, 0);
 
         let bank = Bank::new_for_tests_with_config(&genesis_config, config);
-        (
-            Arc::new(RwLock::new(BankForks::new(bank))),
-            mint_keypair,
-            Arc::new(voting_keypair),
-        )
+        (BankForks::new(bank), mint_keypair, Arc::new(voting_keypair))
     }
 
     #[test]
@@ -8317,7 +8310,7 @@ pub mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
 
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -6630,7 +6630,11 @@ pub mod tests {
         genesis_config.fee_rate_governor = FeeRateGovernor::new(TEST_SIGNATURE_FEE, 0);
 
         let bank = Bank::new_for_tests_with_config(&genesis_config, config);
-        (BankForks::new(bank), mint_keypair, Arc::new(voting_keypair))
+        (
+            BankForks::new_rw_arc(bank),
+            mint_keypair,
+            Arc::new(voting_keypair),
+        )
     }
 
     #[test]
@@ -8310,7 +8314,7 @@ pub mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
 
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -150,7 +150,7 @@ pub mod tests {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let bank0 = bank_forks.read().unwrap().root_bank();

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -150,7 +150,7 @@ pub mod tests {
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let bank0 = bank_forks.read().unwrap().root_bank();

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -684,7 +684,7 @@ mod tests {
         let bob_pubkey = bob.pubkey();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -813,7 +813,7 @@ mod tests {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let mut io = IoHandler::<()>::default();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -871,7 +871,7 @@ mod tests {
         let stake_program_id = stake::program::id();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -999,7 +999,7 @@ mod tests {
         let nonce_account = Keypair::new();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1088,9 +1088,7 @@ mod tests {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(Bank::new_for_tests(
-            &genesis_config,
-        ))));
+        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
 
         let mut io = IoHandler::<()>::default();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -1138,7 +1136,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bob = Keypair::new();
 
         let exit = Arc::new(AtomicBool::new(false));
@@ -1190,7 +1188,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1272,7 +1270,7 @@ mod tests {
     fn test_slot_subscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1305,7 +1303,7 @@ mod tests {
     fn test_slot_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1348,7 +1346,7 @@ mod tests {
         );
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         // Setup Subscriptions
         let optimistically_confirmed_bank =
@@ -1390,7 +1388,7 @@ mod tests {
     fn test_vote_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1409,7 +1407,7 @@ mod tests {
     fn test_get_version() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(

--- a/rpc/src/rpc_pubsub.rs
+++ b/rpc/src/rpc_pubsub.rs
@@ -684,7 +684,7 @@ mod tests {
         let bob_pubkey = bob.pubkey();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
@@ -813,7 +813,7 @@ mod tests {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let mut io = IoHandler::<()>::default();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -871,7 +871,7 @@ mod tests {
         let stake_program_id = stake::program::id();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -999,7 +999,7 @@ mod tests {
         let nonce_account = Keypair::new();
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1088,7 +1088,7 @@ mod tests {
         let bob_pubkey = solana_sdk::pubkey::new_rand();
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
-        let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+        let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
 
         let mut io = IoHandler::<()>::default();
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -1136,7 +1136,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bob = Keypair::new();
 
         let exit = Arc::new(AtomicBool::new(false));
@@ -1188,7 +1188,7 @@ mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1270,7 +1270,7 @@ mod tests {
     fn test_slot_subscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1303,7 +1303,7 @@ mod tests {
     fn test_slot_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1346,7 +1346,7 @@ mod tests {
         );
         let exit = Arc::new(AtomicBool::new(false));
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         // Setup Subscriptions
         let optimistically_confirmed_bank =
@@ -1388,7 +1388,7 @@ mod tests {
     fn test_vote_unsubscribe() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
@@ -1407,7 +1407,7 @@ mod tests {
     fn test_get_version() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let rpc_subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -491,7 +491,7 @@ mod tests {
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -491,7 +491,7 @@ mod tests {
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -617,7 +617,7 @@ mod tests {
             ip_addr,
             solana_net_utils::find_available_port_in_range(ip_addr, (10000, 65535)).unwrap(),
         );
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
@@ -674,7 +674,7 @@ mod tests {
         } = create_genesis_config(10_000);
         genesis_config.cluster_type = ClusterType::MainnetBeta;
         let bank = Bank::new_for_tests(&genesis_config);
-        Arc::new(RwLock::new(BankForks::new(bank)))
+        BankForks::new(bank)
     }
 
     #[test]

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -617,7 +617,7 @@ mod tests {
             ip_addr,
             solana_net_utils::find_available_port_in_range(ip_addr, (10000, 65535)).unwrap(),
         );
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
         let blockstore = Arc::new(Blockstore::open(ledger_path.path()).unwrap());
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));
@@ -674,7 +674,7 @@ mod tests {
         } = create_genesis_config(10_000);
         genesis_config.cluster_type = ClusterType::MainnetBeta;
         let bank = Bank::new_for_tests(&genesis_config);
-        BankForks::new(bank)
+        BankForks::new_rw_arc(bank)
     }
 
     #[test]

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -700,7 +700,7 @@ mod tests {
     fn subscription_info() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let mut tracker = SubscriptionsTracker::new(bank_forks);
 
         tracker.subscribe(SubscriptionParams::Slot, 0.into(), || 0);
@@ -746,7 +746,7 @@ mod tests {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let mut tracker = SubscriptionsTracker::new(bank_forks);
 
         tracker.subscribe(SubscriptionParams::Slot, 0.into(), || 0);

--- a/rpc/src/rpc_subscription_tracker.rs
+++ b/rpc/src/rpc_subscription_tracker.rs
@@ -700,7 +700,7 @@ mod tests {
     fn subscription_info() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut tracker = SubscriptionsTracker::new(bank_forks);
 
         tracker.subscribe(SubscriptionParams::Slot, 0.into(), || 0);
@@ -746,7 +746,7 @@ mod tests {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut tracker = SubscriptionsTracker::new(bank_forks);
 
         tracker.subscribe(SubscriptionParams::Slot, 0.into(), || 0);

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1325,7 +1325,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1471,7 +1471,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1591,7 +1591,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1709,7 +1709,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1827,7 +1827,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let alice = Keypair::new();
         let tx = system_transaction::create_account(
             &mint_keypair,
@@ -1939,7 +1939,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2134,7 +2134,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2250,7 +2250,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2436,7 +2436,8 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let mut bank_forks = BankForks::new(bank);
+        let bank_forks_arc = BankForks::new(bank);
+        let mut bank_forks = bank_forks_arc.write().unwrap();
         let alice = Keypair::new();
 
         let past_bank_tx =
@@ -2466,8 +2467,6 @@ pub(crate) mod tests {
             .unwrap();
         let bank1 = bank_forks[1].clone();
 
-        let bank_forks = Arc::new(RwLock::new(bank_forks));
-
         let mut cache0 = BlockCommitment::default();
         cache0.increase_confirmation_stake(1, 10);
         let cache1 = BlockCommitment::default();
@@ -2484,16 +2483,19 @@ pub(crate) mod tests {
             },
         );
 
+        // Drop the write locked bank_forks
+        drop(bank_forks);
+
         let exit = Arc::new(AtomicBool::new(false));
         let optimistically_confirmed_bank =
-            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
+            OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks_arc);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let subscriptions = Arc::new(RpcSubscriptions::new_for_tests(
             exit,
             max_complete_transaction_status_slot,
             max_complete_rewards_slot,
-            bank_forks,
+            bank_forks_arc,
             Arc::new(RwLock::new(block_commitment_cache)),
             optimistically_confirmed_bank,
         ));
@@ -2660,7 +2662,7 @@ pub(crate) mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -2707,7 +2709,7 @@ pub(crate) mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -2756,7 +2758,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -2970,7 +2972,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let alice = Keypair::new();
 
@@ -3054,7 +3056,7 @@ pub(crate) mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
             max_complete_transaction_status_slot,
             max_complete_rewards_slot,

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1325,7 +1325,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -1471,7 +1471,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1591,7 +1591,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1709,7 +1709,7 @@ pub(crate) mod tests {
         } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         let rent_exempt_amount = bank.get_minimum_balance_for_rent_exemption(0);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -1827,7 +1827,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let alice = Keypair::new();
         let tx = system_transaction::create_account(
             &mint_keypair,
@@ -1939,7 +1939,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2134,7 +2134,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2250,7 +2250,7 @@ pub(crate) mod tests {
         bank.lazy_rent_collection.store(true, Relaxed);
 
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -2436,7 +2436,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks_arc = BankForks::new(bank);
+        let bank_forks_arc = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks_arc.write().unwrap();
         let alice = Keypair::new();
 
@@ -2662,7 +2662,7 @@ pub(crate) mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -2709,7 +2709,7 @@ pub(crate) mod tests {
         let exit = Arc::new(AtomicBool::new(false));
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let optimistically_confirmed_bank =
             OptimisticallyConfirmedBank::locked_from_bank_forks_root(&bank_forks);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
@@ -2758,7 +2758,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().get(0).unwrap();
         let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
         bank_forks.write().unwrap().insert(bank1);
@@ -2972,7 +2972,7 @@ pub(crate) mod tests {
         } = create_genesis_config(100);
         let bank = Bank::new_for_tests(&genesis_config);
         let blockhash = bank.last_blockhash();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let alice = Keypair::new();
 
@@ -3056,7 +3056,7 @@ pub(crate) mod tests {
         let bank = Bank::new_for_tests(&genesis_config);
         let max_complete_transaction_status_slot = Arc::new(AtomicU64::default());
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let subscriptions = Arc::new(RpcSubscriptions::default_with_bank_forks(
             max_complete_transaction_status_slot,
             max_complete_rewards_slot,

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -100,7 +100,7 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank0 = Bank::new_for_benches(&genesis_config);
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
     let bank = bank_forks.working_bank();
     let collector = solana_sdk::pubkey::new_rand();
     let banks = (1..=NUM_SLOTS)

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -101,7 +101,7 @@ fn bench_process_transactions_multiple_slots(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank0 = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank0);
-    let bank = bank_forks.working_bank();
+    let bank = bank_forks.read().unwrap().working_bank();
     let collector = solana_sdk::pubkey::new_rand();
     let banks = (1..=NUM_SLOTS)
         .map(|n| Arc::new(Bank::new_from_parent(bank.clone(), &collector, n as u64)))

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12504,8 +12504,8 @@ fn test_runtime_feature_enable_with_program_cache() {
     genesis_config
         .accounts
         .remove(&feature_set::reject_callx_r10::id());
-    let mut bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
-    let root_bank = bank_forks.root_bank();
+    let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+    let root_bank = bank_forks.read().unwrap().root_bank();
 
     // Test a basic transfer
     let amount = genesis_config.rent.minimum_balance(0);
@@ -12564,9 +12564,16 @@ fn test_runtime_feature_enable_with_program_cache() {
 
     // Reroot to call LoadedPrograms::prune() and end the current recompilation phase
     goto_end_of_slot(bank.clone());
-    bank_forks.insert(Arc::into_inner(bank).unwrap());
-    let bank = bank_forks.working_bank();
-    bank_forks.set_root(bank.slot, &AbsRequestSender::default(), None);
+    bank_forks
+        .write()
+        .unwrap()
+        .insert(Arc::into_inner(bank).unwrap());
+    let bank = bank_forks.read().unwrap().working_bank();
+    bank_forks.read().unwrap().prune_program_cache(bank.slot);
+    bank_forks
+        .write()
+        .unwrap()
+        .set_root(bank.slot, &AbsRequestSender::default(), None);
 
     // Advance to next epoch, which starts the next recompilation phase
     let bank = new_from_parent_next_epoch(bank, 1);

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -12504,7 +12504,7 @@ fn test_runtime_feature_enable_with_program_cache() {
     genesis_config
         .accounts
         .remove(&feature_set::reject_callx_r10::id());
-    let bank_forks = BankForks::new(Bank::new_for_tests(&genesis_config));
+    let bank_forks = BankForks::new_rw_arc(Bank::new_for_tests(&genesis_config));
     let root_bank = bank_forks.read().unwrap().root_bank();
 
     // Test a basic transfer

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -200,7 +200,7 @@ impl BankForks {
             highest_slot_at_startup: 0,
         }));
 
-        for (_, bank) in &bank_forks.read().unwrap().banks {
+        for bank in bank_forks.read().unwrap().banks.values() {
             bank.loaded_programs_cache
                 .write()
                 .unwrap()

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -77,7 +77,7 @@ impl Index<u64> for BankForks {
 }
 
 impl BankForks {
-    pub fn new(bank: Bank) -> Arc<RwLock<Self>> {
+    pub fn new_rw_arc(bank: Bank) -> Arc<RwLock<Self>> {
         let root = bank.slot();
         Self::new_from_banks(&[Arc::new(bank)], root)
     }
@@ -735,7 +735,7 @@ mod tests {
     fn test_bank_forks_new() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let child_bank = Bank::new_from_parent(bank_forks[0].clone(), &Pubkey::default(), 1);
         child_bank.register_default_tick_for_test();
@@ -763,7 +763,7 @@ mod tests {
     fn test_bank_forks_descendants() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
@@ -781,7 +781,7 @@ mod tests {
     fn test_bank_forks_ancestors() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
         let bank = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
@@ -800,7 +800,7 @@ mod tests {
     fn test_bank_forks_frozen_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
         let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -813,7 +813,7 @@ mod tests {
     fn test_bank_forks_active_banks() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let mut bank_forks = bank_forks.write().unwrap();
         let bank0 = bank_forks[0].clone();
         let child_bank = Bank::new_from_parent(bank0, &Pubkey::default(), 1);
@@ -866,12 +866,12 @@ mod tests {
         };
 
         let bank0 = Bank::new_for_tests(&genesis_config);
-        let bank_forks0 = BankForks::new(bank0);
+        let bank_forks0 = BankForks::new_rw_arc(bank0);
         let mut bank_forks0 = bank_forks0.write().unwrap();
         bank_forks0.set_root(0, &abs_request_sender, None);
 
         let bank1 = Bank::new_for_tests(&genesis_config);
-        let bank_forks1 = BankForks::new(bank1);
+        let bank_forks1 = BankForks::new_rw_arc(bank1);
         let mut bank_forks1 = bank_forks1.write().unwrap();
 
         let additional_timestamp_secs = 2;
@@ -943,7 +943,7 @@ mod tests {
     fn test_bank_forks_with_set_root() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks_arc = BankForks::new(bank);
+        let bank_forks_arc = BankForks::new_rw_arc(bank);
 
         let parent_child_pairs = vec![(0, 1), (1, 2), (0, 3), (3, 4)];
         extend_bank_forks(bank_forks_arc.clone(), &parent_child_pairs);
@@ -1006,7 +1006,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
         assert_eq!(bank.slot(), 0);
-        let bank_forks_arc = BankForks::new(bank);
+        let bank_forks_arc = BankForks::new_rw_arc(bank);
 
         let parent_child_pairs = vec![(0, 1), (1, 2), (0, 3), (3, 4)];
         extend_bank_forks(bank_forks_arc.clone(), &parent_child_pairs);
@@ -1075,7 +1075,7 @@ mod tests {
     fn test_fork_graph() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let parent_child_pairs = vec![
             (0, 1),

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -214,19 +214,6 @@ impl BankForks {
         bank.check_program_modification_slot =
             self.root.load(Ordering::Relaxed) < self.highest_slot_at_startup;
 
-        if let Some(fork_graph) = &self
-            .root_bank()
-            .loaded_programs_cache
-            .read()
-            .unwrap()
-            .fork_graph
-        {
-            bank.loaded_programs_cache
-                .write()
-                .unwrap()
-                .set_fork_graph(fork_graph.clone());
-        }
-
         let bank = BankWithScheduler::new_without_scheduler(Arc::new(bank));
         let prev = self.banks.insert(bank.slot(), bank.clone_with_scheduler());
         assert!(prev.is_none());

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -613,7 +613,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new(bank0);
-        let bank = bank_forks.working_bank();
+        let bank = bank_forks.read().unwrap().working_bank();
         let collector = solana_sdk::pubkey::new_rand();
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
         let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
@@ -865,7 +865,7 @@ mod tests {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank0 = Bank::new_for_benches(&genesis_config);
         let bank_forks = BankForks::new(bank0);
-        let bank = bank_forks.working_bank();
+        let bank = bank_forks.read().unwrap().working_bank();
         let collector = solana_sdk::pubkey::new_rand();
         let slot: Slot = 999;
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, slot));

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -612,7 +612,7 @@ mod tests {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank0 = Bank::new_for_benches(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
         let collector = solana_sdk::pubkey::new_rand();
         let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
@@ -864,7 +864,7 @@ mod tests {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank0 = Bank::new_for_benches(&genesis_config);
-        let bank_forks = BankForks::new(bank0);
+        let bank_forks = BankForks::new_rw_arc(bank0);
         let bank = bank_forks.read().unwrap().working_bank();
         let collector = solana_sdk::pubkey::new_rand();
         let slot: Slot = 999;

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -60,7 +60,7 @@ mod tests {
     fn test_root_bank_cache() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
 
         let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
 

--- a/runtime/src/root_bank_cache.rs
+++ b/runtime/src/root_bank_cache.rs
@@ -60,7 +60,7 @@ mod tests {
     fn test_root_bank_cache() {
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
 
         let mut root_bank_cache = RootBankCache::new(bank_forks.clone());
 

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -826,7 +826,7 @@ mod test {
     fn service_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let bank = Bank::default_for_tests();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let (sender, receiver) = unbounded();
 
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
@@ -849,7 +849,7 @@ mod test {
     fn validator_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let bank = Bank::default_for_tests();
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let (sender, receiver) = bounded(0);
 
         let dummy_tx_info = || TransactionInfo {
@@ -893,7 +893,7 @@ mod test {
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,
@@ -1159,7 +1159,7 @@ mod test {
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -826,7 +826,7 @@ mod test {
     fn service_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let bank = Bank::default_for_tests();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let (sender, receiver) = unbounded();
 
         let connection_cache = Arc::new(ConnectionCache::new("connection_cache_test"));
@@ -849,7 +849,7 @@ mod test {
     fn validator_exit() {
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let bank = Bank::default_for_tests();
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let (sender, receiver) = bounded(0);
 
         let dummy_tx_info = || TransactionInfo {
@@ -893,7 +893,7 @@ mod test {
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,
@@ -1159,7 +1159,7 @@ mod test {
 
         let (genesis_config, mint_keypair) = create_genesis_config(4);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let tpu_address = "127.0.0.1:0".parse().unwrap();
         let config = Config {
             leader_forward_count: 1,

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -25,12 +25,7 @@ use {
         },
         cluster_nodes::ClusterNodesCache,
     },
-    std::{
-        collections::HashMap,
-        net::UdpSocket,
-        sync::{Arc, RwLock},
-        time::Duration,
-    },
+    std::{collections::HashMap, net::UdpSocket, sync::Arc, time::Duration},
     test::Bencher,
 };
 

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -49,7 +49,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
-    let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+    let bank_forks = BankForks::new(bank);
 
     const NUM_SHREDS: usize = 32;
     let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);

--- a/turbine/benches/cluster_info.rs
+++ b/turbine/benches/cluster_info.rs
@@ -49,7 +49,7 @@ fn broadcast_shreds_bench(bencher: &mut Bencher) {
     let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
     let bank = Bank::new_for_benches(&genesis_config);
-    let bank_forks = BankForks::new(bank);
+    let bank_forks = BankForks::new_rw_arc(bank);
 
     const NUM_SHREDS: usize = 32;
     let shred = Shred::new_from_data(0, 0, 0, &[], ShredFlags::empty(), 0, 0, 0);

--- a/turbine/benches/retransmit_stage.rs
+++ b/turbine/benches/retransmit_stage.rs
@@ -74,7 +74,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
 
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank0 = Bank::new_for_benches(&genesis_config);
-    let bank_forks = BankForks::new(bank0);
+    let bank_forks = BankForks::new_rw_arc(bank0);
     let bank = bank_forks.working_bank();
     let bank_forks = Arc::new(RwLock::new(bank_forks));
     let (shreds_sender, shreds_receiver) = unbounded();

--- a/turbine/benches/retransmit_stage.rs
+++ b/turbine/benches/retransmit_stage.rs
@@ -32,7 +32,7 @@ use {
         net::{Ipv4Addr, UdpSocket},
         sync::{
             atomic::{AtomicUsize, Ordering},
-            Arc, RwLock,
+            Arc,
         },
         thread::{sleep, Builder},
         time::Duration,
@@ -75,8 +75,7 @@ fn bench_retransmitter(bencher: &mut Bencher) {
     let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(100_000);
     let bank0 = Bank::new_for_benches(&genesis_config);
     let bank_forks = BankForks::new_rw_arc(bank0);
-    let bank = bank_forks.working_bank();
-    let bank_forks = Arc::new(RwLock::new(bank_forks));
+    let bank = bank_forks.read().unwrap().working_bank();
     let (shreds_sender, shreds_receiver) = unbounded();
     const NUM_THREADS: usize = 2;
     let sockets = (0..NUM_THREADS)

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -668,7 +668,7 @@ pub mod test {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank = bank_forks.read().unwrap().root_bank();
 
         // Start up the broadcast stage

--- a/turbine/src/broadcast_stage.rs
+++ b/turbine/src/broadcast_stage.rs
@@ -668,7 +668,7 @@ pub mod test {
 
         let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank = bank_forks.read().unwrap().root_bank();
 
         // Start up the broadcast stage

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -544,7 +544,7 @@ mod test {
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = Arc::new(RwLock::new(BankForks::new(bank)));
+        let bank_forks = BankForks::new(bank);
         let bank0 = bank_forks.read().unwrap().root_bank();
         (
             blockstore,

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -544,7 +544,7 @@ mod test {
         genesis_config.ticks_per_slot = max_ticks_per_n_shreds(num_shreds_per_slot, None) + 1;
 
         let bank = Bank::new_for_tests(&genesis_config);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let bank0 = bank_forks.read().unwrap().root_bank();
         (
             blockstore,

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -598,7 +598,7 @@ mod tests {
             let GenesisConfigInfo { genesis_config, .. } =
                 create_genesis_config(/*mint_lamports:*/ 100_000);
             let bank = Bank::new_for_tests(&genesis_config);
-            Arc::new(RwLock::new(BankForks::new(bank)))
+            BankForks::new(bank)
         };
         let (endpoints, senders, tasks): (Vec<_>, Vec<_>, Vec<_>) =
             multiunzip(keypairs.iter().zip(sockets).zip(senders).map(

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -598,7 +598,7 @@ mod tests {
             let GenesisConfigInfo { genesis_config, .. } =
                 create_genesis_config(/*mint_lamports:*/ 100_000);
             let bank = Bank::new_for_tests(&genesis_config);
-            BankForks::new(bank)
+            BankForks::new_rw_arc(bank)
         };
         let (endpoints, senders, tasks): (Vec<_>, Vec<_>, Vec<_>) =
             multiunzip(keypairs.iter().zip(sockets).zip(senders).map(

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -284,7 +284,7 @@ mod tests {
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
         );
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
-        let bank_forks = RwLock::new(BankForks::new(bank));
+        let bank_forks = BankForks::new(bank);
         let batch_size = 2;
         let mut batch = PacketBatch::with_capacity(batch_size);
         batch.resize(batch_size, Packet::default());

--- a/turbine/src/sigverify_shreds.rs
+++ b/turbine/src/sigverify_shreds.rs
@@ -284,7 +284,7 @@ mod tests {
             &create_genesis_config_with_leader(100, &leader_pubkey, 10).genesis_config,
         );
         let leader_schedule_cache = LeaderScheduleCache::new_from_bank(&bank);
-        let bank_forks = BankForks::new(bank);
+        let bank_forks = BankForks::new_rw_arc(bank);
         let batch_size = 2;
         let mut batch = PacketBatch::with_capacity(batch_size);
         batch.resize(batch_size, Packet::default());

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -917,7 +917,7 @@ mod tests {
         } = create_genesis_config(1_000_000_000);
 
         let bank = Bank::new_for_tests_with_config(&genesis_config, config);
-        (BankForks::new(bank), Arc::new(voting_keypair))
+        (BankForks::new_rw_arc(bank), Arc::new(voting_keypair))
     }
 
     #[test]

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -917,10 +917,7 @@ mod tests {
         } = create_genesis_config(1_000_000_000);
 
         let bank = Bank::new_for_tests_with_config(&genesis_config, config);
-        (
-            Arc::new(RwLock::new(BankForks::new(bank))),
-            Arc::new(voting_keypair),
-        )
+        (BankForks::new(bank), Arc::new(voting_keypair))
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
The instance of `fork_graph` in `LoadedPrograms` cache is not initialized in all the tests.

#### Summary of Changes
- Move code to set fork_graph in `BankForks` constructors
- Rename constructor to indicate that it's returning `Arc<RwLock<>>`
- Update tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
