### PR TITLE
blockstore: add merkle root to ErasureMeta column family

### DIFF
--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -3,7 +3,7 @@ use {
     itertools::Itertools,
     solana_ledger::{
         blockstore::BlockstoreError,
-        blockstore_meta::{DuplicateSlotProof, MerkleErasureMeta},
+        blockstore_meta::{DuplicateSlotProof, ErasureMeta},
         shred::{self, Shred, ShredType},
     },
     solana_sdk::{
@@ -141,7 +141,7 @@ where
     // a part of the same fec set. Further work to enhance detection is planned in
     // https://github.com/solana-labs/solana/issues/33037
     if shred1.fec_set_index() == shred2.fec_set_index()
-        && !MerkleErasureMeta::check_erasure_consistency(shred1, shred2)
+        && !ErasureMeta::check_erasure_consistency(shred1, shred2)
     {
         return Ok(());
     }

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -3,7 +3,7 @@ use {
     itertools::Itertools,
     solana_ledger::{
         blockstore::BlockstoreError,
-        blockstore_meta::{DuplicateSlotProof, ErasureMeta},
+        blockstore_meta::{DuplicateSlotProof, MerkleErasureMeta},
         shred::{self, Shred, ShredType},
     },
     solana_sdk::{
@@ -141,7 +141,7 @@ where
     // a part of the same fec set. Further work to enhance detection is planned in
     // https://github.com/solana-labs/solana/issues/33037
     if shred1.fec_set_index() == shred2.fec_set_index()
-        && !ErasureMeta::check_erasure_consistency(shred1, shred2)
+        && !MerkleErasureMeta::check_erasure_consistency(shred1, shred2)
     {
         return Ok(());
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7533,6 +7533,10 @@ pub mod tests {
             erasure_meta_old.first_coding_index
         );
         assert_eq!(erasure_meta.config(), erasure_meta_old.config);
+        assert_eq!(
+            erasure_meta.first_received_coding_index(),
+            erasure_meta_old.first_coding_index
+        );
         assert_eq!(erasure_meta.merkle_root(), Hash::default());
 
         let erasure_meta_new = ErasureMetaLegacy {
@@ -7551,6 +7555,10 @@ pub mod tests {
             erasure_meta_new.first_coding_index()
         );
         assert_eq!(erasure_meta.config(), erasure_meta_new.config());
+        assert_eq!(
+            erasure_meta.first_received_coding_index(),
+            erasure_meta_new.first_coding_index()
+        );
         assert_eq!(erasure_meta.merkle_root(), Hash::default());
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7511,10 +7511,7 @@ pub mod tests {
         let blockstore = Blockstore::open(ledger_path.path()).unwrap();
         let erasure_meta_cf = &blockstore.erasure_meta_cf;
 
-        let config = ErasureConfig {
-            num_data: 1,
-            num_coding: 17,
-        };
+        let config = ErasureConfig::new(1, 17);
         let erasure_meta_old = ErasureMetaLegacy {
             set_index: 5,
             first_coding_index: 8,

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -220,7 +220,7 @@ pub mod columns {
     /// and a FEC (Forward Error Correction) set index.
     ///
     /// * index type: `crate::shred::ErasureSetId` `(Slot, fec_set_index: u64)`
-    /// * value type: [`blockstore_meta::MerkleErasureMeta`]
+    /// * value type: [`blockstore_meta::ErasureMeta`]
     pub struct ErasureMeta;
 
     #[derive(Debug)]
@@ -1222,11 +1222,11 @@ impl ColumnName for columns::ErasureMeta {
     const NAME: &'static str = ERASURE_META_CF;
 }
 impl TypedColumn for columns::ErasureMeta {
-    type Type = blockstore_meta::MerkleErasureMeta;
+    type Type = blockstore_meta::ErasureMeta;
 }
 impl BincodeTypeTransition for columns::ErasureMeta {
     #[allow(deprecated)]
-    type OldType = blockstore_meta::ErasureMeta;
+    type OldType = blockstore_meta::ErasureMetaLegacy;
 }
 
 impl SlotColumn for columns::OptimisticSlots {}

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -118,10 +118,10 @@ pub struct ShredIndex {
     index: BTreeSet<u64>,
 }
 
-#[deprecated = "Use MerkleErasureMeta"]
+#[deprecated = "Use ErasureMeta"]
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 /// Erasure coding information
-pub struct ErasureMeta {
+pub struct ErasureMetaLegacy {
     /// Which erasure set in the slot this is
     pub(crate) set_index: u64,
     /// First coding index in the FEC set
@@ -135,7 +135,7 @@ pub struct ErasureMeta {
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
 /// Erasure coding information for merkle shreds
-pub struct MerkleErasureMeta {
+pub struct ErasureMeta {
     /// Which erasure set in the slot this is
     set_index: u64,
     /// First coding index in the FEC set
@@ -335,7 +335,7 @@ impl SlotMeta {
     }
 }
 
-impl MerkleErasureMeta {
+impl ErasureMeta {
     pub(crate) fn from_coding_shred(shred: &Shred) -> Option<Self> {
         match shred.shred_type() {
             ShredType::Data => None,
@@ -346,7 +346,7 @@ impl MerkleErasureMeta {
                 };
                 let first_coding_index = u64::from(shred.first_coding_index()?);
                 let merkle_root = Hash::default();
-                let erasure_meta = MerkleErasureMeta {
+                let erasure_meta = ErasureMeta {
                     set_index: u64::from(shred.fec_set_index()),
                     config,
                     first_coding_index,
@@ -425,9 +425,9 @@ impl MerkleErasureMeta {
     }
 }
 
-impl From<ErasureMeta> for MerkleErasureMeta {
-    fn from(erasure_meta: ErasureMeta) -> MerkleErasureMeta {
-        MerkleErasureMeta {
+impl From<ErasureMetaLegacy> for ErasureMeta {
+    fn from(erasure_meta: ErasureMetaLegacy) -> ErasureMeta {
+        ErasureMeta {
             set_index: erasure_meta.set_index,
             first_coding_index: erasure_meta.first_coding_index,
             config: erasure_meta.config,
@@ -551,7 +551,7 @@ mod test {
             num_data: 8,
             num_coding: 16,
         };
-        let e_meta = MerkleErasureMeta {
+        let e_meta = ErasureMeta {
             set_index,
             first_coding_index: set_index,
             config: erasure_config,

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -150,8 +150,18 @@ pub struct ErasureMeta {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub(crate) struct ErasureConfig {
-    pub(crate) num_data: usize,
-    pub(crate) num_coding: usize,
+    num_data: usize,
+    num_coding: usize,
+}
+
+#[cfg(test)]
+impl ErasureConfig {
+    pub(crate) fn new(num_data: usize, num_coding: usize) -> Self {
+        ErasureConfig {
+            num_data,
+            num_coding,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize)]

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -10,6 +10,7 @@ pub mod block_error;
 pub mod blockstore;
 pub mod ancestor_iterator;
 pub mod blockstore_db;
+#[allow(deprecated)]
 pub mod blockstore_meta;
 pub mod blockstore_metrics;
 pub mod blockstore_options;


### PR DESCRIPTION
#### Problem
In order to detect duplicate blocks with conflicting merkle roots we need to be able to access the merkle root for each FEC set.

We store the merkle root along with the existing `ErasureMeta` for each FEC set.

#### Summary of Changes
This change allows us to read blockstore in both formats, with or without the merkle root. It is intended to be backported.

Contributes to #33644 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
