### PR TITLE
Remove deletion of TransactionStatusIndex entries

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2239,12 +2239,8 @@ impl Blockstore {
         if let Some(highest_primary_index_slot) = *w_highest_primary_index_slot {
             if oldest_slot > highest_primary_index_slot {
                 *w_highest_primary_index_slot = None;
-                self.transaction_status_index_cf.delete(0)?;
-                self.transaction_status_index_cf.delete(1)?;
+                self.db.set_clean_slot_0(true);
             }
-        }
-        if w_highest_primary_index_slot.is_none() {
-            self.db.set_clean_slot_0(true);
         }
         Ok(())
     }


### PR DESCRIPTION
#### Problem
These entries are legacy code at this point; however, older release branches (v1.16 and v1.17) require these entries to be present. Also, while it would be nice to clean up these entries immediately, they only occupy a small amount of space so having them linger a little longer isn't a big deal.

#### Summary of Changes
Hold off on deleting these entries until a later point in time.

Funny enough, we've had some churn here:
- https://github.com/solana-labs/solana/pull/33649
    - The `TransactionStatusIndex` entries stopped getting populated at startup
- https://github.com/solana-labs/solana/pull/33668
    - The `TransactionStatusIndex` entries are explicitly deleted during blockstore cleaning via `Blockstore::maybe_cleanup_highest_primary_index_slot()`
- https://github.com/solana-labs/solana/pull/33756
    - The `TransactionStatusIndex` entries are once again populated at startup.
    - However, this PR was developed in parallel to the above one. So, I did not encounter the issue of the entries getting cleaned even tho they were being initialized at startup.

This issue was reported [in Discord by Brooks](https://discord.com/channels/428295358100013066/439194979856809985/1172605782991306752) who was trying to run `v1.17/v1.16 solana-ledger-tool` on a ledger that had been created with master.