### PR TITLE
[TieredStorage] Make HotStorageReader use AccountOffset type

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -9,7 +9,7 @@ use {
             footer::{
                 AccountBlockFormat, AccountMetaFormat, OwnersBlockFormat, TieredStorageFooter,
             },
-            index::IndexBlockFormat,
+            index::{AccountOffset, IndexBlockFormat},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
             mmap_utils::get_type,
             TieredStorageFormat, TieredStorageResult,
@@ -223,8 +223,11 @@ impl HotStorageReader {
     }
 
     /// Returns the account meta located at the specified offset.
-    fn get_account_meta_from_offset(&self, offset: usize) -> TieredStorageResult<&HotAccountMeta> {
-        let (meta, _) = get_type::<HotAccountMeta>(&self.mmap, offset)?;
+    fn get_account_meta_from_offset(
+        &self,
+        account_offset: AccountOffset,
+    ) -> TieredStorageResult<&HotAccountMeta> {
+        let (meta, _) = get_type::<HotAccountMeta>(&self.mmap, account_offset.block)?;
         Ok(meta)
     }
 }
@@ -241,7 +244,7 @@ pub mod tests {
                 FOOTER_SIZE,
             },
             hot::{HotAccountMeta, HotStorageReader},
-            index::IndexBlockFormat,
+            index::{AccountOffset, IndexBlockFormat},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
         },
         memoffset::offset_of,
@@ -444,7 +447,7 @@ pub mod tests {
                 .map(|meta| {
                     let prev_offset = current_offset;
                     current_offset += file.write_type(meta).unwrap();
-                    prev_offset
+                    AccountOffset { block: prev_offset }
                 })
                 .collect();
             // while the test only focuses on account metas, writing a footer


### PR DESCRIPTION
#### Problem
#33927 introduced a new type AccountOffset, but HotStorageReader
still uses `usize` to access accounts.

#### Summary of Changes
This PR makes HotStorageReader use the new AccountOffset type.

