### PR TITLE
Add more comments about solana-program patch (downstream)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,9 @@ crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd2
 # If you are developing downstream using non-crates-io solana-program (local or
 # forked repo, or from github rev, eg), duplicate the following patch statements
 # in your Cargo.toml. If you still hit duplicate-type errors with the patch
-# statements in place, refresh your Cargo.lock file.
+# statements in place, run `cargo update -p solana-program` and/or `cargo update
+# -p solana-zk-token-sdk` to remove extraneous versions from your Cargo.lock
+# file.
 #
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both comments and the
 # overrides in sync.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,6 +451,11 @@ crossbeam-epoch = { git = "https://github.com/solana-labs/crossbeam", rev = "fd2
 # and we end up with two versions of `solana-program` and `solana-zk-token-sdk` and all of their
 # dependencies in our build tree.
 #
+# If you are developing downstream using non-crates-io solana-program (local or
+# forked repo, or from github rev, eg), duplicate the following patch statements
+# in your Cargo.toml. If you still hit duplicate-type errors with the patch
+# statements in place, refresh your Cargo.lock file.
+#
 # There is a similar override in `programs/sbf/Cargo.toml`.  Please keep both comments and the
 # overrides in sync.
 solana-program = { path = "sdk/program" }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -196,6 +196,11 @@ targets = ["x86_64-unknown-linux-gnu"]
 # and we end up with two versions of `solana-program` and `solana-zk-token-sdk` and all of their
 # dependencies in our build tree.
 #
+# If you are developing downstream using non-crates-io solana-program (local or
+# forked repo, or from github rev, eg), duplicate the following patch statements
+# in your Cargo.toml. If you still hit duplicate-type errors with the patch
+# statements in place, refresh your Cargo.lock file.
+#
 # There is a similar override in `../../Cargo.toml`.  Please keep both comments and the
 # overrides in sync.
 solana-program = { path = "../../sdk/program" }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -199,7 +199,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 # If you are developing downstream using non-crates-io solana-program (local or
 # forked repo, or from github rev, eg), duplicate the following patch statements
 # in your Cargo.toml. If you still hit duplicate-type errors with the patch
-# statements in place, refresh your Cargo.lock file.
+# statements in place, run `cargo update -p solana-program` and/or `cargo update
+# -p solana-zk-token-sdk` to remove extraneous versions from your Cargo.lock
+# file.
 #
 # There is a similar override in `../../Cargo.toml`.  Please keep both comments and the
 # overrides in sync.


### PR DESCRIPTION
#### Problem
I ran into the errors described at #33424 while developing a geyser plugin, despite having the patch statements in my Cargo.toml already. I didn't think to wipe my Cargo.lock until @joncinque suggested it, and it fixed all my problems. 

The behavior feels a bit unintuitive. If having compiled successfully, you comment out the patch statements and recompile (fails), cargo adds the crates.io dependencies to the Cargo.lock. If you subsequently uncomment the patch statements and recompile, cargo does not remove these declarations from the Cargo.lock, so the compilation continues to fail.

#### Summary of Changes
We have helpful comments around the patch statements in the monorepo Cargo.tomls; extend them with some tips about using downstream.

Fixes #33424
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
