### PR TITLE
chore: replace ref with readable branch name for curve25519-dalek patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=c14774464c4d38de553c6ef2f48a10982c1b4801#c14774464c4d38de553c6ef2f48a10982c1b4801"
+source = "git+https://github.com/solana-labs/curve25519-dalek.git?branch=3.2.1-unpin-zeroize#b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 dependencies = [
  "byteorder",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -526,4 +526,4 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 #
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/solana-labs/curve25519-dalek.git"
-rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"
+branch = "3.2.1-unpin-zeroize"


### PR DESCRIPTION
#### Problem

the commit, `c14774464c4d38de553c6ef2f48a10982c1b4801`, doesn't belong to our fork repository. 

https://github.com/solana-labs/solana/blob/b0bf24b6fc3b5b57032416643e2db169e8bd79ca/Cargo.toml#L527-L529

I suspect that is why we get a 404 sometimes when we patch.

(from: https://github.com/solana-labs/solana/actions/runs/6674393643/job/18141176890)

![Screenshot 2023-10-28 at 17 14 54](https://github.com/solana-labs/solana/assets/8209234/262fd1d1-0de9-4cd0-ac16-da4c6423e61f)


also we already have a branch for the patch. I think maybe we can just use the branch name for better readability


#### Summary of Changes

```diff
[patch.crates-io.curve25519-dalek]
git = "https://github.com/solana-labs/curve25519-dalek.git"
- rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"
+ branch = "3.2.1-unpin-zeroize"
```
