### PR TITLE
test: check the existence of target_path_parent before detelting

### DIFF
--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -626,14 +626,16 @@ fn build_solana_package(
         // The package version directory doesn't contain a valid
         // installation, and it should be removed.
         let target_path_parent = target_path.parent().expect("Invalid package path");
-        fs::remove_dir_all(target_path_parent).unwrap_or_else(|err| {
-            error!(
-                "Failed to remove {} while recovering from installation failure: {}",
-                target_path_parent.to_string_lossy(),
-                err,
-            );
-            exit(1);
-        });
+        if target_path_parent.exists() {
+            fs::remove_dir_all(target_path_parent).unwrap_or_else(|err| {
+                error!(
+                    "Failed to remove {} while recovering from installation failure: {}",
+                    target_path_parent.to_string_lossy(),
+                    err,
+                );
+                exit(1);
+            });
+        }
         error!("Failed to install platform-tools: {}", err);
         exit(1);
     });


### PR DESCRIPTION
#### Problem

when `install_if_missing` receives a "permission denied" error, `target_path_parent` doesn't exist. if we remove it without checking, the real error will be hidden and return a "directory doesn't exist" error

#### Summary of Changes

check the existence of target_path_parent before delete it