### PR TITLE
[TieredStorage] Rename account-index to index-block

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -19,7 +19,7 @@ use {
     },
     error::TieredStorageError,
     footer::{AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat},
-    index::AccountIndexFormat,
+    index::IndexBlockFormat,
     readable::TieredStorageReader,
     solana_sdk::account::ReadableAccount,
     std::{
@@ -40,7 +40,7 @@ pub struct TieredStorageFormat {
     pub meta_entry_size: usize,
     pub account_meta_format: AccountMetaFormat,
     pub owners_block_format: OwnersBlockFormat,
-    pub account_index_format: AccountIndexFormat,
+    pub index_block_format: IndexBlockFormat,
     pub account_block_format: AccountBlockFormat,
 }
 
@@ -236,7 +236,7 @@ mod tests {
         assert_eq!(tiered_storage_readonly.reader().unwrap().num_accounts(), 0);
         assert_eq!(footer.account_meta_format, HOT_FORMAT.account_meta_format);
         assert_eq!(footer.owners_block_format, HOT_FORMAT.owners_block_format);
-        assert_eq!(footer.account_index_format, HOT_FORMAT.account_index_format);
+        assert_eq!(footer.index_block_format, HOT_FORMAT.index_block_format);
         assert_eq!(footer.account_block_format, HOT_FORMAT.account_block_format);
         assert_eq!(
             tiered_storage_readonly.file_size().unwrap() as usize,
@@ -379,7 +379,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: expected_format.account_meta_format,
             owners_block_format: expected_format.owners_block_format,
-            account_index_format: expected_format.account_index_format,
+            index_block_format: expected_format.index_block_format,
             account_block_format: expected_format.account_block_format,
             account_entry_count: expected_accounts.len() as u32,
             // Hash is not yet implemented, so we bypass the check

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        error::TieredStorageError, file::TieredStorageFile, index::AccountIndexFormat,
+        error::TieredStorageError, file::TieredStorageFile, index::IndexBlockFormat,
         mmap_utils::get_type, TieredStorageResult as TsResult,
     },
     memmap2::Mmap,
@@ -95,7 +95,7 @@ pub struct TieredStorageFooter {
     /// The format of the owners block.
     pub owners_block_format: OwnersBlockFormat,
     /// The format of the account index block.
-    pub account_index_format: AccountIndexFormat,
+    pub index_block_format: IndexBlockFormat,
     /// The format of the account block.
     pub account_block_format: AccountBlockFormat,
 
@@ -120,7 +120,7 @@ pub struct TieredStorageFooter {
     // Offsets
     // Note that offset to the account blocks is omitted as it's always 0.
     /// The offset pointing to the first byte of the account index block.
-    pub account_index_offset: u64,
+    pub index_block_offset: u64,
     /// The offset pointing to the first byte of the owners block.
     pub owners_offset: u64,
 
@@ -149,14 +149,14 @@ impl Default for TieredStorageFooter {
         Self {
             account_meta_format: AccountMetaFormat::default(),
             owners_block_format: OwnersBlockFormat::default(),
-            account_index_format: AccountIndexFormat::default(),
+            index_block_format: IndexBlockFormat::default(),
             account_block_format: AccountBlockFormat::default(),
             account_entry_count: 0,
             account_meta_entry_size: 0,
             account_block_size: 0,
             owner_count: 0,
             owner_entry_size: 0,
-            account_index_offset: 0,
+            index_block_offset: 0,
             owners_offset: 0,
             hash: Hash::new_unique(),
             min_account_address: Pubkey::default(),
@@ -241,14 +241,14 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            account_index_format: AccountIndexFormat::AddressAndOffset,
+            index_block_format: IndexBlockFormat::AddressAndOffset,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,
             account_block_size: 4096,
             owner_count: 250,
             owner_entry_size: 32,
-            account_index_offset: 1069600,
+            index_block_offset: 1069600,
             owners_offset: 1081200,
             hash: Hash::new_unique(),
             min_account_address: Pubkey::default(),
@@ -275,7 +275,7 @@ mod tests {
     fn test_footer_layout() {
         assert_eq!(offset_of!(TieredStorageFooter, account_meta_format), 0x00);
         assert_eq!(offset_of!(TieredStorageFooter, owners_block_format), 0x02);
-        assert_eq!(offset_of!(TieredStorageFooter, account_index_format), 0x04);
+        assert_eq!(offset_of!(TieredStorageFooter, index_block_format), 0x04);
         assert_eq!(offset_of!(TieredStorageFooter, account_block_format), 0x06);
         assert_eq!(offset_of!(TieredStorageFooter, account_entry_count), 0x08);
         assert_eq!(
@@ -285,7 +285,7 @@ mod tests {
         assert_eq!(offset_of!(TieredStorageFooter, account_block_size), 0x10);
         assert_eq!(offset_of!(TieredStorageFooter, owner_count), 0x18);
         assert_eq!(offset_of!(TieredStorageFooter, owner_entry_size), 0x1C);
-        assert_eq!(offset_of!(TieredStorageFooter, account_index_offset), 0x20);
+        assert_eq!(offset_of!(TieredStorageFooter, index_block_offset), 0x20);
         assert_eq!(offset_of!(TieredStorageFooter, owners_offset), 0x28);
         assert_eq!(offset_of!(TieredStorageFooter, min_account_address), 0x30);
         assert_eq!(offset_of!(TieredStorageFooter, max_account_address), 0x50);

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -9,7 +9,7 @@ use {
             footer::{
                 AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat, TieredStorageFooter,
             },
-            index::AccountIndexFormat,
+            index::IndexBlockFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
             mmap_utils::get_type,
             TieredStorageFormat, TieredStorageResult,
@@ -25,7 +25,7 @@ pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
     account_meta_format: AccountMetaFormat::Hot,
     owners_block_format: OwnersBlockFormat::LocalIndex,
-    account_index_format: AccountIndexFormat::AddressAndOffset,
+    index_block_format: IndexBlockFormat::AddressAndOffset,
     account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
@@ -241,7 +241,7 @@ pub mod tests {
                 FOOTER_SIZE,
             },
             hot::{HotAccountMeta, HotStorageReader},
-            index::AccountIndexFormat,
+            index::IndexBlockFormat,
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
         },
         memoffset::offset_of,
@@ -383,14 +383,14 @@ pub mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            account_index_format: AccountIndexFormat::AddressAndOffset,
+            index_block_format: IndexBlockFormat::AddressAndOffset,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 16,
             account_block_size: 4096,
             owner_count: 250,
             owner_entry_size: 32,
-            account_index_offset: 1069600,
+            index_block_offset: 1069600,
             owners_offset: 1081200,
             hash: Hash::new_unique(),
             min_account_address: Pubkey::default(),

--- a/accounts-db/src/tiered_storage/writer.rs
+++ b/accounts-db/src/tiered_storage/writer.rs
@@ -46,7 +46,7 @@ impl<'format> TieredStorageWriter<'format> {
             account_meta_format: self.format.account_meta_format,
             owners_block_format: self.format.owners_block_format,
             account_block_format: self.format.account_block_format,
-            account_index_format: self.format.account_index_format,
+            index_block_format: self.format.index_block_format,
             account_entry_count: accounts
                 .accounts
                 .len()


### PR DESCRIPTION
#### Problem
The current tiered-storage code uses "account-index" to call index-block.
This could lead to confusion especially as we start giving each offset/position/index a specific type.

#### Summary of Changes
This PR renames all structs/variables that use account-index to refer to index-block.
