### PR TITLE
Adds `S` to HashMap/HashSet impls of Contains

### DIFF
--- a/accounts-db/src/contains.rs
+++ b/accounts-db/src/contains.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Borrow,
     cmp::Eq,
     collections::{HashMap, HashSet},
-    hash::Hash,
+    hash::{BuildHasher, Hash},
 };
 
 pub trait Contains<'a, T: Eq + Hash> {
@@ -12,24 +12,24 @@ pub trait Contains<'a, T: Eq + Hash> {
     fn contains_iter(&'a self) -> Self::Iter;
 }
 
-impl<'a, T: 'a + Eq + Hash, U: 'a> Contains<'a, T> for HashMap<T, U> {
+impl<'a, T: 'a + Eq + Hash, U: 'a, S: BuildHasher> Contains<'a, T> for HashMap<T, U, S> {
     type Item = &'a T;
     type Iter = std::collections::hash_map::Keys<'a, T, U>;
 
     fn contains(&self, key: &T) -> bool {
-        <HashMap<T, U>>::contains_key(self, key)
+        <HashMap<T, U, S>>::contains_key(self, key)
     }
     fn contains_iter(&'a self) -> Self::Iter {
         self.keys()
     }
 }
 
-impl<'a, T: 'a + Eq + Hash> Contains<'a, T> for HashSet<T> {
+impl<'a, T: 'a + Eq + Hash, S: BuildHasher> Contains<'a, T> for HashSet<T, S> {
     type Item = &'a T;
     type Iter = std::collections::hash_set::Iter<'a, T>;
 
     fn contains(&self, key: &T) -> bool {
-        <HashSet<T>>::contains(self, key)
+        <HashSet<T, S>>::contains(self, key)
     }
     fn contains_iter(&'a self) -> Self::Iter {
         self.iter()


### PR DESCRIPTION
#### Problem

When working on switch a HashMap to an IntMap within `shrink`, the build failed. Here's what one of the compiler errors was:

```
error[E0599]: the method `contains` exists for struct `HashMap<u64, Arc<AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>`, but its trait bounds were not satisfied
     --> accounts-db/src/accounts_db.rs:13530:45
      |
13530 |                 assert!(selected_candidates.contains(&slot2));
      |                                             ^^^^^^^^
      |
     ::: /Users/brooks/.rustup/toolchains/1.73.0-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/collections/hash/map.rs:216:1
      |
216   | pub struct HashMap<K, V, S = RandomState> {
      | -----------------------------------------
      | |
      | doesn't satisfy `_: Contains<'_, HashMap<u64, Arc<AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>>`
      | doesn't satisfy `_: Copy`
      | doesn't satisfy `_: Eq`
      | doesn't satisfy `_: Hash`
      | doesn't satisfy `_: Iterator`
      | doesn't satisfy `_: Itertools`
      |
note: the following trait bounds were not satisfied:
      `std::collections::HashMap<u64, std::sync::Arc<accounts_db::AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>: std::cmp::Eq`
      `std::collections::HashMap<u64, std::sync::Arc<accounts_db::AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>: std::hash::Hash`
      `std::collections::HashMap<u64, std::sync::Arc<accounts_db::AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>: std::marker::Copy`
     --> accounts-db/src/contains.rs:39:18
      |
39    | impl<'a, T: 'a + Eq + Hash + Copy> Contains<'a, T> for T {
      |                  ^^   ^^^^   ^^^^  ---------------     -
      |                  |    |      |
      |                  |    |      unsatisfied trait bound introduced here
      |                  |    unsatisfied trait bound introduced here
      |                  unsatisfied trait bound introduced here
      = note: the following trait bounds were not satisfied:
              `std::collections::HashMap<u64, std::sync::Arc<accounts_db::AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>: Iterator`
              which is required by `std::collections::HashMap<u64, std::sync::Arc<accounts_db::AccountStorageEntry>, BuildHasherDefault<NoHashHasher<u64>>>: itertools::Itertools`
```

Basically, the `Contains` trait wasn't matching the impl for HashMap. This is because the impl did not specify the HashMap's
`S` generic, so the default `RandomState` was used. Since IntMap uses a different `S`, this impl didn't match, and thus a fall-through to the impl on `T`, which failed with the above errors. 

Since the HashMap/HashSet impls don't use `S`, we can widen the impls so that IntMap and IntSet work with Contains.


#### Summary of Changes

Specify `S` in the HashMap/HashSet impls of Contains.