### PR TITLE
 Remove redundant bounds check from getBlock and getBlockTime

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -482,8 +482,7 @@ impl Blockstore {
     }
 
     fn min_root(&self) -> Slot {
-        self
-            .rooted_slot_iterator(0)
+        self.rooted_slot_iterator(0)
             .ok()
             .and_then(|mut iter| iter.next())
             .unwrap_or_default()
@@ -3116,11 +3115,10 @@ impl Blockstore {
     /// been rooted. This is either because the slot was skipped, or due to a gap in ledger data,
     /// as when booting from a newer snapshot.
     pub fn is_skipped(&self, slot: Slot) -> bool {
-        match self.db.get::<cf::Root>(slot).ok().flatten() {
-            Some(_) => false,
-            None => {
-                slot > self.min_root() && slot < self.max_root()
-            },
+        if self.is_root(slot) {
+            false
+        } else {
+            slot > self.min_root() && slot < self.max_root()
         }
     }
 

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3119,8 +3119,8 @@ impl Blockstore {
         match self.db.get::<cf::Root>(slot).ok().flatten() {
             Some(_) => false,
             None => {
-                slot < self.max_root() && slot > self.min_root(),
-            }
+                slot > self.min_root() && slot < self.max_root()
+            },
         }
     }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1002,26 +1002,36 @@ impl JsonRpcRequestProcessor {
         })
     }
 
-    fn check_blockstore_root<T>(
+    // Check if the given `slot` is within the blockstore bounds. This function assumes that
+    // `result` is from a blockstore fetch, and that the fetch:
+    // 1) Checked if `slot` is above the lowest cleanup slot (and errored if not)
+    // 2) Checked if `slot` is a root
+    fn check_blockstore_bounds<T>(
         &self,
         result: &std::result::Result<T, BlockstoreError>,
         slot: Slot,
     ) -> Result<()> {
-        if let Err(err) = result {
-            debug!(
-                "check_blockstore_root, slot: {:?}, max root: {:?}, err: {:?}",
-                slot,
-                self.blockstore.max_root(),
-                err
-            );
-            if slot >= self.blockstore.max_root() {
-                return Err(RpcCustomError::BlockNotAvailable { slot }.into());
+        match result {
+            // The slot was found, all good
+            Ok(Some(_)) => Ok(()),
+            // The slot was cleaned up, return Ok() for now to allow fallback to bigtable
+            Err(BlockstoreError::SlotCleanedUp) => Ok(()),
+            // The slot was not cleaned up but also not found
+            Ok(_) => {
+                let max_root = self.blockstore.max_root();
+                debug!("check_blockstore_bounds, slot: {slot}, max root: {max_root}");
+                // Our node hasn't seen this slot yet, error out
+                if slot >= max_root {
+                    return Err(RpcCustomError::BlockNotAvailable { slot }.into());
+                }
+                // The slot is within the bounds of the blockstore as the lookup that yielded
+                // `result` checked that `slot` was greater than the blockstore's lowest
+                // cleanup slot and we just checked that `slot` was less than the blockstore's
+                // largest root. Thus, the slot must have been skipped and we can error out.
+                Err(RpcCustomError::SlotSkipped { slot }.into())
             }
-            if self.blockstore.is_skipped(slot) {
-                return Err(RpcCustomError::SlotSkipped { slot }.into());
-            }
+            _ => Ok(()),
         }
-        Ok(())
     }
 
     fn check_slot_cleaned_up<T>(
@@ -1098,7 +1108,7 @@ impl JsonRpcRequestProcessor {
             {
                 self.check_blockstore_writes_complete(slot)?;
                 let result = self.blockstore.get_rooted_block(slot, true);
-                self.check_blockstore_root(&result, slot)?;
+                self.check_blockstore_bounds(&result, slot)?;
                 let encode_block = |confirmed_block: ConfirmedBlock| -> Result<UiConfirmedBlock> {
                     let mut encoded_block = confirmed_block
                         .encode_with_options(encoding, encoding_options)
@@ -1322,7 +1332,7 @@ impl JsonRpcRequestProcessor {
                 .highest_super_majority_root()
         {
             let result = self.blockstore.get_rooted_block_time(slot);
-            self.check_blockstore_root(&result, slot)?;
+            self.check_blockstore_bounds(&result, slot)?;
             if result.is_err() {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                     let bigtable_result = bigtable_ledger_storage.get_confirmed_block(slot).await;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1013,11 +1013,11 @@ impl JsonRpcRequestProcessor {
     ) -> Result<()> {
         match result {
             // The slot was found, all good
-            Ok(Some(_)) => Ok(()),
+            Ok(_) => Ok(()),
             // The slot was cleaned up, return Ok() for now to allow fallback to bigtable
             Err(BlockstoreError::SlotCleanedUp) => Ok(()),
             // The slot was not cleaned up but also not found
-            Ok(_) => {
+            Err(BlockstoreError::SlotNotRooted) => {
                 let max_root = self.blockstore.max_root();
                 debug!("check_blockstore_bounds, slot: {slot}, max root: {max_root}");
                 // Our node hasn't seen this slot yet, error out
@@ -1030,6 +1030,7 @@ impl JsonRpcRequestProcessor {
                 // largest root. Thus, the slot must have been skipped and we can error out.
                 Err(RpcCustomError::SlotSkipped { slot }.into())
             }
+            // Some other Blockstore error, ignore for now
             _ => Ok(()),
         }
     }


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/issues/33859 for some additional details but the TLDR is:
- The current logic in `rpc.rs` looks up min/max roots from the Blockstore to perform bounds check for the sake of error reporting
- Looking up these roots is currently expensive as it is done by constructing an iterator
- Regardless of the overhead of looking up min/max roots, some of these checks are repetitive

#### Summary of Changes
Remove / condense code to avoid repeating checks that have already occurred. Namely,
- `Blockstore::is_skipped()`, which was called by these two RPC methods, has been removed as it was redundant
    - This avoids the overhead of (2) rocksdb iterators
- Rename `check_blockstore_root() ==> check_blockstore_bounds()` and add a bunch of comments about the handling of `Blockstore` errors at the RPC level
