### PR TITLE
Adds documentation to verify_and_unarchive_snapshots()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1230,6 +1230,7 @@ pub struct BankFromDirTimings {
 // From testing, 4 seems to be a sweet spot for ranges of 60M-360M accounts and 16-64 cores. This may need to be tuned later.
 const PARALLEL_UNTAR_READERS_DEFAULT: usize = 4;
 
+/// Unarchives the given full and incremental snapshot archives, as long as they are compatible.
 pub fn verify_and_unarchive_snapshots(
     bank_snapshots_dir: impl AsRef<Path>,
     full_snapshot_archive_info: &FullSnapshotArchiveInfo,


### PR DESCRIPTION
#### Problem

`verify_and_unarchive_snapshots()` doesn't have any documentation. It's a public function, so it probably should.


#### Summary of Changes

Add documentation.