### PR TITLE
docs: updating apt install to apt upgrade

### DIFF
--- a/docs/src/validator/get-started/setup-a-validator.md
+++ b/docs/src/validator/get-started/setup-a-validator.md
@@ -131,7 +131,7 @@ Make sure you have the latest and greatest package versions on your server
 
 ```
 sudo apt update
-sudo apt install
+sudo apt upgrade
 ```
 
 ## Sol User


### PR DESCRIPTION
#### Problem

The docs are trying to tell the user to make sure all packages are up to date, however an `upgrade` should be run, not an `install`.

#### Summary of Changes

Update `sudo apt install` to `sudo apt upgrade`

