### PR TITLE
send duplicate shred proofs for merkle root conflicts

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -148,6 +148,7 @@ fn run_check_duplicate(
         let (shred1, shred2) = match shred {
             PossibleDuplicateShred::LastIndexConflict(shred, conflict) => (shred, conflict),
             PossibleDuplicateShred::ErasureConflict(shred, conflict) => (shred, conflict),
+            PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
             PossibleDuplicateShred::Exists(shred) => {
                 // Unlike the other cases we have to wait until here to decide to handle the duplicate and store
                 // in blockstore. This is because the duplicate could have been part of the same insert batch,

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -267,7 +267,7 @@ pub fn make_accounts_hashes_message(
 pub(crate) type Ping = ping_pong::Ping<[u8; GOSSIP_PING_TOKEN_SIZE]>;
 
 // TODO These messages should go through the gpu pipeline for spam filtering
-#[frozen_abi(digest = "CVvKB495YW6JN4w1rWwajyZmG5wvNhmD97V99rSv9fGw")]
+#[frozen_abi(digest = "CroFF8MTW2fxatwv7ALz9Wde4e9L9yE4L59yebM3XuWe")]
 #[derive(Serialize, Deserialize, Debug, AbiEnumVisitor, AbiExample)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Protocol {

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -8,6 +8,7 @@ use {
     },
     solana_sdk::{
         clock::Slot,
+        hash::Hash,
         pubkey::Pubkey,
         sanitize::{Sanitize, SanitizeError},
     },
@@ -30,7 +31,7 @@ pub struct DuplicateShred {
     pub(crate) wallclock: u64,
     pub(crate) slot: Slot,
     _unused: u32,
-    shred_type: ShredType,
+    _unused_shred_type: ShredType,
     // Serialized DuplicateSlotProof split into chunks.
     num_chunks: u8,
     chunk_index: u8,
@@ -66,6 +67,8 @@ pub enum Error {
     InvalidErasureMetaConflict,
     #[error("invalid last index conflict")]
     InvalidLastIndexConflict,
+    #[error("invalid merkle root conflict")]
+    InvalidMerkleRootConflict,
     #[error("invalid signature")]
     InvalidSignature,
     #[error("invalid size limit")]
@@ -78,8 +81,6 @@ pub enum Error {
     MissingDataChunk,
     #[error("(de)serialization error")]
     SerializationError(#[from] bincode::Error),
-    #[error("shred type mismatch")]
-    ShredTypeMismatch,
     #[error("slot mismatch")]
     SlotMismatch,
     #[error("type conversion error")]
@@ -90,8 +91,8 @@ pub enum Error {
 
 /// Check that `shred1` and `shred2` indicate a valid duplicate proof
 ///     - Must be for the same slot
-///     - Must have the same `shred_type`
 ///     - Must both sigverify for the correct leader
+///     - Must have a merkle root conflict, otherwise `shred1` and `shred2` must have the same `shred_type`
 ///     - If `shred1` and `shred2` share the same index they must be not equal
 ///     - If `shred1` and `shred2` do not share the same index and are data shreds
 ///       verify that they indicate an index conflict. One of them must be the
@@ -106,16 +107,29 @@ where
         return Err(Error::SlotMismatch);
     }
 
-    if shred1.shred_type() != shred2.shred_type() {
-        return Err(Error::ShredTypeMismatch);
-    }
-
     if let Some(leader_schedule) = leader_schedule {
         let slot_leader =
             leader_schedule(shred1.slot()).ok_or(Error::UnknownSlotLeader(shred1.slot()))?;
         if !shred1.verify(&slot_leader) || !shred2.verify(&slot_leader) {
             return Err(Error::InvalidSignature);
         }
+    }
+
+    // Merkle root conflict check
+    if let Some((mr1, mr2)) = shred1.merkle_root().zip(shred2.merkle_root()) {
+        // Hash::default check to exclude legacy shreds
+        if shred1.fec_set_index() == shred2.fec_set_index()
+            && mr1 != mr2
+            && mr1 != Hash::default()
+            && mr2 != Hash::default()
+        {
+            return Ok(());
+        }
+    }
+
+    if shred1.shred_type() != shred2.shred_type() {
+        // Only valid proof here is a merkle conflict which was checked above
+        return Err(Error::InvalidMerkleRootConflict);
     }
 
     if shred1.index() == shred2.index() {
@@ -164,7 +178,7 @@ where
     }
     let other_shred = Shred::new_from_serialized_shred(other_payload)?;
     check_shreds(leader_schedule, &shred, &other_shred)?;
-    let (slot, shred_type) = (shred.slot(), shred.shred_type());
+    let slot = shred.slot();
     let proof = DuplicateSlotProof {
         shred1: shred.into_payload(),
         shred2: other_shred.into_payload(),
@@ -184,27 +198,21 @@ where
             from: self_pubkey,
             wallclock,
             slot,
-            shred_type,
             num_chunks,
             chunk_index: i as u8,
             chunk,
             _unused: 0,
+            _unused_shred_type: ShredType::Code,
         });
     Ok(chunks)
 }
 
 // Returns a predicate checking if a duplicate-shred chunk matches
-// (slot, shred_type) and has valid chunk_index.
-fn check_chunk(
-    slot: Slot,
-    shred_type: ShredType,
-    num_chunks: u8,
-) -> impl Fn(&DuplicateShred) -> Result<(), Error> {
+// the slot and has valid chunk_index.
+fn check_chunk(slot: Slot, num_chunks: u8) -> impl Fn(&DuplicateShred) -> Result<(), Error> {
     move |dup| {
         if dup.slot != slot {
             Err(Error::SlotMismatch)
-        } else if dup.shred_type != shred_type {
-            Err(Error::ShredTypeMismatch)
         } else if dup.num_chunks != num_chunks {
             Err(Error::NumChunksMismatch)
         } else if dup.chunk_index >= num_chunks {
@@ -226,13 +234,12 @@ pub(crate) fn into_shreds(
     let mut chunks = chunks.into_iter();
     let DuplicateShred {
         slot,
-        shred_type,
         num_chunks,
         chunk_index,
         chunk,
         ..
     } = chunks.next().ok_or(Error::InvalidDuplicateShreds)?;
-    let check_chunk = check_chunk(slot, shred_type, num_chunks);
+    let check_chunk = check_chunk(slot, num_chunks);
     let mut data = HashMap::new();
     data.insert(chunk_index, chunk);
     for chunk in chunks {
@@ -260,8 +267,6 @@ pub(crate) fn into_shreds(
     let shred2 = Shred::new_from_serialized_shred(proof.shred2)?;
     if shred1.slot() != slot || shred2.slot() != slot {
         Err(Error::SlotMismatch)
-    } else if shred1.shred_type() != shred_type || shred2.shred_type() != shred_type {
-        Err(Error::ShredTypeMismatch)
     } else {
         check_shreds(Some(|_| Some(slot_leader).copied()), &shred1, &shred2)?;
         Ok((shred1, shred2))
@@ -300,7 +305,7 @@ pub(crate) mod tests {
             from: Pubkey::new_unique(),
             wallclock: u64::MAX,
             slot: Slot::MAX,
-            shred_type: ShredType::Data,
+            _unused_shred_type: ShredType::Data,
             num_chunks: u8::MAX,
             chunk_index: u8::MAX,
             chunk: Vec::default(),
@@ -421,7 +426,7 @@ pub(crate) mod tests {
         wallclock: u64,
         max_size: usize, // Maximum serialized size of each DuplicateShred.
     ) -> Result<impl Iterator<Item = DuplicateShred>, Error> {
-        let (slot, shred_type) = (shred.slot(), shred.shred_type());
+        let slot = shred.slot();
         let proof = DuplicateSlotProof {
             shred1: shred.into_payload(),
             shred2: other_shred.into_payload(),
@@ -437,11 +442,11 @@ pub(crate) mod tests {
                 from: self_pubkey,
                 wallclock,
                 slot,
-                shred_type,
                 num_chunks,
                 chunk_index: i as u8,
                 chunk,
                 _unused: 0,
+                _unused_shred_type: ShredType::Code,
             });
         Ok(chunks)
     }
@@ -815,6 +820,14 @@ pub(crate) mod tests {
             &leader,
             merkle_variant,
         );
+        let coding_shreds_different_merkle_root = new_rand_coding_shreds(
+            &mut rng,
+            next_shred_index,
+            10,
+            &shredder,
+            &leader,
+            merkle_variant,
+        );
         let coding_shreds_bigger = new_rand_coding_shreds(
             &mut rng,
             next_shred_index,
@@ -833,10 +846,18 @@ pub(crate) mod tests {
         );
 
         // Same fec-set, different index, different erasure meta
-        let test_cases = vec![
+        let mut test_cases = vec![
             (coding_shreds[0].clone(), coding_shreds_bigger[1].clone()),
             (coding_shreds[0].clone(), coding_shreds_smaller[1].clone()),
         ];
+        if merkle_variant {
+            // Same erasure config, different merkle root is still different
+            // erasure meta
+            test_cases.push((
+                coding_shreds[0].clone(),
+                coding_shreds_different_merkle_root[0].clone(),
+            ));
+        }
         for (shred1, shred2) in test_cases.into_iter() {
             let chunks: Vec<_> = from_shred(
                 shred1.clone(),
@@ -946,6 +967,175 @@ pub(crate) mod tests {
             assert_matches!(
                 into_shreds(&leader.pubkey(), chunks).err().unwrap(),
                 Error::InvalidErasureMetaConflict
+            );
+        }
+    }
+
+    #[test]
+    fn test_merkle_root_conflict_round_trip() {
+        let mut rng = rand::thread_rng();
+        let leader = Arc::new(Keypair::new());
+        let (slot, parent_slot, reference_tick, version) = (53084024, 53084023, 0, 0);
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
+        let next_shred_index = rng.gen_range(0..31_000);
+        let leader_schedule = |s| {
+            if s == slot {
+                Some(leader.pubkey())
+            } else {
+                None
+            }
+        };
+        let (coding_shreds, data_shreds) = new_rand_shreds(
+            &mut rng,
+            next_shred_index,
+            next_shred_index,
+            10,
+            true,
+            &shredder,
+            &leader,
+            false,
+        );
+        let (diff_coding_shreds, diff_data_shreds) = new_rand_shreds(
+            &mut rng,
+            next_shred_index,
+            next_shred_index,
+            10,
+            true,
+            &shredder,
+            &leader,
+            false,
+        );
+
+        let test_cases = vec![
+            (data_shreds[0].clone(), diff_data_shreds[1].clone()),
+            (coding_shreds[0].clone(), diff_coding_shreds[1].clone()),
+            (data_shreds[0].clone(), diff_coding_shreds[0].clone()),
+            (coding_shreds[0].clone(), diff_data_shreds[0].clone()),
+        ];
+        for (shred1, shred2) in test_cases.into_iter() {
+            let chunks: Vec<_> = from_shred(
+                shred1.clone(),
+                Pubkey::new_unique(), // self_pubkey
+                shred2.payload().clone(),
+                Some(leader_schedule),
+                rng.gen(), // wallclock
+                512,       // max_size
+            )
+            .unwrap()
+            .collect();
+            assert!(chunks.len() > 4);
+            let (shred3, shred4) = into_shreds(&leader.pubkey(), chunks).unwrap();
+            assert_eq!(shred1, shred3);
+            assert_eq!(shred2, shred4);
+        }
+    }
+
+    #[test]
+    fn test_merkle_root_conflict_invalid() {
+        let mut rng = rand::thread_rng();
+        let leader = Arc::new(Keypair::new());
+        let (slot, parent_slot, reference_tick, version) = (53084024, 53084023, 0, 0);
+        let shredder = Shredder::new(slot, parent_slot, reference_tick, version).unwrap();
+        let next_shred_index = rng.gen_range(0..31_000);
+        let leader_schedule = |s| {
+            if s == slot {
+                Some(leader.pubkey())
+            } else {
+                None
+            }
+        };
+
+        let (data_shreds, coding_shreds) = new_rand_shreds(
+            &mut rng,
+            next_shred_index,
+            next_shred_index,
+            10,
+            true,
+            &shredder,
+            &leader,
+            true,
+        );
+
+        let (next_data_shreds, next_coding_shreds) = new_rand_shreds(
+            &mut rng,
+            next_shred_index + 1,
+            next_shred_index + 1,
+            10,
+            true,
+            &shredder,
+            &leader,
+            true,
+        );
+
+        let (legacy_data_shreds, legacy_coding_shreds) = new_rand_shreds(
+            &mut rng,
+            next_shred_index,
+            next_shred_index,
+            10,
+            false,
+            &shredder,
+            &leader,
+            true,
+        );
+
+        let test_cases = vec![
+            // Same fec set same merkle root
+            (coding_shreds[0].clone(), data_shreds[0].clone()),
+            (data_shreds[0].clone(), coding_shreds[0].clone()),
+            // Different FEC set different merkle root
+            (coding_shreds[0].clone(), next_data_shreds[0].clone()),
+            (next_coding_shreds[0].clone(), data_shreds[0].clone()),
+            (data_shreds[0].clone(), next_coding_shreds[0].clone()),
+            (next_data_shreds[0].clone(), coding_shreds[0].clone()),
+            // Legacy shreds
+            (
+                legacy_coding_shreds[0].clone(),
+                legacy_data_shreds[0].clone(),
+            ),
+            (
+                legacy_data_shreds[0].clone(),
+                legacy_coding_shreds[0].clone(),
+            ),
+            // Mix of legacy and merkle
+            (legacy_coding_shreds[0].clone(), data_shreds[0].clone()),
+            (coding_shreds[0].clone(), legacy_data_shreds[0].clone()),
+            (legacy_data_shreds[0].clone(), coding_shreds[0].clone()),
+            (data_shreds[0].clone(), legacy_coding_shreds[0].clone()),
+            // Mix of legacy and merkle with different fec index
+            (legacy_coding_shreds[0].clone(), next_data_shreds[0].clone()),
+            (next_coding_shreds[0].clone(), legacy_data_shreds[0].clone()),
+            (legacy_data_shreds[0].clone(), next_coding_shreds[0].clone()),
+            (next_data_shreds[0].clone(), legacy_coding_shreds[0].clone()),
+        ];
+        for (shred1, shred2) in test_cases.into_iter() {
+            assert_matches!(
+                from_shred(
+                    shred1.clone(),
+                    Pubkey::new_unique(), // self_pubkey
+                    shred2.payload().clone(),
+                    Some(leader_schedule),
+                    rng.gen(), // wallclock
+                    512,       // max_size
+                )
+                .err()
+                .unwrap(),
+                Error::InvalidMerkleRootConflict
+            );
+
+            let chunks: Vec<_> = from_shred_bypass_checks(
+                shred1.clone(),
+                Pubkey::new_unique(), // self_pubkey
+                shred2.clone(),
+                rng.gen(), // wallclock
+                512,       // max_size
+            )
+            .unwrap()
+            .collect();
+            assert!(chunks.len() > 4);
+
+            assert_matches!(
+                into_shreds(&leader.pubkey(), chunks).err().unwrap(),
+                Error::InvalidMerkleRootConflict
             );
         }
     }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -406,6 +406,28 @@ impl ErasureMeta {
     }
 }
 
+impl MerkleRootMeta {
+    pub(crate) fn from_shred(shred: &Shred) -> Self {
+        Self {
+            merkle_root: shred.merkle_root().unwrap_or_default(),
+            first_received_shred_index: shred.index(),
+            first_received_shred_type: shred.shred_type(),
+        }
+    }
+
+    pub(crate) fn merkle_root(&self) -> Hash {
+        self.merkle_root
+    }
+
+    pub(crate) fn first_received_shred_index(&self) -> u32 {
+        self.first_received_shred_index
+    }
+
+    pub(crate) fn first_received_shred_type(&self) -> ShredType {
+        self.first_received_shred_type
+    }
+}
+
 impl DuplicateSlotProof {
     pub(crate) fn new(shred1: Vec<u8>, shred2: Vec<u8>) -> Self {
         DuplicateSlotProof { shred1, shred2 }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -287,6 +287,10 @@ impl ErasureSetId {
     pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u64) {
         (self.0, u64::from(self.1))
     }
+
+    pub(crate) fn key(&self) -> (Slot, /*fec_set_index:*/ u32) {
+        (self.0, self.1)
+    }
 }
 
 macro_rules! dispatch {
@@ -336,6 +340,8 @@ impl Shred {
     dispatch!(pub fn into_payload(self) -> Vec<u8>);
     dispatch!(pub fn payload(&self) -> &Vec<u8>);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
+
+    dispatch!(pub fn merkle_root(&self) -> Option<Hash>);
 
     // Only for tests.
     dispatch!(pub fn set_index(&mut self, index: u32));

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -154,7 +154,7 @@ impl ShredData {
         Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size)?)
     }
 
-    fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         let proof_size = self.proof_size()?;
         let index = self.erasure_shard_index()?;
         let proof_offset = Self::proof_offset(proof_size)?;
@@ -266,7 +266,7 @@ impl ShredCode {
         Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size)?)
     }
 
-    fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         let proof_size = self.proof_size()?;
         let index = self.erasure_shard_index()?;
         let proof_offset = Self::proof_offset(proof_size)?;

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -6,7 +6,7 @@ use {
         CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
         DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
-    solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
+    solana_sdk::{clock::Slot, hash::Hash, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
 };
 
@@ -44,6 +44,13 @@ impl ShredCode {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
             Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
+
+    pub(super) fn merkle_root(&self) -> Option<Hash> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Merkle(shred) => shred.merkle_root().ok(),
         }
     }
 

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -7,7 +7,7 @@ use {
         DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant, SignedData,
         MAX_DATA_SHREDS_PER_SLOT,
     },
-    solana_sdk::{clock::Slot, signature::Signature},
+    solana_sdk::{clock::Slot, hash::Hash, signature::Signature},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,6 +38,13 @@ impl ShredData {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
             Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
+
+    pub(super) fn merkle_root(&self) -> Option<Hash> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Merkle(shred) => shred.merkle_root().ok(),
         }
     }
 


### PR DESCRIPTION
#### Problem
Data shred + coding shred that are part of the same FEC set with different merkle roots are not marked duplicate.

#### Summary of Changes
Detect this scenario, store the proof in blockstore and notify the cluster. 

Fixes #33644 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
