### PR TITLE
validator: deprecates `--disable-accounts-disk-index`

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1865,12 +1865,10 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
     );
-    add_arg!(
-        Arg::with_name("disable_accounts_disk_index")
-            .long("disable-accounts-disk-index")
-            .help("Disable the disk-based accounts index if it is enabled by default.")
-            .conflicts_with("accounts_index_memory_limit_mb")
-    )
+    add_arg!(Arg::with_name("disable_accounts_disk_index")
+        .long("disable-accounts-disk-index")
+        .help("Disable the disk-based accounts index if it is enabled by default.")
+        .conflicts_with("accounts_index_memory_limit_mb"));
 
     res
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1241,12 +1241,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("How much memory the accounts index can consume. If this is exceeded, some account index entries will be stored on disk."),
         )
         .arg(
-            Arg::with_name("disable_accounts_disk_index")
-                .long("disable-accounts-disk-index")
-                .help("Disable the disk-based accounts index if it is enabled by default.")
-                .conflicts_with("accounts_index_memory_limit_mb")
-        )
-        .arg(
             Arg::with_name("accounts_index_bins")
                 .long("accounts-index-bins")
                 .value_name("BINS")
@@ -1871,6 +1865,12 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
     );
+    add_arg!(
+        Arg::with_name("disable_accounts_disk_index")
+            .long("disable-accounts-disk-index")
+            .help("Disable the disk-based accounts index if it is enabled by default.")
+            .conflicts_with("accounts_index_memory_limit_mb")
+    )
 
     res
 }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1781,6 +1781,10 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
                 Ok(())
             }
         }));
+    add_arg!(Arg::with_name("disable_accounts_disk_index")
+        .long("disable-accounts-disk-index")
+        .help("Disable the disk-based accounts index if it is enabled by default.")
+        .conflicts_with("accounts_index_memory_limit_mb"));
     add_arg!(
         Arg::with_name("disable_quic_servers")
             .long("disable-quic-servers")
@@ -1865,10 +1869,6 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .help("Skip ledger verification at validator bootup."),
         replaced_by: "skip-startup-ledger-verification",
     );
-    add_arg!(Arg::with_name("disable_accounts_disk_index")
-        .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index if it is enabled by default.")
-        .conflicts_with("accounts_index_memory_limit_mb"));
 
     res
 }


### PR DESCRIPTION
#### Problem

accounts disk index is the future, but we still offer a flag to disable it. every operator silently reverting to old behavior is going to be a problem when we need to drop support. 

#### Summary of Changes

reduce the burden today. deprecate the flag