### PR TITLE
Remove Option<_> from Blockstore::get_rooted_block_time() return type

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1967,14 +1967,18 @@ impl Blockstore {
         self.blocktime_cf.get(slot)
     }
 
-    pub fn get_rooted_block_time(&self, slot: Slot) -> Result<Option<UnixTimestamp>> {
+    pub fn get_rooted_block_time(&self, slot: Slot) -> Result<UnixTimestamp> {
         datapoint_info!(
             "blockstore-rpc-api",
             ("method", "get_rooted_block_time", String)
         );
         let _lock = self.check_lowest_cleanup_slot(slot)?;
+
         if self.is_root(slot) {
-            return self.blocktime_cf.get(slot);
+            return self
+                .blocktime_cf
+                .get(slot)?
+                .ok_or(BlockstoreError::SlotUnavailable);
         }
         Err(BlockstoreError::SlotNotRooted)
     }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1323,7 +1323,7 @@ impl JsonRpcRequestProcessor {
         {
             let result = self.blockstore.get_rooted_block_time(slot);
             self.check_blockstore_root(&result, slot)?;
-            if result.is_err() || matches!(result, Ok(None)) {
+            if result.is_err() {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                     let bigtable_result = bigtable_ledger_storage.get_confirmed_block(slot).await;
                     self.check_bigtable_result(&bigtable_result)?;
@@ -1333,7 +1333,7 @@ impl JsonRpcRequestProcessor {
                 }
             }
             self.check_slot_cleaned_up(&result, slot)?;
-            Ok(result.ok().unwrap_or(None))
+            Ok(result.ok())
         } else {
             let r_bank_forks = self.bank_forks.read().unwrap();
             if let Some(bank) = r_bank_forks.get(slot) {


### PR DESCRIPTION
#### Problem
See https://github.com/solana-labs/solana/pull/33901/files#r1374932022 for some discussion

#### Summary of Changes
Instead of returning Result<Option<UnixTimestamp>>, return Result<UnixTimestamp> and map None to an error. This makes the return type similar to that of Blockstore::get_rooted_block().

Given that `get_rooted_block_time()` is a new addition to the `Blockstore` API that is only present in master as of right now (https://github.com/solana-labs/solana/pull/33871), I don't think there are any concerns about adjusting the return type of a `pub` function
