### PR TITLE
Uses IntSet for uncleaned slots from visit_duplicate_pubkeys_during_startup()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9501,9 +9501,9 @@ impl AccountsDb {
         pubkeys: &[Pubkey],
         rent_collector: &RentCollector,
         timings: &GenerateIndexTimings,
-    ) -> (u64, HashSet<Slot>) {
+    ) -> (u64, IntSet<Slot>) {
         let mut accounts_data_len_from_duplicates = 0;
-        let mut uncleaned_slots = HashSet::<Slot>::default();
+        let mut uncleaned_slots = IntSet::default();
         let mut removed_rent_paying = 0;
         let mut removed_top_off = 0;
         self.accounts_index.scan(


### PR DESCRIPTION
#### Problem

Similar to #34008, `AccountsDb::visit_duplicate_pubkeys_during_startup()` identifies uncleaned slots. It puts them in a HashSet. The slot itself is already a unique identifier, and furthermore, there won't be any collisions here. We also don't need cryptographic security for the HashSet. Instead, we can use an IntSet to skip hashing the slot.


#### Summary of Changes

Replace HashSet with IntSet.