### PR TITLE
Removes Default from RollingBitField

### DIFF
--- a/accounts-db/src/rolling_bit_field.rs
+++ b/accounts-db/src/rolling_bit_field.rs
@@ -4,7 +4,7 @@
 
 use {bv::BitVec, solana_nohash_hasher::IntSet, solana_sdk::clock::Slot};
 
-#[derive(Debug, Default, AbiExample, Clone)]
+#[derive(Debug, AbiExample, Clone)]
 pub struct RollingBitField {
     max_width: u64,
     min: u64,


### PR DESCRIPTION
#### Problem

RollingBitField derives `Default`, but this is not safe nor valid.

A default RollingBitField will have `max_width` set to zero. One of the RollingBitField's invariants is that `max_width` is greater than zero. This is because `max_width` is used with modulo to compute the address from a given key, and zero is not allowed here.


#### Summary of Changes

Do not derive Default.