### PR TITLE
Avoid superfluous LUT borrow for owner check

### DIFF
--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -173,13 +173,6 @@ impl Processor {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
-        let lookup_table_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        if *lookup_table_account.get_owner() != id() {
-            return Err(InstructionError::InvalidAccountOwner);
-        }
-        drop(lookup_table_account);
-
         let authority_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
@@ -191,6 +184,9 @@ impl Processor {
 
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+        if *lookup_table_account.get_owner() != id() {
+            return Err(InstructionError::InvalidAccountOwner);
+        }
         let lookup_table_data = lookup_table_account.get_data();
         let lookup_table = AddressLookupTable::deserialize(lookup_table_data)?;
 
@@ -227,14 +223,6 @@ impl Processor {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
-        let lookup_table_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        let table_key = *lookup_table_account.get_key();
-        if *lookup_table_account.get_owner() != id() {
-            return Err(InstructionError::InvalidAccountOwner);
-        }
-        drop(lookup_table_account);
-
         let authority_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
@@ -246,6 +234,10 @@ impl Processor {
 
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+        if *lookup_table_account.get_owner() != id() {
+            return Err(InstructionError::InvalidAccountOwner);
+        }
+        let table_key = *lookup_table_account.get_key();
         let lookup_table_data = lookup_table_account.get_data();
         let lookup_table_lamports = lookup_table_account.get_lamports();
         let mut lookup_table = AddressLookupTable::deserialize(lookup_table_data)?;
@@ -343,13 +335,6 @@ impl Processor {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
-        let lookup_table_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        if *lookup_table_account.get_owner() != id() {
-            return Err(InstructionError::InvalidAccountOwner);
-        }
-        drop(lookup_table_account);
-
         let authority_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
@@ -361,6 +346,9 @@ impl Processor {
 
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+        if *lookup_table_account.get_owner() != id() {
+            return Err(InstructionError::InvalidAccountOwner);
+        }    
         let lookup_table_data = lookup_table_account.get_data();
         let lookup_table = AddressLookupTable::deserialize(lookup_table_data)?;
 
@@ -392,13 +380,6 @@ impl Processor {
         let transaction_context = &invoke_context.transaction_context;
         let instruction_context = transaction_context.get_current_instruction_context()?;
 
-        let lookup_table_account =
-            instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        if *lookup_table_account.get_owner() != id() {
-            return Err(InstructionError::InvalidAccountOwner);
-        }
-        drop(lookup_table_account);
-
         let authority_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
         let authority_key = *authority_account.get_key();
@@ -421,6 +402,9 @@ impl Processor {
 
         let lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
+        if *lookup_table_account.get_owner() != id() {
+            return Err(InstructionError::InvalidAccountOwner);
+        }
         let withdrawn_lamports = lookup_table_account.get_lamports();
         let lookup_table_data = lookup_table_account.get_data();
         let lookup_table = AddressLookupTable::deserialize(lookup_table_data)?;


### PR DESCRIPTION
#### Problem
LUT account is being borrowed to perform an owner check, dropped, then subsequently borrowed again in the Freeze, Extend, Deactivate and Close instructions of the LUT program. This can be avoided by simply removing the initial borrow and moving the owner check into the subsequent borrow. 

#### Summary of Changes
- Removed initial borrow of the LUT used in the owner check
- Combined LUT owner check into the subsequent LUT borrow to ensure we only need to borrow once
- All existing LUT tests still pass (on my machine!)

#### Notes
There is also a double borrow in the Create instruction, however it looks to be a non-trivial fix due to im/mutability concerns.