### PR TITLE
Use AtomicAppendVecId type alias in verify_and_unarchive_snapshot()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -38,7 +38,7 @@ use {
         path::{Path, PathBuf},
         process::ExitStatus,
         str::FromStr,
-        sync::{atomic::AtomicU32, Arc, Mutex},
+        sync::{Arc, Mutex},
         thread::{Builder, JoinHandle},
     },
     tar::{self, Archive},
@@ -1235,7 +1235,11 @@ pub fn verify_and_unarchive_snapshots(
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,
     incremental_snapshot_archive_info: Option<&IncrementalSnapshotArchiveInfo>,
     account_paths: &[PathBuf],
-) -> Result<(UnarchivedSnapshot, Option<UnarchivedSnapshot>, AtomicU32)> {
+) -> Result<(
+    UnarchivedSnapshot,
+    Option<UnarchivedSnapshot>,
+    AtomicAppendVecId,
+)> {
     check_are_snapshots_compatible(
         full_snapshot_archive_info,
         incremental_snapshot_archive_info,


### PR DESCRIPTION
#### Problem

`verify_and_unarchive_snapshots()` returns the next append vec id. There is a type alias for this already, `AtomicAppendVecId`. We already use it *within* the function, but the return type doesn't use it, yet it should.


#### Summary of Changes

Use the alias.