### PR TITLE
Replaces `bv` with `bit-vec` in bucket_map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5541,7 +5541,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.18.0"
 dependencies = [
- "bv",
+ "bit-vec",
  "bytemuck",
  "fs_extra",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ backoff = "0.4.0"
 base64 = "0.21.5"
 bincode = "1.3.3"
 bitflags = { version = "2.3.3", features = ["serde"] }
+bit-vec = "0.6.3"
 blake3 = "1.5.0"
 block-buffer = "0.10.4"
 borsh = "0.10.3"

--- a/bucket_map/Cargo.toml
+++ b/bucket_map/Cargo.toml
@@ -11,7 +11,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-bv = { workspace = true, features = ["serde"] }
+bit-vec = { workspace = true }
 bytemuck = { workspace = true, features = ["derive"] }
 log = { workspace = true }
 memmap2 = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -583,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,7 +4806,7 @@ dependencies = [
 name = "solana-bucket-map"
 version = "1.18.0"
 dependencies = [
- "bv",
+ "bit-vec",
  "bytemuck",
  "log",
  "memmap2",


### PR DESCRIPTION
#### Problem

`bucket_map` uses a BitVec in its index. The BitVec from `bv` is slow[^1]. There are other BitVec crates that are faster. 

[^1]: https://github.com/brooksprumo/bitvec-benchmarking


#### Summary of Changes

Replace `bv` with `bit-vec` for bucket-map