### PR TITLE
solana-tokens: unpub/remove some helpers

### DIFF
--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -40,7 +40,7 @@ pub fn spl_token_amount(amount: f64, decimals: u8) -> u64 {
     (amount * 10_usize.pow(decimals as u32) as f64) as u64
 }
 
-pub fn build_spl_token_instructions(
+pub(crate) fn build_spl_token_instructions(
     allocation: &Allocation,
     args: &DistributeTokensArgs,
     do_create_associated_token_account: bool,
@@ -77,7 +77,7 @@ pub fn build_spl_token_instructions(
     instructions
 }
 
-pub fn check_spl_token_balances(
+pub(crate) fn check_spl_token_balances(
     messages: &[Message],
     allocations: &[Allocation],
     client: &RpcClient,
@@ -114,7 +114,7 @@ pub fn check_spl_token_balances(
     Ok(())
 }
 
-pub fn print_token_balances(
+pub(crate) fn print_token_balances(
     client: &RpcClient,
     allocation: &Allocation,
     spl_token_args: &SplTokenArgs,

--- a/tokens/src/spl_token.rs
+++ b/tokens/src/spl_token.rs
@@ -36,10 +36,6 @@ pub fn update_decimals(client: &RpcClient, args: &mut Option<SplTokenArgs>) -> R
     Ok(())
 }
 
-pub fn spl_token_amount(amount: f64, decimals: u8) -> u64 {
-    (amount * 10_usize.pow(decimals as u32) as f64) as u64
-}
-
 pub(crate) fn build_spl_token_instructions(
     allocation: &Allocation,
     args: &DistributeTokensArgs,


### PR DESCRIPTION
#### Problem
`solana-tokens` is overly public in its interface.

#### Summary of Changes
Reduce the scope of some helper functions. crates.io reports that no projects are using `solana-tokens` as a dependency, so this shouldn't break anyone.
Remove a function that isn't being used (and we couldn't tell, bc pub)
