### PR TITLE
Fastboots by default

### DIFF
--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -8,7 +8,6 @@ use strum::{Display, EnumString, EnumVariantNames, IntoStaticStr, VariantNames};
 pub enum UseSnapshotArchivesAtStartup {
     /// If snapshot archives are used, they will be extracted and overwrite any existing state
     /// already on disk.  This will incur the associated runtime costs for extracting.
-    #[default]
     Always,
     /// If snapshot archives are not used, then the local snapshot state already on disk is
     /// used instead.  If there is no local state on disk, startup will fail.
@@ -18,6 +17,7 @@ pub enum UseSnapshotArchivesAtStartup {
     /// restarting.  At startup, the snapshot archive would be the newest and loaded from.
     /// Note, this also implies that snapshot archives will be used if there is no local snapshot
     /// state on disk.
+    #[default]
     WhenNewest,
 }
 


### PR DESCRIPTION
#### Problem

Fastboot is available as a CLI arg, but it's not on by default. This means most validators will not use it/know about it.


#### Summary of Changes

Turn on fastboot by default.

Note that fastboot was properly added/supported in v1.17. Turning it on by default is v1.18+. This will allow for testing from a wider audience as v1.17 is rolled out to the various clusters.