### PR TITLE
[TieredStorage] HotStorageReader::get_account_offset

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -228,15 +228,15 @@ impl HotStorageReader {
         Ok(meta)
     }
 
-    /// Returns the offset of the account associated with the specified index.
-    fn get_account_offset(&self, index: usize) -> usize {
+    /// Returns the offset to the account stored in the underlying TieredStorage
+    /// file associated with the specified index.
+    fn get_account_offset(&self, index: usize) -> TieredStorageResult<u64> {
         // As Hot storage currently don't support compression, each account has
         // its own account block.  As a result, the account block offset is the
         // account offset.
         self.footer
             .account_index_format
             .get_account_block_offset(&self.mmap, &self.footer, index)
-            .unwrap() as usize
     }
 }
 
@@ -518,7 +518,7 @@ pub mod tests {
         for (i, index_entry) in index_entries.iter().enumerate() {
             assert_eq!(
                 index_entry.block_offset,
-                hot_storage.get_account_offset(i) as u64,
+                hot_storage.get_account_offset(i).unwrap(),
             );
         }
         assert_eq!(&footer, hot_storage.footer());


### PR DESCRIPTION
#### Problem
HotStorageReader currently has get_account_meta_from_offset() as its
internal get account API for given its offset, but how to obtain the offset
of one account is missing.  

#### Summary of Changes
This PR implements HotStorageReader::get_account_offset, which allows
the HotStorageReader to obtain the offset of one account.

#### Test Plan
A new test is included in this PR.