### PR TITLE
changelog: Uses fastboot by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Release channels have their own copy of this changelog:
 ## [1.18.0] - Unreleased
 * Changes
   * Added a github check to support `changelog` label
-  * Uses fastboot by default (#33883)
+  * The default for `--use-snapshot-archives-at-startup` is now `when-newest` (#33883)
 * Upgrade Notes
 
 ## [1.17.0]


### PR DESCRIPTION
[Fastboot](https://github.com/orgs/solana-labs/projects/33) was switched on by default in https://github.com/solana-labs/solana/pull/33883.

(I think I should've put this changelog diff inside the PR above, but forgot; sorry!)