### PR TITLE
Fixup: zeroize: Allow versions newer than 1.3 for `curve25519-dalek`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
-source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=c14774464c4d38de553c6ef2f48a10982c1b4801#c14774464c4d38de553c6ef2f48a10982c1b4801"
+source = "git+https://github.com/solana-labs/curve25519-dalek.git?rev=b500cdc2a920cd5bff9e2dd974d7b97349d61464#b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 dependencies = [
  "byteorder",
  "digest 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -516,9 +516,9 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 #
 # https://github.com/dalek-cryptography/curve25519-dalek/commit/29e5c29b0e5c6821e4586af58b0d0891dd2ec639
 #
-# Comparison with `c14774464c4d38de553c6ef2f48a10982c1b4801`:
+# Comparison with `b500cdc2a920cd5bff9e2dd974d7b97349d61464`:
 #
-# https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:c14774464c4d38de553c6ef2f48a10982c1b4801
+# https://github.com/dalek-cryptography/curve25519-dalek/compare/3.2.1...solana-labs:curve25519-dalek:b500cdc2a920cd5bff9e2dd974d7b97349d61464
 #
 # Or, using the branch name instead of the hash:
 #
@@ -526,4 +526,4 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 #
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/solana-labs/curve25519-dalek.git"
-rev = "c14774464c4d38de553c6ef2f48a10982c1b4801"
+rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"


### PR DESCRIPTION
#### Problem

#33516 used an incorrect version of the commit hash.
One from a different repository.

#### Summary of Changes
Fixes

    commit a099c7a0b8ac4281dbc6dd422d697e700c28a7d1
    Author: Illia Bobyr <illia.bobyr@solana.com>
    Date:   Mon Oct 23 12:19:59 2023 -0700

    zeroize: Allow versions newer than 1.3 for `curve25519-dalek` (#33516)

Use correct commit hash from `solana-labs/curve25519-dalek.git`.