### PR TITLE
[TieredStorage] Add type TieredStorageOffset

### DIFF
--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -5,6 +5,9 @@ use std::{
     path::Path,
 };
 
+pub type TieredStorageOffset = u64;
+pub type TieredStorageSeekOffset = i64;
+
 #[derive(Debug)]
 pub struct TieredStorageFile(pub File);
 
@@ -50,11 +53,14 @@ impl TieredStorageFile {
         Ok(())
     }
 
-    pub fn seek(&self, offset: u64) -> Result<u64, std::io::Error> {
+    pub fn seek(&self, offset: TieredStorageOffset) -> Result<TieredStorageOffset, std::io::Error> {
         (&self.0).seek(SeekFrom::Start(offset))
     }
 
-    pub fn seek_from_end(&self, offset: i64) -> Result<u64, std::io::Error> {
+    pub fn seek_from_end(
+        &self,
+        offset: TieredStorageSeekOffset,
+    ) -> Result<TieredStorageOffset, std::io::Error> {
         (&self.0).seek(SeekFrom::End(offset))
     }
 

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -1,7 +1,10 @@
 use {
     crate::tiered_storage::{
-        error::TieredStorageError, file::TieredStorageFile, index::AccountIndexFormat,
-        mmap_utils::get_type, TieredStorageResult as TsResult,
+        error::TieredStorageError,
+        file::{TieredStorageFile, TieredStorageOffset},
+        index::AccountIndexFormat,
+        mmap_utils::get_type,
+        TieredStorageResult as TsResult,
     },
     memmap2::Mmap,
     solana_sdk::{hash::Hash, pubkey::Pubkey},
@@ -120,9 +123,9 @@ pub struct TieredStorageFooter {
     // Offsets
     // Note that offset to the account blocks is omitted as it's always 0.
     /// The offset pointing to the first byte of the account index block.
-    pub account_index_offset: u64,
+    pub account_index_offset: TieredStorageOffset,
     /// The offset pointing to the first byte of the owners block.
-    pub owners_offset: u64,
+    pub owners_offset: TieredStorageOffset,
 
     // account range
     /// The smallest account address in this file.
@@ -206,8 +209,8 @@ impl TieredStorageFooter {
 
     pub fn new_from_mmap(map: &Mmap) -> TsResult<&TieredStorageFooter> {
         let offset = map.len().saturating_sub(FOOTER_TAIL_SIZE);
-        let (footer_size, offset) = get_type::<u64>(map, offset)?;
-        let (_footer_version, offset) = get_type::<u64>(map, offset)?;
+        let (footer_size, offset) = get_type::<TieredStorageOffset>(map, offset)?;
+        let (_footer_version, offset) = get_type::<TieredStorageOffset>(map, offset)?;
         let (magic_number, _offset) = get_type::<TieredStorageMagicNumber>(map, offset)?;
 
         if *magic_number != TieredStorageMagicNumber::default() {


### PR DESCRIPTION
#### Problem
TieredStorage currently uses `u64` to represent its offset
and does not have a type that is specific for its offset usage.

#### Summary of Changes
To avoid misuse and improve readability, this PR introduces
type TieredStorageOffset, which is defined as u64.

