### PR TITLE
Move RPC root check to underlying Blockstore functions

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1975,12 +1975,14 @@ impl Blockstore {
         let _lock = self.check_lowest_cleanup_slot(slot)?;
 
         if self.is_root(slot) {
-            return self
-                .blocktime_cf
+            self.blocktime_cf
                 .get(slot)?
-                .ok_or(BlockstoreError::SlotUnavailable);
+                .ok_or(BlockstoreError::SlotUnavailable)
+        } else if slot > self.max_root() {
+            Err(BlockstoreError::SlotGreaterThanMaxRoot)
+        } else {
+            Err(BlockstoreError::SlotNotRooted)
         }
-        Err(BlockstoreError::SlotNotRooted)
     }
 
     pub fn cache_block_time(&self, slot: Slot, timestamp: UnixTimestamp) -> Result<()> {
@@ -2021,9 +2023,12 @@ impl Blockstore {
         let _lock = self.check_lowest_cleanup_slot(slot)?;
 
         if self.is_root(slot) {
-            return self.get_complete_block(slot, require_previous_blockhash);
+            self.get_complete_block(slot, require_previous_blockhash)
+        } else if slot > self.max_root() {
+            Err(BlockstoreError::SlotGreaterThanMaxRoot)
+        } else {
+            Err(BlockstoreError::SlotNotRooted)
         }
-        Err(BlockstoreError::SlotNotRooted)
     }
 
     pub fn get_complete_block(

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -148,6 +148,8 @@ pub enum BlockstoreError {
     MissingTransactionMetadata,
     #[error("transaction-index overflow")]
     TransactionIndexOverflow,
+    #[error("slot greater than max root")]
+    SlotGreaterThanMaxRoot,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1002,11 +1002,7 @@ impl JsonRpcRequestProcessor {
         })
     }
 
-    // Check if the given `slot` is within the blockstore bounds. This function assumes that
-    // `result` is from a blockstore fetch, and that the fetch:
-    // 1) Checked if `slot` is above the lowest cleanup slot (and errored if not)
-    // 2) Checked if `slot` is a root
-    fn check_blockstore_bounds<T>(
+    fn map_get_rooted_blockstore_result<T>(
         &self,
         result: &std::result::Result<T, BlockstoreError>,
         slot: Slot,
@@ -1101,7 +1097,7 @@ impl JsonRpcRequestProcessor {
             {
                 self.check_blockstore_writes_complete(slot)?;
                 let result = self.blockstore.get_rooted_block(slot, true);
-                self.check_blockstore_bounds(&result, slot)?;
+                self.map_get_rooted_blockstore_result(&result, slot)?;
                 let encode_block = |confirmed_block: ConfirmedBlock| -> Result<UiConfirmedBlock> {
                     let mut encoded_block = confirmed_block
                         .encode_with_options(encoding, encoding_options)
@@ -1325,7 +1321,7 @@ impl JsonRpcRequestProcessor {
                 .highest_super_majority_root()
         {
             let result = self.blockstore.get_rooted_block_time(slot);
-            self.check_blockstore_bounds(&result, slot)?;
+            self.map_get_rooted_blockstore_result(&result, slot)?;
             if result.is_err() {
                 if let Some(bigtable_ledger_storage) = &self.bigtable_ledger_storage {
                     let bigtable_result = bigtable_ledger_storage.get_confirmed_block(slot).await;


### PR DESCRIPTION
#### Problem
The `getBlock` and `getBlockTime` methods perform several checks to return a proper error when commitment level `finalized` is passed. Currently, most of these checks occur within the underlying `Blockstore` methods, but one of these checks occurs in `rpc.rs`. It would be better to have all of the checks in the same location.

#### Summary of Changes
Move the logic that checks whether a requested slot exceeds the `Blockstore`'s maximum root from `JsonRpcRequestProcessor` to `Blockstore`. The result is that the previous function in `JsonRpcRequestProcessor` simply translates `BlockstoreError` to the appropriate RPC error type.

This is a spin out from https://github.com/solana-labs/solana/pull/33901#discussion_r1384282511.
