### PR TITLE
add program examples repo to docs

### DIFF
--- a/docs/src/developing/on-chain-programs/developing-rust.md
+++ b/docs/src/developing/on-chain-programs/developing-rust.md
@@ -386,5 +386,10 @@ $ cargo build-bpf --dump
 ## Examples
 
 The [Solana Program Library
-github](https://github.com/solana-labs/solana-program-library/tree/master/examples/rust)
+GitHub](https://github.com/solana-labs/solana-program-library/tree/master/examples/rust)
 repo contains a collection of Rust examples.
+
+The [Solana Developers
+Program Examples GitHub](https://github.com/solana-developers/program-examples)
+repo also contains a collection of beginner to intermediate Rust program
+examples.


### PR DESCRIPTION
#### Problem
DevRel has been building out a nice collection of small, modular Rust program examples ranging from beginner to intermediate level.

It would be great to link out to this repository, since the first Google search result for "Solana program examples" is the docs for "Program Examples".

#### Summary of Changes
Add a link to the repository.