### PR TITLE
swap programify feature parameters

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8044,8 +8044,8 @@ impl Bank {
             let datapoint_name = "bank-progamify_feature_gate_program";
             if let Err(e) = replace_account::replace_empty_account_with_upgradeable_program(
                 self,
-                &feature::id(),
                 &inline_feature_gate_program::noop_program::id(),
+                &feature::id(),
                 datapoint_name,
             ) {
                 warn!(


### PR DESCRIPTION
#### Problem
The parameters for `replace_empty_account_with_upgradeable_program` in the feature activation for `programify_feature_gate_program` are reversed.

#### Summary of Changes
Put them in the correct order.
