### PR TITLE
Adds logs for starting/stopping of the background account hasher

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2912,6 +2912,7 @@ impl AccountsDb {
     }
 
     fn background_hasher(receiver: Receiver<CachedAccount>) {
+        info!("Background account hasher has started");
         loop {
             let result = receiver.recv();
             match result {
@@ -2922,11 +2923,13 @@ impl AccountsDb {
                         let _ = (*account).hash();
                     };
                 }
-                Err(_) => {
+                Err(err) => {
+                    info!("Background account hasher is stopping because: {err}");
                     break;
                 }
             }
         }
+        info!("Background account hasher has stopped");
     }
 
     fn start_background_hasher(&mut self) {


### PR DESCRIPTION
#### Problem

When the background account hasher thread is started/stopped, there are no logs indicating such. This likely isn't a big deal but if there's ever an error that causes the underlying channel to disconnect early, it would be helpful to have a log message indicating as such.


#### Summary of Changes

Add logs for when the background account hasher starts and stops.