### PR TITLE
Scheduler adjusts underpriced transaction consumed CUs

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -1456,6 +1456,7 @@ mod tests {
                 durable_nonce_fee: nonce.map(DurableNonceFee::from),
                 return_data: None,
                 executed_units: 0,
+                executed_us: 0,
                 accounts_data_len_delta: 0,
             },
             programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -76,6 +76,7 @@ pub struct TransactionExecutionDetails {
     pub durable_nonce_fee: Option<DurableNonceFee>,
     pub return_data: Option<TransactionReturnData>,
     pub executed_units: u64,
+    pub executed_us: u64,
     /// The change in accounts data len for this transaction.
     /// NOTE: This value is valid IFF `status` is `Ok`.
     pub accounts_data_len_delta: i64,

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -25,7 +25,10 @@ use {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CommitTransactionDetails {
-    Committed { compute_units: u64 },
+    Committed {
+        executed_units: u64,
+        executed_us: u64,
+    },
     NotCommitted,
 }
 
@@ -107,7 +110,8 @@ impl Committer {
             .iter()
             .map(|execution_result| match execution_result.details() {
                 Some(details) => CommitTransactionDetails::Committed {
-                    compute_units: details.executed_units,
+                    executed_units: details.executed_units,
+                    executed_us: details.executed_us,
                 },
                 None => CommitTransactionDetails::NotCommitted,
             })

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -30,7 +30,7 @@ pub enum CommitTransactionDetails {
         executed_units: u64,
         // actual micro-second elapsed for executing the committed transaction
         executed_us: u64,
-        // compute units to add to executed_units to compensate under priced CUs
+        // compute units to add to executed_units to compensate for under priced CUs
         adjust_units: u64,
     },
     NotCommitted,
@@ -200,7 +200,7 @@ impl Committer {
         executed_units: u64,
         executed_us: u64,
     ) -> u64 {
-        // "actual executed units" is consistent cross cluster, but "adjustment" are only based
+        // "actual executed units" is consistent across cluster, but "adjustment" is only based
         // on current leader node. Add a 50% taper to reduce local variance.
         const TAPER: u64 = 2;
         solana_cost_model::block_cost_limits::COMPUTE_UNIT_TO_US_RATIO

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1275,7 +1275,10 @@ mod tests {
 
             let expected_block_cost = if !apply_cost_tracker_during_replay_enabled {
                 let actual_bpf_execution_cost = match commit_transactions_result.first().unwrap() {
-                    CommitTransactionDetails::Committed { compute_units } => *compute_units,
+                    CommitTransactionDetails::Committed {
+                        executed_units,
+                        executed_us: _,
+                    } => *executed_units,
                     CommitTransactionDetails::NotCommitted => {
                         unreachable!()
                     }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -507,6 +507,14 @@ impl Consumer {
         self.qos_service.accumulate_actual_execute_cu(cu);
         self.qos_service.accumulate_actual_execute_time(us);
 
+        let (committed_cu, adjust_cu, committed_us) =
+            Self::accumulate_commit_transactions_result(commit_transactions_result.as_ref().ok());
+        self.qos_service
+            .accumulate_committed_execute_cu(committed_cu);
+        self.qos_service
+            .accumulate_committed_execute_time(committed_us);
+        self.qos_service.accumulate_committed_adjust_cu(adjust_cu);
+
         // reports qos service stats for this batch
         self.qos_service.report_metrics(bank.slot());
 
@@ -681,6 +689,34 @@ impl Consumer {
                 )
             },
         )
+    }
+
+    fn accumulate_commit_transactions_result(
+        transaction_committed_status: Option<&Vec<CommitTransactionDetails>>,
+    ) -> (u64, u64, u64) {
+        if let Some(transaction_committed_status) = transaction_committed_status {
+            transaction_committed_status.iter().fold(
+                (0, 0, 0),
+                |(units, time, adjustment), transaction_committed_details| {
+                    if let CommitTransactionDetails::Committed {
+                        executed_units,
+                        executed_us,
+                        adjust_units,
+                    } = transaction_committed_details
+                    {
+                        (
+                            units.saturating_add(*executed_units),
+                            time.saturating_add(*executed_us),
+                            adjustment.saturating_add(*adjust_units),
+                        )
+                    } else {
+                        (units, time, adjustment)
+                    }
+                },
+            )
+        } else {
+            (0, 0, 0)
+        }
     }
 
     /// This function filters pending packets that are still valid
@@ -1277,11 +1313,9 @@ mod tests {
                 let actual_bpf_execution_cost = match commit_transactions_result.first().unwrap() {
                     CommitTransactionDetails::Committed {
                         executed_units,
-                        executed_us,
-                    } => QosService::adjust_compute_units_for_potential_underpricing(
-                        *executed_units,
-                        *executed_us,
-                    ),
+                        executed_us: _,
+                        adjust_units,
+                    } => executed_units.saturating_add(*adjust_units),
                     CommitTransactionDetails::NotCommitted => {
                         unreachable!()
                     }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -507,7 +507,7 @@ impl Consumer {
         self.qos_service.accumulate_actual_execute_cu(cu);
         self.qos_service.accumulate_actual_execute_time(us);
 
-        let (committed_cu, adjust_cu, committed_us) =
+        let (committed_cu, committed_us, adjust_cu) =
             Self::accumulate_commit_transactions_result(commit_transactions_result.as_ref().ok());
         self.qos_service
             .accumulate_committed_execute_cu(committed_cu);

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -1277,8 +1277,11 @@ mod tests {
                 let actual_bpf_execution_cost = match commit_transactions_result.first().unwrap() {
                     CommitTransactionDetails::Committed {
                         executed_units,
-                        executed_us: _,
-                    } => *executed_units,
+                        executed_us,
+                    } => QosService::adjust_compute_units_for_potential_underpricing(
+                        *executed_units,
+                        *executed_us,
+                    ),
                     CommitTransactionDetails::NotCommitted => {
                         unreachable!()
                     }

--- a/core/src/banking_stage/qos_service.rs
+++ b/core/src/banking_stage/qos_service.rs
@@ -213,7 +213,7 @@ impl QosService {
     // additional executing time it needs.
     // adjustment is u64 for now, meaning only add more CUs when transactions are under priced,
     // but not to reduce CU if transactions are over priced.
-    fn adjust_compute_units_for_potential_underpricing(
+    pub(crate) fn adjust_compute_units_for_potential_underpricing(
         executed_units: u64,
         executed_us: u64,
     ) -> u64 {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -388,6 +388,7 @@ pub(crate) mod tests {
             )),
             return_data: None,
             executed_units: 0,
+            executed_us: 0,
             accounts_data_len_delta: 0,
         });
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5015,6 +5015,7 @@ impl Bank {
                 durable_nonce_fee,
                 return_data,
                 executed_units,
+                executed_us: timings.execute_accessories.process_instructions.total_us,
                 accounts_data_len_delta,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4907,6 +4907,7 @@ impl Bank {
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
 
         let mut executed_units = 0u64;
+        let mut executed_us = timings.execute_accessories.process_instructions.total_us;
         let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(
             self.slot,
             programs_loaded_for_tx_batch.environments.clone(),
@@ -4929,6 +4930,11 @@ impl Bank {
             &mut executed_units,
         );
         process_message_time.stop();
+        executed_us = timings
+            .execute_accessories
+            .process_instructions
+            .total_us
+            .saturating_sub(executed_us);
 
         saturating_add_assign!(
             timings.execute_accessories.process_message_us,
@@ -5015,7 +5021,7 @@ impl Bank {
                 durable_nonce_fee,
                 return_data,
                 executed_units,
-                executed_us: timings.execute_accessories.process_instructions.total_us,
+                executed_us,
                 accounts_data_len_delta,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -201,6 +201,7 @@ fn new_execution_result(
             durable_nonce_fee: nonce.map(DurableNonceFee::from),
             return_data: None,
             executed_units: 0,
+            executed_us: 0,
             accounts_data_len_delta: 0,
         },
         programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),


### PR DESCRIPTION
#### Problem
It is possible that Runtime underprices execution CU for some transactions, which could lead to overpacking block, therefore extending replay time over 400ms target.

One of potential patches is to adjust underpriced transaction's execution CUs . After leader had processed and committed transaction, it can evaluate its actual CU/us ratio (`= actual_consumed_cu / actual_spent_microsecond`), if it is below cluster average (30CU/us), calculate additional CUs to match to it.

Since the additional CU is solely based on current leader's configuration, can halve it to reduce local variance.

#### Summary of Changes
- add `executed_us` to `TransactionExecutionDetails` to capture actual spent time on executing transaction;
- pass `executed_us` to qos_service via `Committed` 
- add `adjust_compute_units_for_potential_underpricing()` to adjust CU for underpriced txs.

Propose to short-term address #33869 