### PR TITLE
Update upload_confirmed_blocks() return value when no blocks to upload

### DIFF
--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -138,7 +138,7 @@ pub async fn upload_confirmed_blocks(
             "No blocks between {} and {} need to be uploaded to bigtable",
             starting_slot, ending_slot
         );
-        return Ok(last_blockstore_slot);
+        return Ok(ending_slot);
     }
     let last_slot = *blocks_to_upload.last().unwrap();
     info!(


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/33831#issuecomment-1779203305 for a detailed walk-through.

#### Summary of Changes
While this problem of looping on the same slot seems to be caused by an operator restarting their warehouse node without `--no-snapshot-fetch` (which can cause a gap in the blockstore), we can still be friendly and break out of this loop

Fixes #33831 