### PR TITLE
Fix `solana-install init` making unnecessary API requests

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -968,12 +968,6 @@ pub fn update(config_file: &str, check_only: bool) -> Result<bool, String> {
 pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Result<bool, String> {
     let mut config = Config::load(config_file)?;
 
-    let semver_update_type = if is_init {
-        SemverUpdateType::Fixed
-    } else {
-        SemverUpdateType::Patch
-    };
-
     let (updated_version, download_url_and_sha256, release_dir) = if let Some(explicit_release) =
         &config.explicit_release
     {
@@ -986,6 +980,11 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
                     let progress_bar = new_spinner_progress_bar();
                     progress_bar.set_message(format!("{LOOKING_GLASS}Checking for updates..."));
 
+                    let semver_update_type = if is_init {
+                        SemverUpdateType::Fixed
+                    } else {
+                        SemverUpdateType::Patch
+                    };
                     let github_release = check_for_newer_github_release(
                         current_release_semver,
                         semver_update_type,

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -979,47 +979,52 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
     {
         match explicit_release {
             ExplicitRelease::Semver(current_release_semver) => {
-                let progress_bar = new_spinner_progress_bar();
-                progress_bar.set_message(format!("{LOOKING_GLASS}Checking for updates..."));
+                let release_dir = config.release_dir(current_release_semver);
+                if release_dir.exists() {
+                    (current_release_semver.to_owned(), None, release_dir)
+                } else {
+                    let progress_bar = new_spinner_progress_bar();
+                    progress_bar.set_message(format!("{LOOKING_GLASS}Checking for updates..."));
 
-                let github_release = check_for_newer_github_release(
-                    current_release_semver,
-                    semver_update_type,
-                    is_init,
-                )?;
+                    let github_release = check_for_newer_github_release(
+                        current_release_semver,
+                        semver_update_type,
+                        is_init,
+                    )?;
 
-                progress_bar.finish_and_clear();
+                    progress_bar.finish_and_clear();
 
-                match github_release {
-                    None => {
-                        return Err(format!("Unknown release: {current_release_semver}"));
-                    }
-                    Some(release_semver) => {
-                        if release_semver == *current_release_semver {
-                            if let Ok(active_release_version) = load_release_version(
-                                &config.active_release_dir().join("version.yml"),
-                            ) {
-                                if format!("v{current_release_semver}")
-                                    == active_release_version.channel
-                                {
-                                    println!(
+                    match github_release {
+                        None => {
+                            return Err(format!("Unknown release: {current_release_semver}"));
+                        }
+                        Some(release_semver) => {
+                            if release_semver == *current_release_semver {
+                                if let Ok(active_release_version) = load_release_version(
+                                    &config.active_release_dir().join("version.yml"),
+                                ) {
+                                    if format!("v{current_release_semver}")
+                                        == active_release_version.channel
+                                    {
+                                        println!(
                                         "Install is up to date. {release_semver} is the latest compatible release"
                                     );
-                                    return Ok(false);
+                                        return Ok(false);
+                                    }
                                 }
                             }
-                        }
-                        config.explicit_release =
-                            Some(ExplicitRelease::Semver(release_semver.clone()));
+                            config.explicit_release =
+                                Some(ExplicitRelease::Semver(release_semver.clone()));
 
-                        let release_dir = config.release_dir(&release_semver);
-                        let download_url_and_sha256 = if release_dir.exists() {
-                            // Release already present in the cache
-                            None
-                        } else {
-                            Some((github_release_download_url(&release_semver), None))
-                        };
-                        (release_semver, download_url_and_sha256, release_dir)
+                            let release_dir = config.release_dir(&release_semver);
+                            let download_url_and_sha256 = if release_dir.exists() {
+                                // Release already present in the cache
+                                None
+                            } else {
+                                Some((github_release_download_url(&release_semver), None))
+                            };
+                            (release_semver, download_url_and_sha256, release_dir)
+                        }
                     }
                 }
             }

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -980,7 +980,7 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
         match explicit_release {
             ExplicitRelease::Semver(current_release_semver) => {
                 let release_dir = config.release_dir(current_release_semver);
-                if release_dir.exists() {
+                if is_init && release_dir.exists() {
                     (current_release_semver.to_owned(), None, release_dir)
                 } else {
                     let progress_bar = new_spinner_progress_bar();


### PR DESCRIPTION
#### Problem

Using `solana-install init` makes API requests to GitHub even when the given version is already installed locally.

#### Summary of Changes

Only fetch releases from GitHub if the given version is not installed.

Fixes #33948