### PR TITLE
Blockstore: only return block times for rooted slots

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1962,8 +1962,7 @@ impl Blockstore {
         }
     }
 
-    pub fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
-        datapoint_info!("blockstore-rpc-api", ("method", "get_block_time", String));
+    fn get_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
         let _lock = self.check_lowest_cleanup_slot(slot)?;
         self.blocktime_cf.get(slot)
     }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1968,6 +1968,18 @@ impl Blockstore {
         self.blocktime_cf.get(slot)
     }
 
+    pub fn get_rooted_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
+        datapoint_info!(
+            "blockstore-rpc-api",
+            ("method", "get_rooted_block_time", String)
+        );
+        let _lock = self.check_lowest_cleanup_slot(slot)?;
+        if self.is_root(slot) {
+            return self.blocktime_cf.get(slot);
+        }
+        Err(BlockstoreError::SlotNotRooted)
+    }
+
     pub fn cache_block_time(&self, slot: Slot, timestamp: UnixTimestamp) -> Result<()> {
         self.blocktime_cf.put(slot, &timestamp)
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1321,7 +1321,7 @@ impl JsonRpcRequestProcessor {
                 .unwrap()
                 .highest_super_majority_root()
         {
-            let result = self.blockstore.get_block_time(slot);
+            let result = self.blockstore.get_rooted_block_time(slot);
             self.check_blockstore_root(&result, slot)?;
             if result.is_err() || matches!(result, Ok(None)) {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {


### PR DESCRIPTION
#### Problem
As described in #33858, we unintentionally support returning block times for unrooted slots from Blockstore. This results in weird behavior where these block times are available only until the slot is purged from the local ledger, since only rooted slots are uploaded to bigtable.

#### Summary of Changes
- Add a new method to Blockstore that only returns block times for rooted slots
- Use this method in solana-rpc. This makes `getBlockTime` follow `getBlock` logic more closely

(edit) I thought at first we could deprecate the old method, but we do use it internally to Blockstore in `get_transaction_with_status()` and `get_confirmed_signatures_for_address2()`. We could maybe un-pub it...

Partially fixes #33858
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
