### PR TITLE
[TieredStorage] HotStorageReader::get_account_offset

### DIFF
--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -30,7 +30,7 @@ pub struct AccountOffset {
 /// This can be used to obtain the AccountOffset and address by looking through
 /// the accounts index block.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct IndexOffset(usize);
+pub struct IndexOffset(pub usize);
 
 /// The index format of a tiered accounts file.
 #[repr(u16)]


### PR DESCRIPTION
#### Problem
HotStorageReader currently not yet has an API to obtain account_offset

#### Summary of Changes
This PR adds HotStorageReader::get_account_offset() which takes
IndexOffset and returns AccountOffset.


#### Test Plan
A new unit-test is included in this PR.
