### PR TITLE
Removes Default and pub from CumulativeOffset

### DIFF
--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -332,14 +332,14 @@ const _: () = assert!(
     "CalculateHashIntermediate cannot have any padding"
 );
 
-#[derive(Default, Debug, PartialEq, Eq)]
-pub struct CumulativeOffset {
+#[derive(Debug, PartialEq, Eq)]
+struct CumulativeOffset {
     /// Since the source data is at most 2D, two indexes are enough.
-    pub index: [usize; 2],
-    pub start_offset: usize,
+    index: [usize; 2],
+    start_offset: usize,
 }
 
-pub trait ExtractSliceFromRawData<'b, T: 'b> {
+trait ExtractSliceFromRawData<'b, T: 'b> {
     fn extract<'a>(&'b self, offset: &'a CumulativeOffset, start: usize) -> &'b [T];
 }
 


### PR DESCRIPTION
#### Problem

1. `CumulativeOffset` and its fields are marked public, but are only used within `accounts_hash.rs`. 
2. With https://github.com/solana-labs/solana/pull/33839, the type of `index` will change to a two-element array. A default doesn't necessarily make sense, as we'll always need at least one valid index to be set.


#### Summary of Changes

Remove `pub` and `Default`.