### PR TITLE
ci: fixed sccache version for sccache-action

### DIFF
--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -43,6 +43,8 @@ jobs:
           .github/scripts/purge-ubuntu-runner.sh
 
       - uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - shell: bash
         run: |
@@ -90,6 +92,8 @@ jobs:
           .github/scripts/purge-ubuntu-runner.sh
 
       - uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - shell: bash
         run: |
@@ -139,6 +143,8 @@ jobs:
           .github/scripts/purge-ubuntu-runner.sh
 
       - uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
 
       - shell: bash
         run: |


### PR DESCRIPTION
#### Problem

We use the latest sccache. If they've tagged a new version but the binaries haven't been uploaded, we will be blocked.

https://github.com/solana-labs/solana/actions/runs/6668375969/job/18124723674

![Screenshot 2023-10-27 at 23 22 12](https://github.com/solana-labs/solana/assets/8209234/aa426084-833d-4d92-b781-a360ad7d6a0f)

#### Summary of Changes

pin sccache version for sccache action.