### PR TITLE
chunk all ancient append vecs

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1439,7 +1439,6 @@ pub struct AccountsDb {
 
     pub storage: AccountStorage,
 
-    #[allow(dead_code)]
     /// from AccountsDbConfig
     create_ancient_storage: CreateAncientStorage,
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7177,7 +7177,7 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
     ) -> Option<Slot> {
         if self.create_ancient_storage == CreateAncientStorage::Pack {
-            // oldest_non_ancient_slot is only applicable, when ancient storages are created with `Append`. When ancient storage are created with `Pack`, ancient storage
+            // oldest_non_ancient_slot is only applicable when ancient storages are created with `Append`. When ancient storages are created with `Pack`, ancient storages
             // can be created in between non-ancient storages. Return None, because oldest_non_ancient_slot is not applicable here.
             None
         } else if self.ancient_append_vec_offset.is_some() {

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16397,7 +16397,7 @@ pub mod tests {
                 // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
                 assert_eq!(
                     db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
-                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
+                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 1, $create_ancient_storage)
 
                 );
                 assert_eq!(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7300,11 +7300,13 @@ impl AccountsDb {
                     if let Ok(mapped_file) =
                         cache_hash_data.get_file_reference_to_map_later(&file_name)
                     {
+                        stats.cache_file_load_hits.fetch_add(1, Ordering::Relaxed);
                         return Some(ScanAccountStorageResult::CacheFileAlreadyExists(
                             mapped_file,
                         ));
                     }
                 }
+                stats.cache_file_load_misses.fetch_add(1, Ordering::Relaxed);
 
                 // fall through and load normally - we failed to load from a cache file but there are storages present
                 Some(ScanAccountStorageResult::CacheFileNeedsToBeCreated((
@@ -7326,6 +7328,7 @@ impl AccountsDb {
                         file_name,
                         range_this_chunk,
                     )) => {
+                        stats.cache_file_created.fetch_add(1, Ordering::Relaxed);
                         let mut scanner = scanner.clone();
                         let mut init_accum = true;
                         // load from cache failed, so create the cache file for this chunk

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7178,19 +7178,19 @@ impl AccountsDb {
             // oldest_non_ancient_slot is only applicable, when ancient storages are created with `Append`. When ancient storage are created with `Pack`, ancient storage
             // can be created in between non-ancient storages. Return None, because oldest_non_ancient_slot is not applicable here.
             None
-        } else {
-            if self.ancient_append_vec_offset.is_some() {
-                // For performance, this is required when ancient appendvecs are enabled
-                Some(self.get_oldest_non_ancient_slot_from_slot(
+        } else if self.ancient_append_vec_offset.is_some() {
+            // For performance, this is required when ancient appendvecs are enabled
+            Some(
+                self.get_oldest_non_ancient_slot_from_slot(
                     config.epoch_schedule,
                     max_slot_inclusive,
-                ))
-            } else {
-                // This causes the entire range to be chunked together, treating older append vecs just like new ones.
-                // This performs well if there are many old append vecs that haven't been cleaned yet.
-                // 0 will have the effect of causing ALL older append vecs to be chunked together, just like every other append vec.
-                Some(0)
-            }
+                ),
+            )
+        } else {
+            // This causes the entire range to be chunked together, treating older append vecs just like new ones.
+            // This performs well if there are many old append vecs that haven't been cleaned yet.
+            // 0 will have the effect of causing ALL older append vecs to be chunked together, just like every other append vec.
+            Some(0)
         }
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1738,11 +1738,12 @@ impl SplitAncientStorages {
         // 2. first unevenly divided chunk starting at 1 epoch old slot (may be empty)
         // 3. evenly divided full chunks in the middle
         // 4. unevenly divided chunk of most recent slots (may be empty)
-        let ancient_slots =
+        let mut ancient_slots =
             Self::get_ancient_slots(oldest_non_ancient_slot, snapshot_storages, |storage| {
                 storage.capacity() > get_ancient_append_vec_capacity() * 50 / 100
             });
 
+        ancient_slots.clear();
         let first_non_ancient_slot = ancient_slots
             .last()
             .map(|last_ancient_slot| last_ancient_slot.saturating_add(1))

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16377,25 +16377,22 @@ pub mod tests {
         // no ancient append vecs, so always 0
         assert_eq!(
             db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-            expected(0) //test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
+            expected(0)
         );
         // ancient append vecs enabled (but at 0 offset), so can be non-zero
         db.ancient_append_vec_offset = Some(0);
         // 0..=(slots_per_epoch - 1) are all non-ancient
         assert_eq!(
             db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch - 1, &config),
-            //test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
             expected(0)
         );
         // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
         assert_eq!(
             db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
-            // test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 1, $create_ancient_storage)
             expected(1)
         );
         assert_eq!(
             db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-            // test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected offset+1, $create_ancient_storage)
             expected(offset + 1)
         );
     }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7167,10 +7167,10 @@ impl AccountsDb {
         }
     }
 
-    /// `oldest_non_ancient_slot`` is only applicable when `Append` is used for ancient appendvec packing.
-    /// If `Pack` are used for ancient apendvec packing, return None.
+    /// `oldest_non_ancient_slot` is only applicable when `Append` is used for ancient append vec packing.
+    /// If `Pack` is used for ancient apend vec packing, return None.
     /// Otherwise, return a slot 'max_slot_inclusive' - (slots_per_epoch - `self.ancient_append_vec_offset`)
-    /// If ancient appendvec is not enabled, return 0.
+    /// If ancient append vecs are not enabled, return 0.
     fn get_oldest_non_ancient_slot_for_hash_calc_scan(
         &self,
         max_slot_inclusive: Slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7167,8 +7167,10 @@ impl AccountsDb {
         }
     }
 
-    /// if ancient append vecs are enabled, return a slot 'max_slot_inclusive' - (slots_per_epoch - `self.ancient_append_vec_offset`)
-    /// otherwise, return 0
+    /// `oldest_non_ancient_slot`` is only applicable when `Append` is used for ancient appendvec packing.
+    /// If `Pack` are used for ancient apendvec packing, return None.
+    /// Otherwise, return a slot 'max_slot_inclusive' - (slots_per_epoch - `self.ancient_append_vec_offset`)
+    /// If ancient appendvec is not enabled, return 0.
     fn get_oldest_non_ancient_slot_for_hash_calc_scan(
         &self,
         max_slot_inclusive: Slot,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16347,36 +16347,74 @@ pub mod tests {
         assert_eq!(db.accounts_index.ref_count_from_storage(&pk1), 0);
     }
 
-    #[test]
-    fn test_get_oldest_non_ancient_slot_for_hash_calc_scan() {
-        let mut db = AccountsDb::new_single_for_tests();
-        let config = CalcAccountsHashConfig::default();
-        let slot = config.epoch_schedule.slots_per_epoch;
-        let slots_per_epoch = config.epoch_schedule.slots_per_epoch;
-        assert_ne!(slot, 0);
-        let offset = 10;
-        // no ancient append vecs, so always 0
-        assert_eq!(
-            db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-            0
-        );
-        // ancient append vecs enabled (but at 0 offset), so can be non-zero
-        db.ancient_append_vec_offset = Some(0);
-        // 0..=(slots_per_epoch - 1) are all non-ancient
-        assert_eq!(
-            db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch - 1, &config),
-            0
-        );
-        // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
-        assert_eq!(
-            db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
-            1
-        );
-        assert_eq!(
-            db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch + offset, &config),
-            offset + 1
-        );
+    impl AccountsDb {
+        pub fn set_create_ancient_storage(&mut self, val: CreateAncientStorage) {
+            self.create_ancient_storage = val;
+        }
     }
+
+    macro_rules! test_get_oldest_non_ancient_slot_for_hash_calc_scan {
+        (@expected $v: expr, $create_ancient_storage: expr) => {
+            if $create_ancient_storage == CreateAncientStorage::Append {
+                Some($v)
+            } else {
+                None
+            }
+        };
+
+        ($name:ident, $create_ancient_storage:expr) => {
+            #[test]
+            fn $name() {
+                let mut db = AccountsDb::new_single_for_tests();
+                db.set_create_ancient_storage($create_ancient_storage);
+
+                let config = CalcAccountsHashConfig::default();
+                let slot = config.epoch_schedule.slots_per_epoch;
+                let slots_per_epoch = config.epoch_schedule.slots_per_epoch;
+                assert_ne!(slot, 0);
+                let offset = 10;
+                // no ancient append vecs, so always 0
+                assert_eq!(
+                    db.get_oldest_non_ancient_slot_for_hash_calc_scan(
+                        slots_per_epoch + offset,
+                        &config
+                    ),
+                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
+                );
+                // ancient append vecs enabled (but at 0 offset), so can be non-zero
+                db.ancient_append_vec_offset = Some(0);
+                // 0..=(slots_per_epoch - 1) are all non-ancient
+                assert_eq!(
+                    db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch - 1, &config),
+                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
+
+                );
+                // 1..=slots_per_epoch are all non-ancient, so 1 is oldest non ancient
+                assert_eq!(
+                    db.get_oldest_non_ancient_slot_for_hash_calc_scan(slots_per_epoch, &config),
+                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected 0, $create_ancient_storage)
+
+                );
+                assert_eq!(
+                    db.get_oldest_non_ancient_slot_for_hash_calc_scan(
+                        slots_per_epoch + offset,
+                        &config
+                    ),
+                    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(@expected offset+1, $create_ancient_storage)
+                );
+            }
+        };
+    }
+
+    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(
+        test_get_oldest_non_ancient_slot_for_hash_calc_scan_append,
+        CreateAncientStorage::Append
+    );
+
+    test_get_oldest_non_ancient_slot_for_hash_calc_scan!(
+        test_get_oldest_non_ancient_slot_for_hash_calc_scan_pack,
+        CreateAncientStorage::Pack
+    );
 
     #[test]
     fn test_mark_dirty_dead_stores_empty() {
@@ -16447,7 +16485,7 @@ pub mod tests {
     fn test_split_storages_ancient_chunks() {
         let storages = SortedStorages::empty();
         assert_eq!(storages.max_slot_inclusive(), 0);
-        let result = SplitAncientStorages::new(0, &storages);
+        let result = SplitAncientStorages::new(Some(0), &storages);
         assert_eq!(result, SplitAncientStorages::default());
     }
 

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -16777,7 +16777,7 @@ pub mod tests {
             // 1 = all storages are non-ancient
             // 2 = ancient slots: 1
             // 3 = ancient slots: 1, 2
-            // 4 = ancient slots: 1, 2, 3 (except 2 is large, 3 is not, so treat 3 as non-ancient)
+            // 4 = ancient slots: 1, 2 (except 2 is large, 3 is not, so treat 3 as non-ancient)
             // 5 = ...
             for oldest_non_ancient_slot in 0..6 {
                 let ancient_slots = SplitAncientStorages::get_ancient_slots(

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7302,13 +7302,11 @@ impl AccountsDb {
                     if let Ok(mapped_file) =
                         cache_hash_data.get_file_reference_to_map_later(&file_name)
                     {
-                        stats.cache_file_load_hits.fetch_add(1, Ordering::Relaxed);
                         return Some(ScanAccountStorageResult::CacheFileAlreadyExists(
                             mapped_file,
                         ));
                     }
                 }
-                stats.cache_file_load_misses.fetch_add(1, Ordering::Relaxed);
 
                 // fall through and load normally - we failed to load from a cache file but there are storages present
                 Some(ScanAccountStorageResult::CacheFileNeedsToBeCreated((
@@ -7330,7 +7328,6 @@ impl AccountsDb {
                         file_name,
                         range_this_chunk,
                     )) => {
-                        stats.cache_file_created.fetch_add(1, Ordering::Relaxed);
                         let mut scanner = scanner.clone();
                         let mut init_accum = true;
                         // load from cache failed, so create the cache file for this chunk

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -194,6 +194,9 @@ pub struct HashStats {
     pub hash_total: usize,
     pub num_snapshot_storage: usize,
     pub scan_chunks: usize,
+    pub cache_file_load_hits: AtomicU64,
+    pub cache_file_load_misses: AtomicU64,
+    pub cache_file_created: AtomicU64,
     pub num_slots: usize,
     pub num_dirty_slots: usize,
     pub collect_snapshots_us: u64,
@@ -250,6 +253,21 @@ impl HashStats {
             ("collect_snapshots_us", self.collect_snapshots_us, i64),
             ("num_snapshot_storage", self.num_snapshot_storage, i64),
             ("scan_chunks", self.scan_chunks, i64),
+            (
+                "cache_file_load_hits",
+                self.cache_file_load_hits.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "cache_file_load_misses",
+                self.cache_file_load_misses.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "cache_file_created",
+                self.cache_file_created.load(Ordering::Relaxed),
+                i64
+            ),
             ("num_slots", self.num_slots, i64),
             ("num_dirty_slots", self.num_dirty_slots, i64),
             ("storage_size_min", self.storage_size_quartiles[0], i64),

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -194,9 +194,6 @@ pub struct HashStats {
     pub hash_total: usize,
     pub num_snapshot_storage: usize,
     pub scan_chunks: usize,
-    pub cache_file_load_hits: AtomicU64,
-    pub cache_file_load_misses: AtomicU64,
-    pub cache_file_created: AtomicU64,
     pub num_slots: usize,
     pub num_dirty_slots: usize,
     pub collect_snapshots_us: u64,
@@ -253,21 +250,6 @@ impl HashStats {
             ("collect_snapshots_us", self.collect_snapshots_us, i64),
             ("num_snapshot_storage", self.num_snapshot_storage, i64),
             ("scan_chunks", self.scan_chunks, i64),
-            (
-                "cache_file_load_hits",
-                self.cache_file_load_hits.load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "cache_file_load_misses",
-                self.cache_file_load_misses.load(Ordering::Relaxed),
-                i64
-            ),
-            (
-                "cache_file_created",
-                self.cache_file_created.load(Ordering::Relaxed),
-                i64
-            ),
             ("num_slots", self.num_slots, i64),
             ("num_dirty_slots", self.num_dirty_slots, i64),
             ("storage_size_min", self.storage_size_quartiles[0], i64),

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -49,7 +49,7 @@ pub(crate) struct CacheHashDataFile {
 }
 
 impl CacheHashDataFileReference {
-    /// convert the open file refrence to a mmapped file that can be returned as a slice
+    /// convert the open file reference to a mmapped file that can be returned as a slice
     pub(crate) fn map(&self) -> Result<CacheHashDataFile, std::io::Error> {
         let file_len = self.file_len;
         let mut m1 = Measure::start("read_file");


### PR DESCRIPTION
#### Problem
When we pack ancient vecs, we end up with  non-ancient append vecs interleaved with ancient append vecs.
This ends up causing hash calculation to take much longer. Hash Calculation is very sensitive to the # of chunks.
The current chunking algorithm assumes the model of appending ancient append vecs.

#### Summary of Changes
Just create ranges instead.
![image](https://github.com/solana-labs/solana/assets/75863576/239c7b25-7df3-4e5c-a08b-2ed8ac0b8ccb)
The blue line that drops here is restarting with the removal of the ancient splitter algorithm (this pr).

Here's the overall hash calc time with removing this code:
![image](https://github.com/solana-labs/solana/assets/75863576/a87b695e-4b15-4070-a2bf-908419127858)


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
