### PR TITLE
Define InstalledScheduler::wait_for_termination()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6258,6 +6258,7 @@ dependencies = [
  "libc",
  "log",
  "lru",
+ "mockall",
  "num_cpus",
  "num_enum 0.7.0",
  "prost",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -42,7 +42,8 @@ use {
         block_error::BlockError,
         blockstore::Blockstore,
         blockstore_processor::{
-            self, BlockstoreProcessorError, ConfirmationProgress, TransactionStatusSender,
+            self, BlockstoreProcessorError, ConfirmationProgress, ExecuteBatchesInternalMetrics,
+            TransactionStatusSender,
         },
         entry_notifier_service::EntryNotifierSender,
         leader_schedule_cache::LeaderScheduleCache,
@@ -2815,6 +2816,40 @@ impl ReplayStage {
                     .expect("Bank fork progress entry missing for completed bank");
 
                 let replay_stats = bank_progress.replay_stats.clone();
+
+                if let Some((result, completed_execute_timings)) =
+                    bank.wait_for_completed_scheduler()
+                {
+                    let metrics = ExecuteBatchesInternalMetrics::new_with_timings_from_all_threads(
+                        completed_execute_timings,
+                    );
+                    replay_stats
+                        .write()
+                        .unwrap()
+                        .batch_execute
+                        .accumulate(metrics);
+
+                    if let Err(err) = result {
+                        Self::mark_dead_slot(
+                            blockstore,
+                            bank,
+                            bank_forks.read().unwrap().root(),
+                            &BlockstoreProcessorError::InvalidTransaction(err),
+                            rpc_subscriptions,
+                            duplicate_slots_tracker,
+                            gossip_duplicate_confirmed_slots,
+                            epoch_slots_frozen_slots,
+                            progress,
+                            heaviest_subtree_fork_choice,
+                            duplicate_slots_to_repair,
+                            ancestor_hashes_replay_update_sender,
+                            purge_repair_slot_counter,
+                        );
+                        // don't try to run the remaining normal processing for the completed bank
+                        continue;
+                    }
+                }
+
                 let r_replay_stats = replay_stats.read().unwrap();
                 let replay_progress = bank_progress.replay_progress.clone();
                 let r_replay_progress = replay_progress.read().unwrap();

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true }
 lru = { workspace = true }
+mockall = { workspace = true }
 num_cpus = { workspace = true }
 num_enum = { workspace = true }
 prost = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5191,6 +5191,7 @@ dependencies = [
  "libc",
  "log",
  "lru",
+ "mockall",
  "num_cpus",
  "num_enum 0.7.0",
  "prost",

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -274,7 +274,7 @@ fn test_bank_new() {
     assert_eq!(rent.lamports_per_byte_year, 5);
 }
 
-fn create_simple_test_bank(lamports: u64) -> Bank {
+pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {
     let (genesis_config, _mint_keypair) = create_genesis_config(lamports);
     Bank::new_for_tests(&genesis_config)
 }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -152,7 +152,7 @@ impl BankWithScheduler {
     }
 
     pub(crate) fn wait_for_paused_scheduler(bank: &Bank, scheduler: &InstalledSchedulerRwLock) {
-        let maybe_result_with_timings = BankWithSchedulerInner::wait_for_scheduler(
+        let maybe_result_with_timings = BankWithSchedulerInner::wait_for_scheduler_termination(
             bank,
             scheduler,
             WaitReason::PausedForRecentBlockhash,
@@ -165,7 +165,7 @@ impl BankWithScheduler {
 
     #[must_use]
     pub fn wait_for_completed_scheduler(&self) -> Option<ResultWithTimings> {
-        BankWithSchedulerInner::wait_for_scheduler(
+        BankWithSchedulerInner::wait_for_scheduler_termination(
             &self.inner.bank,
             &self.inner.scheduler,
             WaitReason::TerminatedToFreeze,
@@ -180,7 +180,7 @@ impl BankWithScheduler {
 impl BankWithSchedulerInner {
     #[must_use]
     fn wait_for_completed_scheduler_from_drop(&self) -> Option<ResultWithTimings> {
-        Self::wait_for_scheduler(
+        Self::wait_for_scheduler_termination(
             &self.bank,
             &self.scheduler,
             WaitReason::DroppedFromBankForks,
@@ -188,13 +188,13 @@ impl BankWithSchedulerInner {
     }
 
     #[must_use]
-    fn wait_for_scheduler(
+    fn wait_for_scheduler_termination(
         bank: &Bank,
         scheduler: &InstalledSchedulerRwLock,
         reason: WaitReason,
     ) -> Option<ResultWithTimings> {
         debug!(
-            "wait_for_scheduler(slot: {}, reason: {:?}): started...",
+            "wait_for_scheduler_termination(slot: {}, reason: {:?}): started...",
             bank.slot(),
             reason,
         );
@@ -212,7 +212,7 @@ impl BankWithSchedulerInner {
             None
         };
         debug!(
-            "wait_for_scheduler(slot: {}, reason: {:?}): finished with: {:?}...",
+            "wait_for_scheduler_termination(slot: {}, reason: {:?}): finished with: {:?}...",
             bank.slot(),
             reason,
             result_with_timings.as_ref().map(|(result, _)| result),

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -4,7 +4,11 @@
 use {
     crate::bank::Bank,
     log::*,
-    solana_sdk::transaction::SanitizedTransaction,
+    solana_program_runtime::timings::ExecuteTimings,
+    solana_sdk::{
+        hash::Hash,
+        transaction::{Result, SanitizedTransaction},
+    },
     std::{
         fmt::Debug,
         ops::Deref,
@@ -23,13 +27,39 @@ use {mockall::automock, qualifier_attr::qualifiers};
     allow(unused_attributes, clippy::needless_lifetimes)
 )]
 pub trait InstalledScheduler: Send + Sync + Debug + 'static {
+    // Calling this is illegal as soon as wait_for_termination is called.
     fn schedule_execution<'a>(
         &'a self,
         transaction_with_index: &'a (&'a SanitizedTransaction, usize),
     );
+
+    #[must_use]
+    fn wait_for_termination(&mut self, reason: &WaitReason) -> Option<ResultWithTimings>;
 }
 
 pub type DefaultInstalledSchedulerBox = Box<dyn InstalledScheduler>;
+
+pub type ResultWithTimings = (Result<()>, ExecuteTimings);
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum WaitReason {
+    // most normal termination waiting mode; couldn't be done implicitly inside Bank::freeze() -> () to return
+    // the result and timing in some way to higher-layer subsystems;
+    TerminatedToFreeze,
+    // just behaves like TerminatedToFreeze but hint that this is called from Drop::drop().
+    DroppedFromBankForks,
+    // scheduler is paused without being returned to the pool to collect ResultWithTimings later.
+    PausedForRecentBlockhash,
+}
+
+impl WaitReason {
+    pub fn is_paused(&self) -> bool {
+        match self {
+            WaitReason::PausedForRecentBlockhash => true,
+            WaitReason::TerminatedToFreeze | WaitReason::DroppedFromBankForks => false,
+        }
+    }
+}
 
 /// Very thin wrapper around Arc<Bank>
 ///
@@ -85,6 +115,14 @@ impl BankWithScheduler {
         self.inner.bank.clone()
     }
 
+    pub fn register_tick(&self, hash: &Hash) {
+        self.inner.bank.register_tick(hash, &self.inner.scheduler);
+    }
+
+    pub fn fill_bank_with_ticks_for_tests(&self) {
+        self.do_fill_bank_with_ticks_for_tests(&self.inner.scheduler);
+    }
+
     pub fn has_installed_scheduler(&self) -> bool {
         self.inner.scheduler.read().unwrap().is_some()
     }
@@ -107,8 +145,108 @@ impl BankWithScheduler {
         }
     }
 
+    // take needless &mut only to communicate its semantic mutability to humans...
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn drop_scheduler(&mut self) {
+        self.inner.drop_scheduler();
+    }
+
+    pub(crate) fn wait_for_paused_scheduler(bank: &Bank, scheduler: &InstalledSchedulerRwLock) {
+        let maybe_result_with_timings = BankWithSchedulerInner::wait_for_scheduler(
+            bank,
+            scheduler,
+            WaitReason::PausedForRecentBlockhash,
+        );
+        assert!(
+            maybe_result_with_timings.is_none(),
+            "Premature result was returned from scheduler after paused"
+        );
+    }
+
+    #[must_use]
+    pub fn wait_for_completed_scheduler(&self) -> Option<ResultWithTimings> {
+        BankWithSchedulerInner::wait_for_scheduler(
+            &self.inner.bank,
+            &self.inner.scheduler,
+            WaitReason::TerminatedToFreeze,
+        )
+    }
+
     pub const fn no_scheduler_available() -> InstalledSchedulerRwLock {
         RwLock::new(None)
+    }
+}
+
+impl BankWithSchedulerInner {
+    #[must_use]
+    fn wait_for_completed_scheduler_from_drop(&self) -> Option<ResultWithTimings> {
+        Self::wait_for_scheduler(
+            &self.bank,
+            &self.scheduler,
+            WaitReason::DroppedFromBankForks,
+        )
+    }
+
+    #[must_use]
+    fn wait_for_scheduler(
+        bank: &Bank,
+        scheduler: &InstalledSchedulerRwLock,
+        reason: WaitReason,
+    ) -> Option<ResultWithTimings> {
+        debug!(
+            "wait_for_scheduler(slot: {}, reason: {:?}): started...",
+            bank.slot(),
+            reason,
+        );
+
+        let mut scheduler = scheduler.write().unwrap();
+        let result_with_timings = if scheduler.is_some() {
+            let result_with_timings = scheduler
+                .as_mut()
+                .and_then(|scheduler| scheduler.wait_for_termination(&reason));
+            if !reason.is_paused() {
+                drop(scheduler.take().expect("scheduler after waiting"));
+            }
+            result_with_timings
+        } else {
+            None
+        };
+        debug!(
+            "wait_for_scheduler(slot: {}, reason: {:?}): finished with: {:?}...",
+            bank.slot(),
+            reason,
+            result_with_timings.as_ref().map(|(result, _)| result),
+        );
+
+        result_with_timings
+    }
+
+    fn drop_scheduler(&self) {
+        if std::thread::panicking() {
+            error!(
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} skipping due to already panicking...",
+                self.bank.slot(),
+            );
+            return;
+        }
+
+        // There's no guarantee ResultWithTimings is available or not at all when being dropped.
+        if let Some(Err(err)) = self
+            .wait_for_completed_scheduler_from_drop()
+            .map(|(result, _timings)| result)
+        {
+            warn!(
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} discarding error from scheduler: {:?}",
+                self.bank.slot(),
+                err,
+            );
+        }
+    }
+}
+
+impl Drop for BankWithSchedulerInner {
+    fn drop(&mut self) {
+        self.drop_scheduler();
     }
 }
 
@@ -117,5 +255,151 @@ impl Deref for BankWithScheduler {
 
     fn deref(&self) -> &Self::Target {
         &self.inner.bank
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::{
+            bank::test_utils::goto_end_of_slot_with_scheduler,
+            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+        },
+        assert_matches::assert_matches,
+        mockall::Sequence,
+        solana_sdk::system_transaction,
+    };
+
+    fn setup_mocked_scheduler_with_extra(
+        wait_reasons: impl Iterator<Item = WaitReason>,
+        f: Option<impl Fn(&mut MockInstalledScheduler)>,
+    ) -> DefaultInstalledSchedulerBox {
+        let mut mock = MockInstalledScheduler::new();
+        let mut seq = Sequence::new();
+
+        for wait_reason in wait_reasons {
+            mock.expect_wait_for_termination()
+                .with(mockall::predicate::eq(wait_reason))
+                .times(1)
+                .in_sequence(&mut seq)
+                .returning(move |_| {
+                    if wait_reason.is_paused() {
+                        None
+                    } else {
+                        Some((Ok(()), ExecuteTimings::default()))
+                    }
+                });
+        }
+
+        if let Some(f) = f {
+            f(&mut mock);
+        }
+
+        Box::new(mock)
+    }
+
+    fn setup_mocked_scheduler(
+        wait_reasons: impl Iterator<Item = WaitReason>,
+    ) -> DefaultInstalledSchedulerBox {
+        setup_mocked_scheduler_with_extra(
+            wait_reasons,
+            None::<fn(&mut MockInstalledScheduler) -> ()>,
+        )
+    }
+
+    #[test]
+    fn test_scheduler_normal_termination() {
+        solana_logger::setup();
+
+        let bank = Arc::new(Bank::default_for_tests());
+        let bank = BankWithScheduler::new(
+            bank,
+            Some(setup_mocked_scheduler(
+                [WaitReason::TerminatedToFreeze].into_iter(),
+            )),
+        );
+        assert!(bank.has_installed_scheduler());
+        assert_matches!(bank.wait_for_completed_scheduler(), Some(_));
+
+        // Repeating to call wait_for_completed_scheduler() is okay with no ResultWithTimings being
+        // returned.
+        assert!(!bank.has_installed_scheduler());
+        assert_matches!(bank.wait_for_completed_scheduler(), None);
+    }
+
+    #[test]
+    fn test_no_scheduler_termination() {
+        solana_logger::setup();
+
+        let bank = Arc::new(Bank::default_for_tests());
+        let bank = BankWithScheduler::new_without_scheduler(bank);
+
+        // Calling wait_for_completed_scheduler() is noop, when no scheduler is installed.
+        assert!(!bank.has_installed_scheduler());
+        assert_matches!(bank.wait_for_completed_scheduler(), None);
+    }
+
+    #[test]
+    fn test_scheduler_termination_from_drop() {
+        solana_logger::setup();
+
+        let bank = Arc::new(Bank::default_for_tests());
+        let bank = BankWithScheduler::new(
+            bank,
+            Some(setup_mocked_scheduler(
+                [WaitReason::DroppedFromBankForks].into_iter(),
+            )),
+        );
+        drop(bank);
+    }
+
+    #[test]
+    fn test_scheduler_pause() {
+        solana_logger::setup();
+
+        let bank = Arc::new(crate::bank::tests::create_simple_test_bank(42));
+        let bank = BankWithScheduler::new(
+            bank,
+            Some(setup_mocked_scheduler(
+                [
+                    WaitReason::PausedForRecentBlockhash,
+                    WaitReason::TerminatedToFreeze,
+                ]
+                .into_iter(),
+            )),
+        );
+        goto_end_of_slot_with_scheduler(&bank);
+        assert_matches!(bank.wait_for_completed_scheduler(), Some(_));
+    }
+
+    #[test]
+    fn test_schedule_executions() {
+        solana_logger::setup();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let tx0 = SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let mocked_scheduler = setup_mocked_scheduler_with_extra(
+            [WaitReason::DroppedFromBankForks].into_iter(),
+            Some(|mocked: &mut MockInstalledScheduler| {
+                mocked
+                    .expect_schedule_execution()
+                    .times(1)
+                    .returning(|(_, _)| ());
+            }),
+        );
+
+        let bank = BankWithScheduler::new(bank, Some(mocked_scheduler));
+        bank.schedule_transaction_executions([(&tx0, &0)].into_iter());
     }
 }


### PR DESCRIPTION
#### Problem

The upcoming unified scheduler is async by nature. so, the replay stage must eventually be blocked on block boundaries in some way for tx execution completion. however, the minimal `InstalledSchduler` (introduced at #33875) doesn't provide any such way.

#### Summary of Changes

Implement it and wire it exhaustively into all the needed relevant blocking points.

(fyi, planned next prs: 1. introduce `InstallSchedulerPool` 2. introduce `SchedulerPool` as its actual impl)

extracted from: https://github.com/solana-labs/solana/pull/33070