### PR TITLE
zeroize: Apply `zeroize` patch to all repository crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -421,6 +421,10 @@ winapi = "0.3.8"
 winreg = "0.50"
 x509-parser = "0.14.0"
 # See "zeroize versioning issues" below if you are updating this version.
+#
+# TL;DR: We can not increment this until we move to a never version of
+# `aes-gcm-siv` and `curve25519-dalek` and remove `[patch]` exceptions below for
+# both crates.
 zeroize = { version = "1.3", default-features = false }
 zstd = "0.11.2"
 
@@ -473,6 +477,13 @@ solana-zk-token-sdk = { path = "zk-token-sdk" }
 # When our dependencies are upgraded, we can remove this patches.  Before that
 # we might need to maintain these patches in sync with our full dependency
 # tree.
+#
+# Same patches are applied to the following `Cargo.toml` files, make sure to
+# update both in sync:
+#
+#  - programs/sbf/Cargo.toml
+#  - sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+#  - sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
 
 # Our dependency tree has `aes-gcm-siv` v0.10.3 and the `zeroize` restriction
 # was removed in the next commit just after the release.  So it seems safe to

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -51,8 +51,7 @@ dependencies = [
 [[package]]
 name = "aes-gcm-siv"
 version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589c637f0e68c877bbd59a4599bbe849cac8e5f3e4b5a3ebae8f528cd218dcdc"
+source = "git+https://github.com/RustCrypto/AEADs?rev=6105d7a5591aefa646a95d12b5e8d3f55a9214ef#6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 dependencies = [
  "aead",
  "aes",
@@ -1175,8 +1174,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=c14774464c4d38de553c6ef2f48a10982c1b4801#c14774464c4d38de553c6ef2f48a10982c1b4801"
 dependencies = [
  "byteorder 1.5.0",
  "digest 0.9.0",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -200,3 +200,15 @@ targets = ["x86_64-unknown-linux-gnu"]
 # overrides in sync.
 solana-program = { path = "../../sdk/program" }
 solana-zk-token-sdk = { path = "../../zk-token-sdk" }
+
+#
+# === zeroize versioning issues ===
+#
+# See `../../Cargo.toml` for details.  The following patches allow us to build
+# the whole repository with a newer version of `zeroize` than 1.3.
+[patch.crates-io.aes-gcm-siv]
+git = "https://github.com/RustCrypto/AEADs"
+rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/solana-labs/curve25519-dalek.git"
+rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -16,3 +16,13 @@ solana-program = { path = "../../../../program", version = "=1.18.0" }
 crate-type = ["cdylib"]
 
 [workspace]
+
+[patch.crates-io]
+#
+# === zeroize versioning issues ===
+#
+# See `../../../../../Cargo.toml` for details.  The following patches allow us
+# to build the whole repository with a newer version of `zeroize` than 1.3.
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/solana-labs/curve25519-dalek.git"
+rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -16,3 +16,16 @@ solana-program = { path = "../../../../program", version = "=1.18.0" }
 crate-type = ["cdylib"]
 
 [workspace]
+
+[patch.crates-io]
+#
+# === zeroize versioning issues ===
+#
+# See `../../../../../Cargo.toml` for details.  The following patches allow us
+# to build the whole repository with a newer version of `zeroize` than 1.3.
+[patch.crates-io.aes-gcm-siv]
+git = "https://github.com/RustCrypto/AEADs"
+rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
+[patch.crates-io.curve25519-dalek]
+git = "https://github.com/solana-labs/curve25519-dalek.git"
+rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"


### PR DESCRIPTION
Similar to the changes in the main workspace `Cargo.toml`, we want to
remove constraints for `zeroize` in the `programs/sbf` and other
workspace crates.

See

> commit a099c7a
> Author: Illia Bobyr <illia.bobyr@solana.com>
> Date:   Mon Oct 23 12:19:59 2023 -0700
>
> zeroize: Allow versions newer than 1.3 for `curve25519-dalek` (#33516)

and

> commit 01f1bf2
> Author: Illia Bobyr <illia.bobyr@solana.com>
> Date:   Fri Oct 20 18:20:51 2023 -0700
> 
> zeroize: Allow versions newer than 1.3 for `aes-gcm-siv` (#33618)