### PR TITLE
BP to 1.16 - Scheduler adjusts underpriced transaction consumed CUs 

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -30,7 +30,7 @@ pub enum CommitTransactionDetails {
         executed_units: u64,
         // actual micro-second elapsed for executing the committed transaction
         executed_us: u64,
-        // compute units to add to executed_units to compensate under priced CUs
+        // compute units to add to executed_units to compensate for under priced CUs
         adjust_units: u64,
     },
     NotCommitted,
@@ -199,7 +199,7 @@ impl Committer {
         executed_units: u64,
         executed_us: u64,
     ) -> u64 {
-        // "actual executed units" is consistent cross cluster, but "adjustment" are only based
+        // "actual executed units" is consistent across cluster, but "adjustment" is only based
         // on current leader node. Add a 50% taper to reduce local variance.
         const TAPER: u64 = 2;
         solana_runtime::block_cost_limits::COMPUTE_UNIT_TO_US_RATIO

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -199,6 +199,12 @@ impl Committer {
         executed_units: u64,
         executed_us: u64,
     ) -> u64 {
+        // Some transactions that only have builtin instructions, or vote transactions, do not
+        // consume compute units yet. Let's not to adjust for these type transactions.
+        if executed_units == 0 {
+            return 0;
+        }
+
         // "actual executed units" is consistent across cluster, but "adjustment" is only based
         // on current leader node. Add a 50% taper to reduce local variance.
         const TAPER: u64 = 2;
@@ -248,10 +254,16 @@ mod tests {
             Committer::adjust_executed_units_for_potential_underpricing(0, 0)
         );
 
+        // no adjustment for those consumed 0 CU (builtins, votes etc)
+        assert_eq!(
+            0,
+            Committer::adjust_executed_units_for_potential_underpricing(0, u64::MAX)
+        );
+
         // the case of extreme underpricing
         assert_eq!(
             u64::MAX / 2, // tapered in half
-            Committer::adjust_executed_units_for_potential_underpricing(0, u64::MAX)
+            Committer::adjust_executed_units_for_potential_underpricing(1, u64::MAX)
         );
 
         // No adjustment if executed_units is already MAX

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -25,7 +25,14 @@ use {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CommitTransactionDetails {
-    Committed { compute_units: u64 },
+    Committed {
+        // actual compute units consumed for executing the committed transaction
+        executed_units: u64,
+        // actual micro-second elapsed for executing the committed transaction
+        executed_us: u64,
+        // compute units to add to executed_units to compensate under priced CUs
+        adjust_units: u64,
+    },
     NotCommitted,
 }
 
@@ -106,7 +113,12 @@ impl Committer {
             .iter()
             .map(|execution_result| match execution_result.details() {
                 Some(details) => CommitTransactionDetails::Committed {
-                    compute_units: details.executed_units,
+                    executed_units: details.executed_units,
+                    executed_us: details.executed_us,
+                    adjust_units: Self::adjust_executed_units_for_potential_underpricing(
+                        details.executed_units,
+                        details.executed_us,
+                    ),
                 },
                 None => CommitTransactionDetails::NotCommitted,
             })
@@ -175,5 +187,81 @@ impl Committer {
                 batch_transaction_indexes,
             );
         }
+    }
+
+    // If transaction's actual CU/us ratio is below cluster average COMPUTE_UNIT_TO_US_RATIO,
+    // it is likely has been under priced. To prevent extending replay time significantly,
+    // we can pad additional CUs to transaction's actual CUs during packing to compensate
+    // additional executing time it needs.
+    // adjustment is u64 for now, meaning only add more CUs when transactions are under priced,
+    // but not to reduce CU if transactions are over priced.
+    fn adjust_executed_units_for_potential_underpricing(
+        executed_units: u64,
+        executed_us: u64,
+    ) -> u64 {
+        // "actual executed units" is consistent cross cluster, but "adjustment" are only based
+        // on current leader node. Add a 50% taper to reduce local variance.
+        const TAPER: u64 = 2;
+        solana_runtime::block_cost_limits::COMPUTE_UNIT_TO_US_RATIO
+            .saturating_mul(executed_us)
+            .saturating_sub(executed_units)
+            .saturating_div(TAPER)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_adjust_executed_units_for_potential_underpricing() {
+        solana_logger::setup();
+        use solana_runtime::block_cost_limits::COMPUTE_UNIT_TO_US_RATIO;
+
+        let executed_cu = 70;
+
+        // no adjust for over-pricing
+        assert_eq!(
+            0,
+            Committer::adjust_executed_units_for_potential_underpricing(
+                executed_cu,
+                executed_cu / (COMPUTE_UNIT_TO_US_RATIO + 10)
+            )
+        );
+
+        // adjust for under pricing
+        let slow_execution_time = executed_cu / (COMPUTE_UNIT_TO_US_RATIO - 10);
+        let expected_adjustment = ((COMPUTE_UNIT_TO_US_RATIO - executed_cu / slow_execution_time)
+            * slow_execution_time)
+            / 2;
+        assert_eq!(
+            expected_adjustment,
+            Committer::adjust_executed_units_for_potential_underpricing(
+                executed_cu,
+                slow_execution_time
+            )
+        );
+
+        // handle zeros
+        assert_eq!(
+            0,
+            Committer::adjust_executed_units_for_potential_underpricing(0, 0)
+        );
+
+        // the case of extreme underpricing
+        assert_eq!(
+            u64::MAX / 2, // tapered in half
+            Committer::adjust_executed_units_for_potential_underpricing(0, u64::MAX)
+        );
+
+        // No adjustment if executed_units is already MAX
+        assert_eq!(
+            0,
+            Committer::adjust_executed_units_for_potential_underpricing(u64::MAX, u64::MAX)
+        );
+        assert_eq!(
+            0,
+            Committer::adjust_executed_units_for_potential_underpricing(u64::MAX, 0)
+        );
     }
 }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -506,7 +506,7 @@ impl Consumer {
         self.qos_service.accumulate_actual_execute_cu(cu);
         self.qos_service.accumulate_actual_execute_time(us);
 
-        let (committed_cu, adjust_cu, committed_us) =
+        let (committed_cu, committed_us, adjust_cu) =
             Self::accumulate_commit_transactions_result(commit_transactions_result.as_ref().ok());
         self.qos_service
             .accumulate_committed_execute_cu(committed_cu);

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -388,6 +388,7 @@ pub(crate) mod tests {
             )),
             return_data: None,
             executed_units: 0,
+            executed_us: 0,
             accounts_data_len_delta: 0,
         });
 

--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1519,6 +1519,7 @@ mod tests {
                 durable_nonce_fee: nonce.map(DurableNonceFee::from),
                 return_data: None,
                 executed_units: 0,
+                executed_us: 0,
                 accounts_data_len_delta: 0,
             },
             programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4151,6 +4151,7 @@ impl Bank {
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
 
         let mut executed_units = 0u64;
+        let mut executed_us = timings.execute_accessories.process_instructions.total_us;
         let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(self.slot);
         let mut programs_updated_only_for_global_cache = LoadedProgramsForTxBatch::new(self.slot);
         let mut process_message_time = Measure::start("process_message_time");
@@ -4173,6 +4174,11 @@ impl Bank {
             &mut executed_units,
         );
         process_message_time.stop();
+        executed_us = timings
+            .execute_accessories
+            .process_instructions
+            .total_us
+            .saturating_sub(executed_us);
 
         saturating_add_assign!(
             timings.execute_accessories.process_message_us,
@@ -4282,7 +4288,7 @@ impl Bank {
                 durable_nonce_fee,
                 return_data,
                 executed_units,
-                executed_us: timings.execute_accessories.process_instructions.total_us,
+                executed_us,
                 accounts_data_len_delta,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -303,6 +303,7 @@ pub struct TransactionExecutionDetails {
     pub durable_nonce_fee: Option<DurableNonceFee>,
     pub return_data: Option<TransactionReturnData>,
     pub executed_units: u64,
+    pub executed_us: u64,
     /// The change in accounts data len for this transaction.
     /// NOTE: This value is valid IFF `status` is `Ok`.
     pub accounts_data_len_delta: i64,
@@ -4281,6 +4282,7 @@ impl Bank {
                 durable_nonce_fee,
                 return_data,
                 executed_units,
+                executed_us: timings.execute_accessories.process_instructions.total_us,
                 accounts_data_len_delta,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -170,6 +170,7 @@ fn new_execution_result(
             durable_nonce_fee: nonce.map(DurableNonceFee::from),
             return_data: None,
             executed_units: 0,
+            executed_us: 0,
             accounts_data_len_delta: 0,
         },
         programs_modified_by_tx: Box::<LoadedProgramsForTxBatch>::default(),


### PR DESCRIPTION
#### Problem
cherry-pick #33914 to 1.16 for canary

#### Summary of Changes
- Scheduler adjusts underpriced transaction consumed CUs
- update consumer test
- add test for adjustment
- refactor to add adjust_units to CommitTransactionDetails::Committed; Reprots committed details to metrics
- fix merge


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
