### PR TITLE
Uses IntSet for uncleaned roots during index generation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9408,7 +9408,7 @@ impl AccountsDb {
             // subtract data.len() from accounts_data_len for all old accounts that are in the index twice
             let mut accounts_data_len_dedup_timer =
                 Measure::start("handle accounts data len duplicates");
-            let uncleaned_roots = Mutex::new(HashSet::<Slot>::default());
+            let uncleaned_roots = Mutex::new(IntSet::default());
             if pass == 0 {
                 let accounts_data_len_from_duplicates = unique_pubkeys_by_bin
                     .par_iter()


### PR DESCRIPTION
#### Problem

Index generation identifies uncleaned rooted slots. It puts them in a HashSet. The slot itself is already a unique identifier, and furthermore, there won't be any collisions here. We also don't need cryptographic security for the HashSet. Instead, we can use an IntSet to skip hashing the slot.


#### Summary of Changes

Replace HashSet with IntSet.