### PR TITLE
Adjust receive window to make them linear to the count of streams

### DIFF
--- a/sdk/src/quic.rs
+++ b/sdk/src/quic.rs
@@ -26,12 +26,12 @@ pub const QUIC_CONNECTION_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// The receive window for QUIC connection from unstaked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 1;
+pub const QUIC_UNSTAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from minimum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 2;
+pub const QUIC_MIN_STAKED_RECEIVE_WINDOW_RATIO: u64 = 128;
 
 /// The receive window for QUIC connection from maximum staked nodes is
 /// set to this ratio times [`solana_sdk::packet::PACKET_DATA_SIZE`]
-pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 10;
+pub const QUIC_MAX_STAKED_RECEIVE_WINDOW_RATIO: u64 = 512;


### PR DESCRIPTION
#### Problem
It has been found in across region testing, transaction sending to remote regions are some time failing with WriteError(Stopped). This is caused that after a stream is opened, the client is blocked from sending due to the following error in Quinn on blocked by connection level flow control. This is due to limited receive window among the multiple streams opened, some stream spent long time in waiting for the limit to be available. The problem is not as obvious when the latency is low as contenders might release the usage fast enough before the time out is reached. But in the case of wide area network with longer latency the problem becomes more severe. Fundamentally, if we allow that many of streams to be opened, we need to ensure they have enough bandwidth to be processed concurrently. 

#### Summary of Changes

Make connection receive window ratio scale to the streams limit.

Without the change, with the following configuration: 4 nodes in the us-west and 1 node in eu-west, running bench-tps tests with thin-client, with duration set to > 300 seconds, we can observe send transaction failures in quic_client with WriteError(Stopped)., with the fix, the problem is no longer observed.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
