### PR TITLE
Make borsh 0.9 dependency optional

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,6 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
+borsh0-9 = ["solana-program/borsh0-9"]
 # "program" feature is a legacy feature retained to support v1.3 and older
 # programs.  New development should not use this feature.  Instead use the
 # solana-program crate

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -96,4 +96,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
+default = ["borsh0-9"]

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.72.0" # solana platform-tools rust version
 bincode = { workspace = true }
 blake3 = { workspace = true, features = ["digest", "traits-preview"] }
 borsh = { workspace = true }
-borsh0-9 = { package = "borsh", version = "0.9.3" }
+borsh0-9 = { package = "borsh", version = "0.9.3", optional = true }
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
 bytemuck = { workspace = true, features = ["derive"] }

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -478,6 +478,7 @@ pub mod big_mod_exp;
 pub mod blake3;
 pub mod borsh;
 pub mod borsh0_10;
+#[cfg(feature = "borsh0-9")]
 pub mod borsh0_9;
 pub mod bpf_loader;
 pub mod bpf_loader_deprecated;

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -668,11 +668,13 @@ impl fmt::Display for Pubkey {
     }
 }
 
+#[cfg(feature = "borsh0-9")]
 impl borsh0_9::de::BorshDeserialize for Pubkey {
     fn deserialize(buf: &mut &[u8]) -> ::core::result::Result<Self, borsh0_9::maybestd::io::Error> {
         Ok(Self(borsh0_9::BorshDeserialize::deserialize(buf)?))
     }
 }
+#[cfg(feature = "borsh0-9")]
 impl borsh0_9::BorshSchema for Pubkey
 where
     [u8; 32]: borsh0_9::BorshSchema,
@@ -700,6 +702,7 @@ where
         <[u8; 32] as borsh0_9::BorshSchema>::add_definitions_recursively(definitions);
     }
 }
+#[cfg(feature = "borsh0-9")]
 impl borsh0_9::ser::BorshSerialize for Pubkey {
     fn serialize<W: borsh0_9::maybestd::io::Write>(
         &self,

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -42,10 +42,12 @@ pub use signer::signers;
 // confusing duplication in the docs due to a rustdoc bug. #26211
 #[allow(deprecated)]
 pub use solana_program::address_lookup_table_account;
+#[cfg(feature = "borsh0_9")]
+pub use solana_program::borsh0_9;
 #[cfg(not(target_os = "solana"))]
 pub use solana_program::program_stubs;
 pub use solana_program::{
-    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10, borsh0_9,
+    account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, borsh, borsh0_10,
     bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable, clock, config, custom_heap_default,
     custom_panic_default, debug_account_data, declare_deprecated_sysvar_id, declare_sysvar_id,
     decode_error, ed25519_program, epoch_rewards, epoch_schedule, fee_calculator, impl_sysvar_get,


### PR DESCRIPTION
Introduce borsh0-9 feature which determines whether the borsh 0.9
dependency is used and borsh0_9 module provided.

The dependency is enabled by default but still this commit is
technically a breaking change for anyone using solana-program
dependency with default features enabled.
