### PR TITLE
TransactionScheduler: CLI and hookup for central-scheduler

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -959,8 +959,7 @@ mod tests {
         with_vers.into_iter().map(|(b, _)| b).collect()
     }
 
-    #[test]
-    fn test_banking_stage_entries_only() {
+    fn test_banking_stage_entries_only(block_production_method: BlockProductionMethod) {
         solana_logger::setup();
         let GenesisConfigInfo {
             genesis_config,
@@ -995,7 +994,7 @@ mod tests {
             let (replay_vote_sender, _replay_vote_receiver) = unbounded();
 
             let banking_stage = BankingStage::new(
-                BlockProductionMethod::ThreadLocalMultiIterator,
+                block_production_method,
                 &cluster_info,
                 &poh_recorder,
                 non_vote_receiver,
@@ -1086,6 +1085,16 @@ mod tests {
             drop(entry_receiver);
         }
         Blockstore::destroy(ledger_path.path()).unwrap();
+    }
+
+    #[test]
+    fn test_banking_stage_entries_only_thread_local_multi_iterator() {
+        test_banking_stage_entries_only(BlockProductionMethod::ThreadLocalMultiIterator);
+    }
+
+    #[test]
+    fn test_banking_stage_entries_only_central_scheduler() {
+        test_banking_stage_entries_only(BlockProductionMethod::CentralScheduler);
     }
 
     #[test]

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -16,10 +16,19 @@ use {
         unprocessed_transaction_storage::{ThreadType, UnprocessedTransactionStorage},
     },
     crate::{
-        banking_trace::BankingPacketReceiver, tracer_packet_stats::TracerPacketStats,
+        banking_stage::{
+            consume_worker::ConsumeWorker,
+            packet_deserializer::PacketDeserializer,
+            transaction_scheduler::{
+                prio_graph_scheduler::PrioGraphScheduler,
+                scheduler_controller::SchedulerController, scheduler_error::SchedulerError,
+            },
+        },
+        banking_trace::BankingPacketReceiver,
+        tracer_packet_stats::TracerPacketStats,
         validator::BlockProductionMethod,
     },
-    crossbeam_channel::RecvTimeoutError,
+    crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender},
     histogram::Histogram,
     solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
@@ -378,6 +387,20 @@ impl BankingStage {
                     prioritization_fee_cache,
                 )
             }
+            BlockProductionMethod::CentralScheduler => Self::new_central_scheduler(
+                cluster_info,
+                poh_recorder,
+                non_vote_receiver,
+                tpu_vote_receiver,
+                gossip_vote_receiver,
+                num_threads,
+                transaction_status_sender,
+                replay_vote_sender,
+                log_messages_bytes_limit,
+                connection_cache,
+                bank_forks,
+                prioritization_fee_cache,
+            ),
         }
     }
 
@@ -462,6 +485,124 @@ impl BankingStage {
                 )
             })
             .collect();
+        Self { bank_thread_hdls }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_central_scheduler(
+        cluster_info: &Arc<ClusterInfo>,
+        poh_recorder: &Arc<RwLock<PohRecorder>>,
+        non_vote_receiver: BankingPacketReceiver,
+        tpu_vote_receiver: BankingPacketReceiver,
+        gossip_vote_receiver: BankingPacketReceiver,
+        num_threads: u32,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        replay_vote_sender: ReplayVoteSender,
+        log_messages_bytes_limit: Option<usize>,
+        connection_cache: Arc<ConnectionCache>,
+        bank_forks: Arc<RwLock<BankForks>>,
+        prioritization_fee_cache: &Arc<PrioritizationFeeCache>,
+    ) -> Self {
+        assert!(num_threads >= MIN_TOTAL_THREADS);
+        // Single thread to generate entries from many banks.
+        // This thread talks to poh_service and broadcasts the entries once they have been recorded.
+        // Once an entry has been recorded, its blockhash is registered with the bank.
+        let data_budget = Arc::new(DataBudget::default());
+        // Keeps track of extraneous vote transactions for the vote threads
+        let latest_unprocessed_votes = Arc::new(LatestUnprocessedVotes::new());
+
+        let decision_maker = DecisionMaker::new(cluster_info.id(), poh_recorder.clone());
+        let committer = Committer::new(
+            transaction_status_sender.clone(),
+            replay_vote_sender.clone(),
+            prioritization_fee_cache.clone(),
+        );
+        let transaction_recorder = poh_recorder.read().unwrap().new_recorder();
+
+        // + 1 for the central scheduler thread
+        let mut bank_thread_hdls = Vec::with_capacity(num_threads as usize + 1);
+
+        // Spawn legacy voting threads first: 1 gossip, 1 tpu
+        for (id, packet_receiver, vote_source) in [
+            (0, gossip_vote_receiver, VoteSource::Gossip),
+            (1, tpu_vote_receiver, VoteSource::Tpu),
+        ] {
+            bank_thread_hdls.push(Self::spawn_thread_local_multi_iterator_thread(
+                id,
+                packet_receiver,
+                bank_forks.clone(),
+                decision_maker.clone(),
+                committer.clone(),
+                transaction_recorder.clone(),
+                log_messages_bytes_limit,
+                Forwarder::new(
+                    poh_recorder.clone(),
+                    bank_forks.clone(),
+                    cluster_info.clone(),
+                    connection_cache.clone(),
+                    data_budget.clone(),
+                ),
+                UnprocessedTransactionStorage::new_vote_storage(
+                    latest_unprocessed_votes.clone(),
+                    vote_source,
+                ),
+            ));
+        }
+
+        // Create channels for communication between scheduler and workers
+        let num_workers = (num_threads).saturating_sub(NUM_VOTE_PROCESSING_THREADS);
+        let (work_senders, work_receivers): (Vec<Sender<_>>, Vec<Receiver<_>>) =
+            (0..num_workers).map(|_| unbounded()).unzip();
+        let (finished_work_sender, finished_work_receiver) = unbounded();
+
+        // Spawn the worker threads
+        for (index, work_receiver) in work_receivers.into_iter().enumerate() {
+            let id = (index as u32).saturating_add(NUM_VOTE_PROCESSING_THREADS);
+            let consume_worker = ConsumeWorker::new(
+                work_receiver,
+                Consumer::new(
+                    committer.clone(),
+                    poh_recorder.read().unwrap().new_recorder(),
+                    QosService::new(id),
+                    log_messages_bytes_limit,
+                ),
+                finished_work_sender.clone(),
+                poh_recorder.read().unwrap().new_leader_bank_notifier(),
+            );
+
+            bank_thread_hdls.push(
+                Builder::new()
+                    .name(format!("solCoWorker{id:02}"))
+                    .spawn(move || {
+                        let _ = consume_worker.run();
+                    })
+                    .unwrap(),
+            )
+        }
+
+        // Spawn the central scheduler thread
+        bank_thread_hdls.push({
+            let packet_deserializer =
+                PacketDeserializer::new(non_vote_receiver, bank_forks.clone());
+            let scheduler = PrioGraphScheduler::new(work_senders, finished_work_receiver);
+            let scheduler_controller = SchedulerController::new(
+                decision_maker.clone(),
+                packet_deserializer,
+                bank_forks,
+                scheduler,
+            );
+            Builder::new()
+                .name("solBnkTxSched".to_string())
+                .spawn(move || match scheduler_controller.run() {
+                    Ok(_) => {}
+                    Err(SchedulerError::DisconnectedRecvChannel(_)) => {}
+                    Err(SchedulerError::DisconnectedSendChannel(_)) => {
+                        warn!("Unexpected worker disconnect from scheduler")
+                    }
+                })
+                .unwrap()
+        });
+
         Self { bank_thread_hdls }
     }
 

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -36,6 +36,7 @@ pub(super) struct PreBalanceInfo {
     pub mint_decimals: HashMap<Pubkey, u8>,
 }
 
+#[derive(Clone)]
 pub struct Committer {
     transaction_status_sender: Option<TransactionStatusSender>,
     replay_vote_sender: ReplayVoteSender,

--- a/core/src/banking_stage/decision_maker.rs
+++ b/core/src/banking_stage/decision_maker.rs
@@ -28,6 +28,7 @@ impl BufferedPacketsDecision {
     }
 }
 
+#[derive(Clone)]
 pub struct DecisionMaker {
     my_pubkey: Pubkey,
     poh_recorder: Arc<RwLock<PohRecorder>>,

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -1,19 +1,13 @@
+mod batch_id_generator;
 #[allow(dead_code)]
+mod in_flight_tracker;
+pub(crate) mod prio_graph_scheduler;
+pub(crate) mod scheduler_controller;
+pub(crate) mod scheduler_error;
 mod thread_aware_account_locks;
-
+mod transaction_id_generator;
 mod transaction_priority_id;
 #[allow(dead_code)]
 mod transaction_state;
 #[allow(dead_code)]
 mod transaction_state_container;
-
-mod batch_id_generator;
-#[allow(dead_code)]
-mod in_flight_tracker;
-#[allow(dead_code)]
-pub(crate) mod prio_graph_scheduler;
-#[allow(dead_code)]
-pub(crate) mod scheduler_controller;
-pub(crate) mod scheduler_error;
-#[allow(dead_code)]
-mod transaction_id_generator;

--- a/core/src/banking_stage/transaction_scheduler/mod.rs
+++ b/core/src/banking_stage/transaction_scheduler/mod.rs
@@ -11,9 +11,9 @@ mod batch_id_generator;
 #[allow(dead_code)]
 mod in_flight_tracker;
 #[allow(dead_code)]
-mod prio_graph_scheduler;
+pub(crate) mod prio_graph_scheduler;
 #[allow(dead_code)]
-mod scheduler_controller;
-mod scheduler_error;
+pub(crate) mod scheduler_controller;
+pub(crate) mod scheduler_error;
 #[allow(dead_code)]
 mod transaction_id_generator;

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -168,6 +168,7 @@ impl BlockVerificationMethod {
 pub enum BlockProductionMethod {
     #[default]
     ThreadLocalMultiIterator,
+    CentralScheduler,
 }
 
 impl BlockProductionMethod {


### PR DESCRIPTION
#### Problem
Need a way to use the new BankingStage w/ central scheduler

#### Summary of Changes
- Factor out some code for spawning legacy/thread-local-multi-iterator banking stage threads
- Add `BlockProductionMethod::CentralScheduler` variant
- Add path to spawn new scheduling thread, workers, and legacy voting threads
- Re-use existing banking stage test to verify new production method works in basic fashion

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
