### PR TITLE
Fix geyser plugin unload crash

### DIFF
--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -220,8 +220,8 @@ impl GeyserPluginManager {
         let mut current_plugin = self.plugins.remove(idx);
         let current_lib = self.libs.remove(idx);
         current_plugin.on_unload();
-        current_lib.close();
-        drop(current_lib);
+        let result = current_lib.close();
+        info!("Unloading plugin at {} returned result {:?}", idx, result);
     }
 }
 

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -219,10 +219,11 @@ impl GeyserPluginManager {
     fn _drop_plugin(&mut self, idx: usize) {
         let current_lib = self.libs.remove(idx);
         let mut current_plugin = self.plugins.remove(idx);
+        let name = current_plugin.name().to_string();
         current_plugin.on_unload();
         drop(current_plugin);
         drop(current_lib);
-        info!("Unloaded plugin at idx {idx}");
+        info!("Unloaded plugin {name} at idx {idx}");
     }
 }
 

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -218,8 +218,10 @@ impl GeyserPluginManager {
 
     fn _drop_plugin(&mut self, idx: usize) {
         let mut current_plugin = self.plugins.remove(idx);
-        let _current_lib = self.libs.remove(idx);
+        let current_lib = self.libs.remove(idx);
         current_plugin.on_unload();
+        current_lib.close();
+        drop(current_lib);
     }
 }
 

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -217,11 +217,12 @@ impl GeyserPluginManager {
     }
 
     fn _drop_plugin(&mut self, idx: usize) {
-        let mut current_plugin = self.plugins.remove(idx);
         let current_lib = self.libs.remove(idx);
+        let mut current_plugin = self.plugins.remove(idx);
         current_plugin.on_unload();
-        let result = current_lib.close();
-        info!("Unloading plugin at {} returned result {:?}", idx, result);
+        drop(current_plugin);
+        drop(current_lib);
+        info!("Unloaded plugin at idx {idx}");
     }
 }
 


### PR DESCRIPTION
#### Problem

Unloading a simple plugin which does nothing other than creating the GeyserPlugin object is found to be crashing the validator. The reason for the crash is there are two objects when _drop_plugin is called: the Library object and the Box<dyn GeyserPlugin> object. The current implementation drops the library first which already de-allocate the memory under the boxed GeyserPlugin. And when the GeyserPlugin is dropped, it tries to deallocate the memory and cause a segmentation fault.

#### Summary of Changes
Explicit ordering of the drop of Library and Box<dyn GeyserPlugin>: drop the latter explicitly first.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
