### PR TITLE
multinode-demo scripts support --block-production-method arg

### DIFF
--- a/multinode-demo/bootstrap-validator.sh
+++ b/multinode-demo/bootstrap-validator.sh
@@ -106,6 +106,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --log-messages-bytes-limit ]]; then
       args+=("$1" "$2")
       shift 2
+    elif [[ $1 == --block-production-method ]]; then
+      args+=("$1" "$2")
+      shift 2
     else
       echo "Unknown argument: $1"
       $program --help

--- a/multinode-demo/validator.sh
+++ b/multinode-demo/validator.sh
@@ -182,6 +182,9 @@ while [[ -n $1 ]]; do
     elif [[ $1 == --skip-require-tower ]]; then
       maybeRequireTower=false
       shift
+    elif [[ $1 == --block-production-method ]]; then
+      args+=("$1" "$2")
+      shift 2
     elif [[ $1 = -h ]]; then
       usage "$@"
     else


### PR DESCRIPTION
#### Problem
- multi-node demo scripts do not currently support --block-production-method arguments.
- #33890 adds a new variant we should be supporting in these scripts

#### Summary of Changes
- Add block-production-method support to `bootstrap-validator.sh` and `validator.sh`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
