### PR TITLE
Remove RwLock on AccountsUpdateNotifier

### DIFF
--- a/accounts-db/src/accounts_update_notifier_interface.rs
+++ b/accounts-db/src/accounts_update_notifier_interface.rs
@@ -3,7 +3,7 @@ use {
     solana_sdk::{
         account::AccountSharedData, clock::Slot, pubkey::Pubkey, transaction::SanitizedTransaction,
     },
-    std::sync::{Arc, RwLock},
+    std::sync::Arc,
 };
 
 pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
@@ -25,4 +25,4 @@ pub trait AccountsUpdateNotifierInterface: std::fmt::Debug {
     fn notify_end_of_restore_from_snapshot(&self);
 }
 
-pub type AccountsUpdateNotifier = Arc<RwLock<dyn AccountsUpdateNotifierInterface + Sync + Send>>;
+pub type AccountsUpdateNotifier = Arc<dyn AccountsUpdateNotifierInterface + Sync + Send>;

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -87,7 +87,7 @@ impl GeyserPluginService {
             if account_data_notifications_enabled {
                 let accounts_update_notifier =
                     AccountsUpdateNotifierImpl::new(plugin_manager.clone());
-                Some(Arc::new(RwLock::new(accounts_update_notifier)))
+                Some(Arc::new(accounts_update_notifier))
             } else {
                 None
             };


### PR DESCRIPTION
#### Problem

The interface covered by the RwLock has no "mut" operations, leaving the RwLock unnecessary for AccountNotify.
#### Summary of Changes

Remove unnecessary RwLock from AccountNotify in geyser.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
