### PR TITLE
[zk-token-sdk] Re-organize error types

### DIFF
--- a/zk-token-sdk/src/encryption/auth_encryption.rs
+++ b/zk-token-sdk/src/encryption/auth_encryption.rs
@@ -52,6 +52,8 @@ pub enum AuthenticatedEncryptionError {
     SeedLengthTooShort,
     #[error("seed length too long for derivation")]
     SeedLengthTooLong,
+    #[error("failed to deserialize")]
+    Deserialization,
 }
 
 struct AuthenticatedEncryption;

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -78,6 +78,10 @@ pub enum ElGamalError {
     SeedLengthTooShort,
     #[error("seed length too long for derivation")]
     SeedLengthTooLong,
+    #[error("failed to deserialize ciphertext")]
+    CiphertextDeserialization,
+    #[error("failed to deserialize public key")]
+    PubkeyDeserialization,
 }
 
 /// Algorithm handle for the twisted ElGamal encryption scheme

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -10,11 +10,11 @@ use {
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ProofGenerationError {
-    #[error("proof generation failed")]
+    #[error("not enough funds in account")]
     NotEnoughFunds,
     #[error("transfer fee calculation error")]
     FeeCalculation,
-    #[error("illegal number of commitment")]
+    #[error("illegal number of commitments")]
     IllegalCommitmentLength,
     #[error("illegal amount bit length")]
     IllegalAmountBitLength,

--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -1,55 +1,50 @@
 //! Errors related to proving and verifying proofs.
 use {
-    crate::{range_proof::errors::RangeProofError, sigma_proofs::errors::*},
+    crate::{
+        encryption::elgamal::ElGamalError,
+        range_proof::errors::{RangeProofGenerationError, RangeProofVerificationError},
+        sigma_proofs::errors::*,
+    },
     thiserror::Error,
 };
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ProofError {
-    #[error("invalid transfer amount range")]
-    TransferAmount,
+pub enum ProofGenerationError {
     #[error("proof generation failed")]
-    Generation,
-    #[error("proof verification failed")]
-    VerificationError(ProofType, ProofVerificationError),
-    #[error("failed to decrypt ciphertext")]
-    Decryption,
-    #[error("invalid ciphertext data")]
-    CiphertextDeserialization,
-    #[error("invalid pubkey data")]
-    PubkeyDeserialization,
-    #[error("ciphertext does not exist in instruction data")]
-    MissingCiphertext,
+    NotEnoughFunds,
+    #[error("transfer fee calculation error")]
+    FeeCalculation,
+    #[error("illegal number of commitment")]
+    IllegalCommitmentLength,
+    #[error("illegal amount bit length")]
+    IllegalAmountBitLength,
+    #[error("invalid commitment")]
+    InvalidCommitment,
+    #[error("range proof generation failed")]
+    RangeProof(#[from] RangeProofGenerationError),
+    #[error("unexpected proof length")]
+    ProofLength,
+}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum ProofVerificationError {
+    #[error("range proof verification failed")]
+    RangeProof(#[from] RangeProofVerificationError),
+    #[error("sigma proof verification failed")]
+    SigmaProof(SigmaProofType, SigmaProofVerificationError),
+    #[error("ElGamal ciphertext or public key error")]
+    ElGamal(#[from] ElGamalError),
+    #[error("Invalid proof context")]
+    ProofContext,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum ProofType {
+pub enum SigmaProofType {
     EqualityProof,
     ValidityProof,
     ZeroBalanceProof,
     FeeSigmaProof,
     PubkeyValidityProof,
-    RangeProof,
-}
-
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
-pub enum ProofVerificationError {
-    #[error("required algebraic relation does not hold")]
-    AlgebraicRelation,
-    #[error("malformed proof")]
-    Deserialization,
-    #[error("multiscalar multiplication failed")]
-    MultiscalarMul,
-    #[error("transcript failed to produce a challenge")]
-    Transcript(#[from] TranscriptError),
-    #[error(
-        "attempted to verify range proof with a non-power-of-two bit size or bit size is too big"
-    )]
-    InvalidBitSize,
-    #[error("insufficient generators for the proof")]
-    InvalidGeneratorsLength,
-    #[error("number of blinding factors do not match the number of values")]
-    WrongNumBlindingFactors,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
@@ -58,37 +53,31 @@ pub enum TranscriptError {
     ValidationError,
 }
 
-impl From<RangeProofError> for ProofError {
-    fn from(err: RangeProofError) -> Self {
-        Self::VerificationError(ProofType::RangeProof, err.0)
+impl From<EqualityProofVerificationError> for ProofVerificationError {
+    fn from(err: EqualityProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::EqualityProof, err.0)
     }
 }
 
-impl From<EqualityProofError> for ProofError {
-    fn from(err: EqualityProofError) -> Self {
-        Self::VerificationError(ProofType::EqualityProof, err.0)
+impl From<FeeSigmaProofVerificationError> for ProofVerificationError {
+    fn from(err: FeeSigmaProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::FeeSigmaProof, err.0)
     }
 }
 
-impl From<FeeSigmaProofError> for ProofError {
-    fn from(err: FeeSigmaProofError) -> Self {
-        Self::VerificationError(ProofType::FeeSigmaProof, err.0)
+impl From<ZeroBalanceProofVerificationError> for ProofVerificationError {
+    fn from(err: ZeroBalanceProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::ZeroBalanceProof, err.0)
+    }
+}
+impl From<ValidityProofVerificationError> for ProofVerificationError {
+    fn from(err: ValidityProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::ValidityProof, err.0)
     }
 }
 
-impl From<ZeroBalanceProofError> for ProofError {
-    fn from(err: ZeroBalanceProofError) -> Self {
-        Self::VerificationError(ProofType::ZeroBalanceProof, err.0)
-    }
-}
-impl From<ValidityProofError> for ProofError {
-    fn from(err: ValidityProofError) -> Self {
-        Self::VerificationError(ProofType::ValidityProof, err.0)
-    }
-}
-
-impl From<PubkeyValidityProofError> for ProofError {
-    fn from(err: PubkeyValidityProofError) -> Self {
-        Self::VerificationError(ProofType::PubkeyValidityProof, err.0)
+impl From<PubkeyValidityProofVerificationError> for ProofVerificationError {
+    fn from(err: PubkeyValidityProofVerificationError) -> Self {
+        Self::SigmaProof(SigmaProofType::PubkeyValidityProof, err.0)
     }
 }

--- a/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity.rs
+++ b/zk-token-sdk/src/instruction/batched_grouped_ciphertext_validity.rs
@@ -19,7 +19,7 @@ use {
             elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext,
             pedersen::PedersenOpening,
         },
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::batched_grouped_ciphertext_validity_proof::BatchedGroupedCiphertext2HandlesValidityProof,
         transcript::TranscriptProtocol,
     },
@@ -69,7 +69,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProofData {
         amount_hi: u64,
         opening_lo: &PedersenOpening,
         opening_hi: &PedersenOpening,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let pod_destination_pubkey = pod::ElGamalPubkey(destination_pubkey.to_bytes());
         let pod_auditor_pubkey = pod::ElGamalPubkey(auditor_pubkey.to_bytes());
         let pod_grouped_ciphertext_lo = (*grouped_ciphertext_lo).into();
@@ -106,7 +106,7 @@ impl ZkProofData<BatchedGroupedCiphertext2HandlesValidityProofContext>
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
         let destination_pubkey = self.context.destination_pubkey.try_into()?;

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -4,7 +4,7 @@
 use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         range_proof::RangeProof,
     },
     std::convert::TryInto,
@@ -42,21 +42,23 @@ impl BatchedRangeProofU256Data {
         amounts: Vec<u64>,
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         // the sum of the bit lengths must be 64
         let batched_bit_length = bit_lengths
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))
-            .ok_or(ProofError::Generation)?;
+            .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
         if batched_bit_length != BATCHED_RANGE_PROOF_U256_BIT_LENGTH {
-            return Err(ProofError::Generation);
+            return Err(ProofGenerationError::IllegalAmountBitLength);
         }
 
         let context =
             BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
 
         let mut transcript = context.new_transcript();
-        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript).try_into()?;
+        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
+            .try_into()
+            .map_err(|_| ProofGenerationError::ProofLength)?;
 
         Ok(Self { context, proof })
     }
@@ -70,7 +72,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let (commitments, bit_lengths) = self.context.try_into()?;
         let mut transcript = self.context_data().new_transcript();
         let proof: RangeProof = self.proof.try_into()?;
@@ -86,8 +88,8 @@ mod test {
     use {
         super::*,
         crate::{
-            encryption::pedersen::Pedersen,
-            errors::{ProofType, ProofVerificationError},
+            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            range_proof::errors::RangeProofVerificationError,
         },
     };
 
@@ -177,10 +179,7 @@ mod test {
 
         assert_eq!(
             proof_data.verify_proof().unwrap_err(),
-            ProofError::VerificationError(
-                ProofType::RangeProof,
-                ProofVerificationError::AlgebraicRelation
-            ),
+            ProofVerificationError::RangeProof(RangeProofVerificationError::AlgebraicRelation),
         );
     }
 }

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u64.rs
@@ -4,7 +4,7 @@
 use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         range_proof::RangeProof,
     },
     std::convert::TryInto,
@@ -39,26 +39,28 @@ impl BatchedRangeProofU64Data {
         amounts: Vec<u64>,
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         // the sum of the bit lengths must be 64
         let batched_bit_length = bit_lengths
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))
-            .ok_or(ProofError::Generation)?;
+            .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
 
         // `u64::BITS` is 64, which fits in a single byte and should not overflow to `usize` for an
         // overwhelming number of platforms. However, to be extra cautious, use `try_from` and
         // `unwrap` here. A simple case `u64::BITS as usize` can silently overflow.
         let expected_bit_length = usize::try_from(u64::BITS).unwrap();
         if batched_bit_length != expected_bit_length {
-            return Err(ProofError::Generation);
+            return Err(ProofGenerationError::IllegalAmountBitLength);
         }
 
         let context =
             BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
 
         let mut transcript = context.new_transcript();
-        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript).try_into()?;
+        let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
+            .try_into()
+            .map_err(|_| ProofGenerationError::ProofLength)?;
 
         Ok(Self { context, proof })
     }
@@ -72,7 +74,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU64Data {
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let (commitments, bit_lengths) = self.context.try_into()?;
         let mut transcript = self.context_data().new_transcript();
         let proof: RangeProof = self.proof.try_into()?;
@@ -88,8 +90,8 @@ mod test {
     use {
         super::*,
         crate::{
-            encryption::pedersen::Pedersen,
-            errors::{ProofType, ProofVerificationError},
+            encryption::pedersen::Pedersen, errors::ProofVerificationError,
+            range_proof::errors::RangeProofVerificationError,
         },
     };
 
@@ -179,10 +181,7 @@ mod test {
 
         assert_eq!(
             proof_data.verify_proof().unwrap_err(),
-            ProofError::VerificationError(
-                ProofType::RangeProof,
-                ProofVerificationError::AlgebraicRelation
-            ),
+            ProofVerificationError::RangeProof(RangeProofVerificationError::AlgebraicRelation),
         );
     }
 }

--- a/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_ciphertext_equality.rs
@@ -15,7 +15,7 @@ use {
             elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
             pedersen::PedersenOpening,
         },
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::ciphertext_ciphertext_equality_proof::CiphertextCiphertextEqualityProof,
         transcript::TranscriptProtocol,
     },
@@ -65,7 +65,7 @@ impl CiphertextCiphertextEqualityProofData {
         destination_ciphertext: &ElGamalCiphertext,
         destination_opening: &PedersenOpening,
         amount: u64,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let pod_source_pubkey = pod::ElGamalPubkey(source_keypair.pubkey().to_bytes());
         let pod_destination_pubkey = pod::ElGamalPubkey(destination_pubkey.to_bytes());
         let pod_source_ciphertext = pod::ElGamalCiphertext(source_ciphertext.to_bytes());
@@ -104,7 +104,7 @@ impl ZkProofData<CiphertextCiphertextEqualityProofContext>
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
         let source_pubkey = self.context.source_pubkey.try_into()?;

--- a/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
+++ b/zk-token-sdk/src/instruction/ciphertext_commitment_equality.rs
@@ -12,7 +12,7 @@ use {
             elgamal::{ElGamalCiphertext, ElGamalKeypair},
             pedersen::{PedersenCommitment, PedersenOpening},
         },
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::ciphertext_commitment_equality_proof::CiphertextCommitmentEqualityProof,
         transcript::TranscriptProtocol,
     },
@@ -60,7 +60,7 @@ impl CiphertextCommitmentEqualityProofData {
         commitment: &PedersenCommitment,
         opening: &PedersenOpening,
         amount: u64,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let context = CiphertextCommitmentEqualityProofContext {
             pubkey: pod::ElGamalPubkey(keypair.pubkey().to_bytes()),
             ciphertext: pod::ElGamalCiphertext(ciphertext.to_bytes()),
@@ -91,7 +91,7 @@ impl ZkProofData<CiphertextCommitmentEqualityProofContext>
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
         let pubkey = self.context.pubkey.try_into()?;

--- a/zk-token-sdk/src/instruction/errors.rs
+++ b/zk-token-sdk/src/instruction/errors.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum InstructionError {
+    #[error("decryption error")]
+    Decryption,
+    #[error("missing ciphertext")]
+    MissingCiphertext,
+}

--- a/zk-token-sdk/src/instruction/errors.rs
+++ b/zk-token-sdk/src/instruction/errors.rs
@@ -1,6 +1,8 @@
+#[cfg(not(target_os = "solana"))]
 use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
+#[cfg(not(target_os = "solana"))]
 pub enum InstructionError {
     #[error("decryption error")]
     Decryption,

--- a/zk-token-sdk/src/instruction/fee_sigma.rs
+++ b/zk-token-sdk/src/instruction/fee_sigma.rs
@@ -12,7 +12,7 @@
 use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::fee_proof::FeeSigmaProof,
         transcript::TranscriptProtocol,
     },
@@ -72,7 +72,7 @@ impl FeeSigmaProofData {
         fee_amount: u64,
         delta_fee: u64,
         max_fee: u64,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let pod_fee_commitment = pod::PedersenCommitment(fee_commitment.to_bytes());
         let pod_delta_commitment = pod::PedersenCommitment(delta_commitment.to_bytes());
         let pod_claimed_commitment = pod::PedersenCommitment(claimed_commitment.to_bytes());
@@ -108,7 +108,7 @@ impl ZkProofData<FeeSigmaProofContext> for FeeSigmaProofData {
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
         let fee_commitment = self.context.fee_commitment.try_into()?;

--- a/zk-token-sdk/src/instruction/grouped_ciphertext_validity.rs
+++ b/zk-token-sdk/src/instruction/grouped_ciphertext_validity.rs
@@ -17,7 +17,7 @@ use {
             elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext,
             pedersen::PedersenOpening,
         },
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::grouped_ciphertext_validity_proof::GroupedCiphertext2HandlesValidityProof,
         transcript::TranscriptProtocol,
     },
@@ -62,7 +62,7 @@ impl GroupedCiphertext2HandlesValidityProofData {
         grouped_ciphertext: &GroupedElGamalCiphertext<2>,
         amount: u64,
         opening: &PedersenOpening,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let pod_destination_pubkey = pod::ElGamalPubkey(destination_pubkey.to_bytes());
         let pod_auditor_pubkey = pod::ElGamalPubkey(auditor_pubkey.to_bytes());
         let pod_grouped_ciphertext = (*grouped_ciphertext).into();
@@ -97,7 +97,7 @@ impl ZkProofData<GroupedCiphertext2HandlesValidityProofContext>
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
 
         let destination_pubkey = self.context.destination_pubkey.try_into()?;

--- a/zk-token-sdk/src/instruction/mod.rs
+++ b/zk-token-sdk/src/instruction/mod.rs
@@ -6,6 +6,7 @@ pub mod batched_grouped_ciphertext_validity;
 pub mod batched_range_proof;
 pub mod ciphertext_ciphertext_equality;
 pub mod ciphertext_commitment_equality;
+pub mod errors;
 pub mod fee_sigma;
 pub mod grouped_ciphertext_validity;
 pub mod pubkey_validity;
@@ -15,7 +16,7 @@ pub mod withdraw;
 pub mod zero_balance;
 
 #[cfg(not(target_os = "solana"))]
-use crate::errors::ProofError;
+use crate::errors::ProofVerificationError;
 use num_derive::{FromPrimitive, ToPrimitive};
 pub use {
     batched_grouped_ciphertext_validity::{
@@ -75,5 +76,5 @@ pub trait ZkProofData<T: Pod> {
     fn context_data(&self) -> &T;
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError>;
+    fn verify_proof(&self) -> Result<(), ProofVerificationError>;
 }

--- a/zk-token-sdk/src/instruction/pubkey_validity.rs
+++ b/zk-token-sdk/src/instruction/pubkey_validity.rs
@@ -8,8 +8,10 @@
 #[cfg(not(target_os = "solana"))]
 use {
     crate::{
-        encryption::elgamal::ElGamalKeypair, errors::ProofError,
-        sigma_proofs::pubkey_proof::PubkeyValidityProof, transcript::TranscriptProtocol,
+        encryption::elgamal::ElGamalKeypair,
+        errors::{ProofGenerationError, ProofVerificationError},
+        sigma_proofs::pubkey_proof::PubkeyValidityProof,
+        transcript::TranscriptProtocol,
     },
     merlin::Transcript,
     std::convert::TryInto,
@@ -47,7 +49,7 @@ pub struct PubkeyValidityProofContext {
 
 #[cfg(not(target_os = "solana"))]
 impl PubkeyValidityData {
-    pub fn new(keypair: &ElGamalKeypair) -> Result<Self, ProofError> {
+    pub fn new(keypair: &ElGamalKeypair) -> Result<Self, ProofGenerationError> {
         let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().to_bytes());
 
         let context = PubkeyValidityProofContext { pubkey: pod_pubkey };
@@ -67,7 +69,7 @@ impl ZkProofData<PubkeyValidityProofContext> for PubkeyValidityData {
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
         let pubkey = self.context.pubkey.try_into()?;
         let proof: PubkeyValidityProof = self.proof.try_into()?;

--- a/zk-token-sdk/src/instruction/zero_balance.rs
+++ b/zk-token-sdk/src/instruction/zero_balance.rs
@@ -8,7 +8,7 @@
 use {
     crate::{
         encryption::elgamal::{ElGamalCiphertext, ElGamalKeypair},
-        errors::ProofError,
+        errors::{ProofGenerationError, ProofVerificationError},
         sigma_proofs::zero_balance_proof::ZeroBalanceProof,
         transcript::TranscriptProtocol,
     },
@@ -53,7 +53,7 @@ impl ZeroBalanceProofData {
     pub fn new(
         keypair: &ElGamalKeypair,
         ciphertext: &ElGamalCiphertext,
-    ) -> Result<Self, ProofError> {
+    ) -> Result<Self, ProofGenerationError> {
         let pod_pubkey = pod::ElGamalPubkey(keypair.pubkey().to_bytes());
         let pod_ciphertext = pod::ElGamalCiphertext(ciphertext.to_bytes());
 
@@ -77,7 +77,7 @@ impl ZkProofData<ZeroBalanceProofContext> for ZeroBalanceProofData {
     }
 
     #[cfg(not(target_os = "solana"))]
-    fn verify_proof(&self) -> Result<(), ProofError> {
+    fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let mut transcript = self.context.new_transcript();
         let pubkey = self.context.pubkey.try_into()?;
         let ciphertext = self.context.ciphertext.try_into()?;

--- a/zk-token-sdk/src/macros.rs
+++ b/zk-token-sdk/src/macros.rs
@@ -74,13 +74,3 @@ macro_rules! define_mul_variants {
         }
     };
 }
-
-macro_rules! impl_from_transcript_error {
-    ($sigma_error_type:ty) => {
-        impl From<TranscriptError> for $sigma_error_type {
-            fn from(err: TranscriptError) -> Self {
-                ProofVerificationError::Transcript(err).into()
-            }
-        }
-    };
-}

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -1,10 +1,23 @@
 //! Errors related to proving and verifying range proofs.
-use {
-    crate::errors::{ProofVerificationError, TranscriptError},
-    thiserror::Error,
-};
+use {crate::errors::TranscriptError, thiserror::Error};
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
-#[error("range proof verification failed: {0}")]
-pub struct RangeProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(RangeProofError);
+pub enum RangeProofGenerationError {}
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum RangeProofVerificationError {
+    #[error("required algebraic relation does not hold")]
+    AlgebraicRelation,
+    #[error("malformed proof")]
+    Deserialization,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMul,
+    #[error("transcript failed to produce a challenge")]
+    Transcript(#[from] TranscriptError),
+    #[error(
+        "attempted to verify range proof with a non-power-of-two bit size or bit size is too big"
+    )]
+    InvalidBitSize,
+    #[error("insufficient generators for the proof")]
+    InvalidGeneratorsLength,
+}

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
-        errors::ProofVerificationError,
-        range_proof::{errors::RangeProofError, util},
+        range_proof::{errors::RangeProofVerificationError, util},
         transcript::TranscriptProtocol,
     },
     core::iter,
@@ -204,15 +203,15 @@ impl InnerProductProof {
         &self,
         n: usize,
         transcript: &mut Transcript,
-    ) -> Result<(Vec<Scalar>, Vec<Scalar>, Vec<Scalar>), RangeProofError> {
+    ) -> Result<(Vec<Scalar>, Vec<Scalar>, Vec<Scalar>), RangeProofVerificationError> {
         let lg_n = self.L_vec.len();
         if lg_n >= 32 {
             // 4 billion multiplications should be enough for anyone
             // and this check prevents overflow in 1<<lg_n below.
-            return Err(ProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize.into());
         }
         if n != (1 << lg_n) {
-            return Err(ProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize.into());
         }
 
         transcript.innerproduct_domain_separator(n as u64);
@@ -270,7 +269,7 @@ impl InnerProductProof {
         G: &[RistrettoPoint],
         H: &[RistrettoPoint],
         transcript: &mut Transcript,
-    ) -> Result<(), RangeProofError>
+    ) -> Result<(), RangeProofVerificationError>
     where
         IG: IntoIterator,
         IG::Item: Borrow<Scalar>,
@@ -301,7 +300,7 @@ impl InnerProductProof {
             .iter()
             .map(|p| {
                 p.decompress()
-                    .ok_or(ProofVerificationError::Deserialization)
+                    .ok_or(RangeProofVerificationError::Deserialization)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -310,7 +309,7 @@ impl InnerProductProof {
             .iter()
             .map(|p| {
                 p.decompress()
-                    .ok_or(ProofVerificationError::Deserialization)
+                    .ok_or(RangeProofVerificationError::Deserialization)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -330,7 +329,7 @@ impl InnerProductProof {
         if expect_P == *P {
             Ok(())
         } else {
-            Err(ProofVerificationError::AlgebraicRelation.into())
+            Err(RangeProofVerificationError::AlgebraicRelation.into())
         }
     }
 
@@ -364,21 +363,21 @@ impl InnerProductProof {
     /// * \\(n\\) is larger or equal to 32 (proof is too big),
     /// * any of \\(2n\\) points are not valid compressed Ristretto points,
     /// * any of 2 scalars are not canonical scalars modulo Ristretto group order.
-    pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, RangeProofError> {
+    pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, RangeProofVerificationError> {
         let b = slice.len();
         if b % 32 != 0 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
         let num_elements = b / 32;
         if num_elements < 2 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
         if (num_elements - 2) % 2 != 0 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
         let lg_n = (num_elements - 2) / 2;
         if lg_n >= 32 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
 
         let mut L_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);
@@ -391,9 +390,9 @@ impl InnerProductProof {
 
         let pos = 2 * lg_n * 32;
         let a = Scalar::from_canonical_bytes(util::read32(&slice[pos..]))
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(RangeProofVerificationError::Deserialization)?;
         let b = Scalar::from_canonical_bytes(util::read32(&slice[pos + 32..]))
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(RangeProofVerificationError::Deserialization)?;
 
         Ok(InnerProductProof { L_vec, R_vec, a, b })
     }

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -208,10 +208,10 @@ impl InnerProductProof {
         if lg_n >= 32 {
             // 4 billion multiplications should be enough for anyone
             // and this check prevents overflow in 1<<lg_n below.
-            return Err(RangeProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize);
         }
         if n != (1 << lg_n) {
-            return Err(RangeProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize);
         }
 
         transcript.innerproduct_domain_separator(n as u64);
@@ -329,7 +329,7 @@ impl InnerProductProof {
         if expect_P == *P {
             Ok(())
         } else {
-            Err(RangeProofVerificationError::AlgebraicRelation.into())
+            Err(RangeProofVerificationError::AlgebraicRelation)
         }
     }
 
@@ -366,18 +366,18 @@ impl InnerProductProof {
     pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, RangeProofVerificationError> {
         let b = slice.len();
         if b % 32 != 0 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
         let num_elements = b / 32;
         if num_elements < 2 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
         if (num_elements - 2) % 2 != 0 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
         let lg_n = (num_elements - 2) / 2;
         if lg_n >= 32 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
 
         let mut L_vec: Vec<CompressedRistretto> = Vec::with_capacity(lg_n);

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -20,9 +20,10 @@ use {
 use {
     crate::{
         encryption::pedersen::{G, H},
-        errors::ProofVerificationError,
         range_proof::{
-            errors::RangeProofError, generators::BulletproofGens, inner_product::InnerProductProof,
+            errors::{RangeProofGenerationError, RangeProofVerificationError},
+            generators::BulletproofGens,
+            inner_product::InnerProductProof,
         },
         transcript::TranscriptProtocol,
     },
@@ -71,7 +72,7 @@ impl RangeProof {
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
         transcript: &mut Transcript,
-    ) -> Self {
+    ) -> Result<Self, RangeProofGenerationError> {
         // amounts, bit-lengths, openings must be same length vectors
         let m = amounts.len();
         assert_eq!(bit_lengths.len(), m);
@@ -216,7 +217,7 @@ impl RangeProof {
             transcript,
         );
 
-        RangeProof {
+        Ok(RangeProof {
             A,
             S,
             T_1,
@@ -225,7 +226,7 @@ impl RangeProof {
             t_x_blinding,
             e_blinding,
             ipp_proof,
-        }
+        })
     }
 
     #[allow(clippy::many_single_char_names)]
@@ -234,7 +235,7 @@ impl RangeProof {
         comms: Vec<&PedersenCommitment>,
         bit_lengths: Vec<usize>,
         transcript: &mut Transcript,
-    ) -> Result<(), RangeProofError> {
+    ) -> Result<(), RangeProofVerificationError> {
         // commitments and bit-lengths must be same length vectors
         assert_eq!(comms.len(), bit_lengths.len());
 
@@ -243,7 +244,7 @@ impl RangeProof {
         let bp_gens = BulletproofGens::new(nm);
 
         if !nm.is_power_of_two() {
-            return Err(ProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize.into());
         }
 
         // append proof data to transcript and derive appropriate challenge scalars
@@ -320,12 +321,12 @@ impl RangeProof {
                 .chain(bp_gens.H(nm).map(|&x| Some(x)))
                 .chain(comms.iter().map(|V| Some(*V.get_point()))),
         )
-        .ok_or(ProofVerificationError::MultiscalarMul)?;
+        .ok_or(RangeProofVerificationError::MultiscalarMul)?;
 
         if mega_check.is_identity() {
             Ok(())
         } else {
-            Err(ProofVerificationError::AlgebraicRelation.into())
+            Err(RangeProofVerificationError::AlgebraicRelation.into())
         }
     }
 
@@ -346,12 +347,12 @@ impl RangeProof {
 
     // Following the dalek rangeproof library signature for now. The exact method signature can be
     // changed.
-    pub fn from_bytes(slice: &[u8]) -> Result<RangeProof, RangeProofError> {
+    pub fn from_bytes(slice: &[u8]) -> Result<RangeProof, RangeProofVerificationError> {
         if slice.len() % 32 != 0 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
         if slice.len() < 7 * 32 {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
 
         let A = CompressedRistretto(util::read32(&slice[0..]));
@@ -360,11 +361,11 @@ impl RangeProof {
         let T_2 = CompressedRistretto(util::read32(&slice[3 * 32..]));
 
         let t_x = Scalar::from_canonical_bytes(util::read32(&slice[4 * 32..]))
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(RangeProofVerificationError::Deserialization)?;
         let t_x_blinding = Scalar::from_canonical_bytes(util::read32(&slice[5 * 32..]))
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(RangeProofVerificationError::Deserialization)?;
         let e_blinding = Scalar::from_canonical_bytes(util::read32(&slice[6 * 32..]))
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(RangeProofVerificationError::Deserialization)?;
 
         let ipp_proof = InnerProductProof::from_bytes(&slice[7 * 32..])?;
 
@@ -410,7 +411,8 @@ mod tests {
         let mut transcript_create = Transcript::new(b"Test");
         let mut transcript_verify = Transcript::new(b"Test");
 
-        let proof = RangeProof::new(vec![55], vec![32], vec![&open], &mut transcript_create);
+        let proof =
+            RangeProof::new(vec![55], vec![32], vec![&open], &mut transcript_create).unwrap();
 
         assert!(proof
             .verify(vec![&comm], vec![32], &mut transcript_verify)
@@ -431,7 +433,8 @@ mod tests {
             vec![64, 32, 32],
             vec![&open_1, &open_2, &open_3],
             &mut transcript_create,
-        );
+        )
+        .unwrap();
 
         assert!(proof
             .verify(

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -244,7 +244,7 @@ impl RangeProof {
         let bp_gens = BulletproofGens::new(nm);
 
         if !nm.is_power_of_two() {
-            return Err(RangeProofVerificationError::InvalidBitSize.into());
+            return Err(RangeProofVerificationError::InvalidBitSize);
         }
 
         // append proof data to transcript and derive appropriate challenge scalars
@@ -326,7 +326,7 @@ impl RangeProof {
         if mega_check.is_identity() {
             Ok(())
         } else {
-            Err(RangeProofVerificationError::AlgebraicRelation.into())
+            Err(RangeProofVerificationError::AlgebraicRelation)
         }
     }
 
@@ -349,10 +349,10 @@ impl RangeProof {
     // changed.
     pub fn from_bytes(slice: &[u8]) -> Result<RangeProof, RangeProofVerificationError> {
         if slice.len() % 32 != 0 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
         if slice.len() < 7 * 32 {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
 
         let A = CompressedRistretto(util::read32(&slice[0..]));

--- a/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity_proof.rs
@@ -16,7 +16,7 @@ use crate::encryption::{
 use {
     crate::{
         sigma_proofs::{
-            errors::ValidityProofError,
+            errors::ValidityProofVerificationError,
             grouped_ciphertext_validity_proof::GroupedCiphertext2HandlesValidityProof,
         },
         transcript::TranscriptProtocol,
@@ -80,7 +80,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         (destination_handle_lo, destination_handle_hi): (&DecryptHandle, &DecryptHandle),
         (auditor_handle_lo, auditor_handle_hi): (&DecryptHandle, &DecryptHandle),
         transcript: &mut Transcript,
-    ) -> Result<(), ValidityProofError> {
+    ) -> Result<(), ValidityProofVerificationError> {
         transcript.batched_grouped_ciphertext_validity_proof_domain_separator();
 
         let t = transcript.challenge_scalar(b"t");
@@ -103,7 +103,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         self.0.to_bytes()
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidityProofError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ValidityProofVerificationError> {
         GroupedCiphertext2HandlesValidityProof::from_bytes(bytes).map(Self)
     }
 }

--- a/zk-token-sdk/src/sigma_proofs/errors.rs
+++ b/zk-token-sdk/src/sigma_proofs/errors.rs
@@ -1,30 +1,49 @@
 //! Errors related to proving and verifying sigma proofs.
-use {
-    crate::errors::{ProofVerificationError, TranscriptError},
-    thiserror::Error,
-};
+use {crate::errors::TranscriptError, thiserror::Error};
+
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
+pub enum SigmaProofVerificationError {
+    #[error("required algebraic relation does not hold")]
+    AlgebraicRelation,
+    #[error("malformed proof")]
+    Deserialization,
+    #[error("multiscalar multiplication failed")]
+    MultiscalarMul,
+    #[error("transcript failed to produce a challenge")]
+    Transcript(#[from] TranscriptError),
+}
+
+macro_rules! impl_from_transcript_error {
+    ($sigma_error_type:ty) => {
+        impl From<TranscriptError> for $sigma_error_type {
+            fn from(err: TranscriptError) -> Self {
+                SigmaProofVerificationError::Transcript(err).into()
+            }
+        }
+    };
+}
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[error("equality proof verification failed: {0}")]
-pub struct EqualityProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(EqualityProofError);
+pub struct EqualityProofVerificationError(#[from] pub(crate) SigmaProofVerificationError);
+impl_from_transcript_error!(EqualityProofVerificationError);
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[error("validity proof verification failed: {0}")]
-pub struct ValidityProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(ValidityProofError);
+pub struct ValidityProofVerificationError(#[from] pub(crate) SigmaProofVerificationError);
+impl_from_transcript_error!(ValidityProofVerificationError);
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[error("zero-balance proof verification failed: {0}")]
-pub struct ZeroBalanceProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(ZeroBalanceProofError);
+pub struct ZeroBalanceProofVerificationError(#[from] pub(crate) SigmaProofVerificationError);
+impl_from_transcript_error!(ZeroBalanceProofVerificationError);
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[error("fee sigma proof verification failed: {0}")]
-pub struct FeeSigmaProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(FeeSigmaProofError);
+pub struct FeeSigmaProofVerificationError(#[from] pub(crate) SigmaProofVerificationError);
+impl_from_transcript_error!(FeeSigmaProofVerificationError);
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
 #[error("public key validity proof verification failed: {0}")]
-pub struct PubkeyValidityProofError(#[from] pub(crate) ProofVerificationError);
-impl_from_transcript_error!(PubkeyValidityProofError);
+pub struct PubkeyValidityProofVerificationError(#[from] pub(crate) SigmaProofVerificationError);
+impl_from_transcript_error!(PubkeyValidityProofVerificationError);

--- a/zk-token-sdk/src/sigma_proofs/fee_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/fee_proof.rs
@@ -21,7 +21,7 @@ use {
 };
 use {
     crate::{
-        errors::ProofVerificationError, sigma_proofs::errors::FeeSigmaProofError,
+        sigma_proofs::errors::{FeeSigmaProofVerificationError, SigmaProofVerificationError},
         transcript::TranscriptProtocol,
     },
     curve25519_dalek::{
@@ -313,7 +313,7 @@ impl FeeSigmaProof {
         claimed_commitment: &PedersenCommitment,
         max_fee: u64,
         transcript: &mut Transcript,
-    ) -> Result<(), FeeSigmaProofError> {
+    ) -> Result<(), FeeSigmaProofVerificationError> {
         // extract the relevant scalar and Ristretto points from the input
         let m = Scalar::from(max_fee);
 
@@ -329,19 +329,19 @@ impl FeeSigmaProof {
             .fee_max_proof
             .Y_max_proof
             .decompress()
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(SigmaProofVerificationError::Deserialization)?;
         let z_max = self.fee_max_proof.z_max_proof;
 
         let Y_delta_real = self
             .fee_equality_proof
             .Y_delta
             .decompress()
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(SigmaProofVerificationError::Deserialization)?;
         let Y_claimed = self
             .fee_equality_proof
             .Y_claimed
             .decompress()
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(SigmaProofVerificationError::Deserialization)?;
         let z_x = self.fee_equality_proof.z_x;
         let z_delta_real = self.fee_equality_proof.z_delta;
         let z_claimed = self.fee_equality_proof.z_claimed;
@@ -387,7 +387,7 @@ impl FeeSigmaProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(ProofVerificationError::AlgebraicRelation.into())
+            Err(SigmaProofVerificationError::AlgebraicRelation.into())
         }
     }
 
@@ -429,7 +429,7 @@ impl FeeSigmaProof {
         buf
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, FeeSigmaProofError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, FeeSigmaProofVerificationError> {
         let mut chunks = bytes.chunks(UNIT_LEN);
         let Y_max_proof = ristretto_point_from_optional_slice(chunks.next())?;
         let z_max_proof = canonical_scalar_from_optional_slice(chunks.next())?;

--- a/zk-token-sdk/src/sigma_proofs/mod.rs
+++ b/zk-token-sdk/src/sigma_proofs/mod.rs
@@ -16,7 +16,7 @@ pub mod zero_balance_proof;
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::{errors::ProofVerificationError, RISTRETTO_POINT_LEN, SCALAR_LEN},
+    crate::{sigma_proofs::errors::SigmaProofVerificationError, RISTRETTO_POINT_LEN, SCALAR_LEN},
     curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
 };
 
@@ -27,11 +27,11 @@ use {
 #[cfg(not(target_os = "solana"))]
 fn ristretto_point_from_optional_slice(
     optional_slice: Option<&[u8]>,
-) -> Result<CompressedRistretto, ProofVerificationError> {
+) -> Result<CompressedRistretto, SigmaProofVerificationError> {
     optional_slice
         .and_then(|slice| (slice.len() == RISTRETTO_POINT_LEN).then_some(slice))
         .map(CompressedRistretto::from_slice)
-        .ok_or(ProofVerificationError::Deserialization)
+        .ok_or(SigmaProofVerificationError::Deserialization)
 }
 
 /// Deserializes an optional slice of bytes to a scalar.
@@ -41,10 +41,10 @@ fn ristretto_point_from_optional_slice(
 #[cfg(not(target_os = "solana"))]
 fn canonical_scalar_from_optional_slice(
     optional_slice: Option<&[u8]>,
-) -> Result<Scalar, ProofVerificationError> {
+) -> Result<Scalar, SigmaProofVerificationError> {
     optional_slice
         .and_then(|slice| (slice.len() == SCALAR_LEN).then_some(slice)) // if chunk is the wrong length, convert to None
         .and_then(|slice| slice.try_into().ok()) // convert to array
         .and_then(Scalar::from_canonical_bytes)
-        .ok_or(ProofVerificationError::Deserialization)
+        .ok_or(SigmaProofVerificationError::Deserialization)
 }

--- a/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
+++ b/zk-token-sdk/src/sigma_proofs/pubkey_proof.rs
@@ -18,7 +18,7 @@ use {
 };
 use {
     crate::{
-        errors::ProofVerificationError, sigma_proofs::errors::PubkeyValidityProofError,
+        sigma_proofs::errors::{PubkeyValidityProofVerificationError, SigmaProofVerificationError},
         transcript::TranscriptProtocol,
     },
     curve25519_dalek::{
@@ -92,7 +92,7 @@ impl PubkeyValidityProof {
         self,
         elgamal_pubkey: &ElGamalPubkey,
         transcript: &mut Transcript,
-    ) -> Result<(), PubkeyValidityProofError> {
+    ) -> Result<(), PubkeyValidityProofVerificationError> {
         transcript.pubkey_proof_domain_separator();
 
         // extract the relvant scalar and Ristretto points from the input
@@ -106,7 +106,7 @@ impl PubkeyValidityProof {
         let Y = self
             .Y
             .decompress()
-            .ok_or(ProofVerificationError::Deserialization)?;
+            .ok_or(SigmaProofVerificationError::Deserialization)?;
 
         let check = RistrettoPoint::vartime_multiscalar_mul(
             vec![&self.z, &(-&c), &(-&Scalar::one())],
@@ -116,7 +116,7 @@ impl PubkeyValidityProof {
         if check.is_identity() {
             Ok(())
         } else {
-            Err(ProofVerificationError::AlgebraicRelation.into())
+            Err(SigmaProofVerificationError::AlgebraicRelation.into())
         }
     }
 
@@ -128,7 +128,7 @@ impl PubkeyValidityProof {
         buf
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, PubkeyValidityProofError> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, PubkeyValidityProofVerificationError> {
         let mut chunks = bytes.chunks(UNIT_LEN);
         let Y = ristretto_point_from_optional_slice(chunks.next())?;
         let z = canonical_scalar_from_optional_slice(chunks.next())?;

--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -49,7 +49,7 @@ impl From<PodRistrettoPoint> for pod::DecryptHandle {
 mod target_arch {
     use {
         super::pod,
-        crate::{curve25519::scalar::PodScalar, errors::ProofError},
+        crate::{curve25519::scalar::PodScalar, encryption::elgamal::ElGamalError},
         curve25519_dalek::{ristretto::CompressedRistretto, scalar::Scalar},
         std::convert::TryFrom,
     };
@@ -61,10 +61,10 @@ mod target_arch {
     }
 
     impl TryFrom<PodScalar> for Scalar {
-        type Error = ProofError;
+        type Error = ElGamalError;
 
         fn try_from(pod: PodScalar) -> Result<Self, Self::Error> {
-            Scalar::from_canonical_bytes(pod.0).ok_or(ProofError::CiphertextDeserialization)
+            Scalar::from_canonical_bytes(pod.0).ok_or(ElGamalError::CiphertextDeserialization)
         }
     }
 
@@ -101,7 +101,8 @@ mod tests {
         let mut transcript_create = Transcript::new(b"Test");
         let mut transcript_verify = Transcript::new(b"Test");
 
-        let proof = RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create);
+        let proof =
+            RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create).unwrap();
 
         let proof_serialized: pod::RangeProofU64 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
@@ -111,7 +112,8 @@ mod tests {
             .is_ok());
 
         // should fail to serialize to pod::RangeProof128
-        let proof = RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create);
+        let proof =
+            RangeProof::new(vec![55], vec![64], vec![&open], &mut transcript_create).unwrap();
 
         assert!(TryInto::<pod::RangeProofU128>::try_into(proof).is_err());
     }
@@ -130,7 +132,8 @@ mod tests {
             vec![64, 32, 32],
             vec![&open_1, &open_2, &open_3],
             &mut transcript_create,
-        );
+        )
+        .unwrap();
 
         let proof_serialized: pod::RangeProofU128 = proof.try_into().unwrap();
         let proof_deserialized: RangeProof = proof_serialized.try_into().unwrap();
@@ -149,7 +152,8 @@ mod tests {
             vec![64, 32, 32],
             vec![&open_1, &open_2, &open_3],
             &mut transcript_create,
-        );
+        )
+        .unwrap();
 
         assert!(TryInto::<pod::RangeProofU64>::try_into(proof).is_err());
     }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/auth_encryption.rs
@@ -1,7 +1,7 @@
 //! Plain Old Data types for the AES128-GCM-SIV authenticated encryption scheme.
 
 #[cfg(not(target_os = "solana"))]
-use crate::{encryption::auth_encryption as decoded, errors::ProofError};
+use crate::encryption::auth_encryption::{self as decoded, AuthenticatedEncryptionError};
 use {
     crate::zk_token_elgamal::pod::{Pod, Zeroable},
     base64::{prelude::BASE64_STANDARD, Engine},
@@ -49,9 +49,9 @@ impl From<decoded::AeCiphertext> for AeCiphertext {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<AeCiphertext> for decoded::AeCiphertext {
-    type Error = ProofError;
+    type Error = AuthenticatedEncryptionError;
 
     fn try_from(pod_ciphertext: AeCiphertext) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_ciphertext.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_ciphertext.0).ok_or(AuthenticatedEncryptionError::Deserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/elgamal.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::{encryption::elgamal as decoded, errors::ProofError},
+    crate::encryption::elgamal::{self as decoded, ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 use {
@@ -55,10 +55,10 @@ impl From<decoded::ElGamalCiphertext> for ElGamalCiphertext {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<ElGamalCiphertext> for decoded::ElGamalCiphertext {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_ciphertext: ElGamalCiphertext) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_ciphertext.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_ciphertext.0).ok_or(ElGamalError::CiphertextDeserialization)
     }
 }
 
@@ -88,10 +88,10 @@ impl From<decoded::ElGamalPubkey> for ElGamalPubkey {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<ElGamalPubkey> for decoded::ElGamalPubkey {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_pubkey: ElGamalPubkey) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_pubkey.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_pubkey.0).ok_or(ElGamalError::PubkeyDeserialization)
     }
 }
 
@@ -123,9 +123,9 @@ impl From<DecryptHandle> for CompressedRistretto {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<DecryptHandle> for decoded::DecryptHandle {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_handle: DecryptHandle) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_handle.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_handle.0).ok_or(ElGamalError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/grouped_elgamal.rs
@@ -1,7 +1,7 @@
 //! Plain Old Data types for the Grouped ElGamal encryption scheme.
 
 #[cfg(not(target_os = "solana"))]
-use crate::{encryption::grouped_elgamal::GroupedElGamalCiphertext, errors::ProofError};
+use crate::encryption::{elgamal::ElGamalError, grouped_elgamal::GroupedElGamalCiphertext};
 use {
     crate::zk_token_elgamal::pod::{
         elgamal::DECRYPT_HANDLE_LEN, pedersen::PEDERSEN_COMMITMENT_LEN, Pod, Zeroable,
@@ -42,10 +42,10 @@ impl From<GroupedElGamalCiphertext<2>> for GroupedElGamalCiphertext2Handles {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<GroupedElGamalCiphertext2Handles> for GroupedElGamalCiphertext<2> {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_ciphertext: GroupedElGamalCiphertext2Handles) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_ciphertext.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_ciphertext.0).ok_or(ElGamalError::CiphertextDeserialization)
     }
 }
 
@@ -75,9 +75,9 @@ impl From<GroupedElGamalCiphertext<3>> for GroupedElGamalCiphertext3Handles {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<GroupedElGamalCiphertext3Handles> for GroupedElGamalCiphertext<3> {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_ciphertext: GroupedElGamalCiphertext3Handles) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_ciphertext.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_ciphertext.0).ok_or(ElGamalError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/instruction.rs
@@ -3,7 +3,7 @@ use crate::zk_token_elgamal::pod::{
     Zeroable,
 };
 #[cfg(not(target_os = "solana"))]
-use crate::{errors::ProofError, instruction::transfer as decoded};
+use crate::{encryption::elgamal::ElGamalError, instruction::transfer as decoded};
 
 #[derive(Clone, Copy, Pod, Zeroable)]
 #[repr(C)]
@@ -18,7 +18,7 @@ impl From<decoded::TransferAmountCiphertext> for TransferAmountCiphertext {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<TransferAmountCiphertext> for decoded::TransferAmountCiphertext {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_ciphertext: TransferAmountCiphertext) -> Result<Self, Self::Error> {
         Ok(Self(pod_ciphertext.0.try_into()?))
@@ -38,7 +38,7 @@ impl From<decoded::FeeEncryption> for FeeEncryption {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<FeeEncryption> for decoded::FeeEncryption {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_ciphertext: FeeEncryption) -> Result<Self, Self::Error> {
         Ok(Self(pod_ciphertext.0.try_into()?))

--- a/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/pedersen.rs
@@ -2,7 +2,7 @@
 
 #[cfg(not(target_os = "solana"))]
 use {
-    crate::{encryption::pedersen as decoded, errors::ProofError},
+    crate::encryption::{elgamal::ElGamalError, pedersen as decoded},
     curve25519_dalek::ristretto::CompressedRistretto,
 };
 use {
@@ -44,9 +44,9 @@ impl From<PedersenCommitment> for CompressedRistretto {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<PedersenCommitment> for decoded::PedersenCommitment {
-    type Error = ProofError;
+    type Error = ElGamalError;
 
     fn try_from(pod_commitment: PedersenCommitment) -> Result<Self, Self::Error> {
-        Self::from_bytes(&pod_commitment.0).ok_or(ProofError::CiphertextDeserialization)
+        Self::from_bytes(&pod_commitment.0).ok_or(ElGamalError::CiphertextDeserialization)
     }
 }

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -45,7 +45,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU64 {
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U64_LEN {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U64_LEN];
@@ -76,7 +76,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU128 {
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U128_LEN {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U128_LEN];
@@ -107,7 +107,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU256 {
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U256_LEN {
-            return Err(RangeProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization);
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U256_LEN];

--- a/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/range_proof.rs
@@ -2,8 +2,7 @@
 
 #[cfg(not(target_os = "solana"))]
 use crate::{
-    errors::ProofVerificationError,
-    range_proof::{self as decoded, errors::RangeProofError},
+    range_proof::{self as decoded, errors::RangeProofVerificationError},
     UNIT_LEN,
 };
 use crate::{
@@ -42,11 +41,11 @@ pub struct RangeProofU64(pub [u8; RANGE_PROOF_U64_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU64 {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U64_LEN {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U64_LEN];
@@ -59,7 +58,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU64 {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<RangeProofU64> for decoded::RangeProof {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(pod_proof: RangeProofU64) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -73,11 +72,11 @@ pub struct RangeProofU128(pub [u8; RANGE_PROOF_U128_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU128 {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U128_LEN {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U128_LEN];
@@ -90,7 +89,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU128 {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<RangeProofU128> for decoded::RangeProof {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(pod_proof: RangeProofU128) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -104,11 +103,11 @@ pub struct RangeProofU256(pub [u8; RANGE_PROOF_U256_LEN]);
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<decoded::RangeProof> for RangeProofU256 {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(decoded_proof: decoded::RangeProof) -> Result<Self, Self::Error> {
         if decoded_proof.ipp_proof.serialized_size() != INNER_PRODUCT_PROOF_U256_LEN {
-            return Err(ProofVerificationError::Deserialization.into());
+            return Err(RangeProofVerificationError::Deserialization.into());
         }
 
         let mut buf = [0_u8; RANGE_PROOF_U256_LEN];
@@ -121,7 +120,7 @@ impl TryFrom<decoded::RangeProof> for RangeProofU256 {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<RangeProofU256> for decoded::RangeProof {
-    type Error = RangeProofError;
+    type Error = RangeProofVerificationError;
 
     fn try_from(pod_proof: RangeProofU256) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)

--- a/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/pod/sigma_proofs.rs
@@ -47,7 +47,7 @@ impl From<DecodedCiphertextCommitmentEqualityProof> for CiphertextCommitmentEqua
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<CiphertextCommitmentEqualityProof> for DecodedCiphertextCommitmentEqualityProof {
-    type Error = EqualityProofError;
+    type Error = EqualityProofVerificationError;
 
     fn try_from(pod_proof: CiphertextCommitmentEqualityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -68,7 +68,7 @@ impl From<DecodedCiphertextCiphertextEqualityProof> for CiphertextCiphertextEqua
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<CiphertextCiphertextEqualityProof> for DecodedCiphertextCiphertextEqualityProof {
-    type Error = EqualityProofError;
+    type Error = EqualityProofVerificationError;
 
     fn try_from(pod_proof: CiphertextCiphertextEqualityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -95,7 +95,7 @@ impl From<DecodedGroupedCiphertext2HandlesValidityProof>
 impl TryFrom<GroupedCiphertext2HandlesValidityProof>
     for DecodedGroupedCiphertext2HandlesValidityProof
 {
-    type Error = ValidityProofError;
+    type Error = ValidityProofVerificationError;
 
     fn try_from(pod_proof: GroupedCiphertext2HandlesValidityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -122,7 +122,7 @@ impl From<DecodedBatchedGroupedCiphertext2HandlesValidityProof>
 impl TryFrom<BatchedGroupedCiphertext2HandlesValidityProof>
     for DecodedBatchedGroupedCiphertext2HandlesValidityProof
 {
-    type Error = ValidityProofError;
+    type Error = ValidityProofVerificationError;
 
     fn try_from(
         pod_proof: BatchedGroupedCiphertext2HandlesValidityProof,
@@ -145,7 +145,7 @@ impl From<DecodedZeroBalanceProof> for ZeroBalanceProof {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<ZeroBalanceProof> for DecodedZeroBalanceProof {
-    type Error = ZeroBalanceProofError;
+    type Error = ZeroBalanceProofVerificationError;
 
     fn try_from(pod_proof: ZeroBalanceProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -166,7 +166,7 @@ impl From<DecodedFeeSigmaProof> for FeeSigmaProof {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<FeeSigmaProof> for DecodedFeeSigmaProof {
-    type Error = FeeSigmaProofError;
+    type Error = FeeSigmaProofVerificationError;
 
     fn try_from(pod_proof: FeeSigmaProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)
@@ -187,7 +187,7 @@ impl From<DecodedPubkeyValidityProof> for PubkeyValidityProof {
 
 #[cfg(not(target_os = "solana"))]
 impl TryFrom<PubkeyValidityProof> for DecodedPubkeyValidityProof {
-    type Error = PubkeyValidityProofError;
+    type Error = PubkeyValidityProofVerificationError;
 
     fn try_from(pod_proof: PubkeyValidityProof) -> Result<Self, Self::Error> {
         Self::from_bytes(&pod_proof.0)


### PR DESCRIPTION
#### Problem
The error types in the zk-token-sdk are organized by `ProofError`, which does not allow fine-grained control of different ways that proof generation can produce error.

#### Summary of Changes
Re-organized error types in the zk-token-sdk.
- [cd164b1](https://github.com/solana-labs/solana/pull/34034/commits/cd164b10b3661f671fd995dde82e945646146473): Added deserialization error variant in `AuthenticatedEncryptionError` and `ElGamalError` types and replaced pod conversion to return these error types instead of `ProofError`.
- [3070d2c](https://github.com/solana-labs/solana/pull/34034/commits/3070d2ca46c302544e3882b97c4e1016a8c02717): Added `SigmaProofVerificationError` type to deal with sigma proof errors. Previously, we used a universal `ProofError` to catch sigma proof error, which provided less flexibility.
- [1c99510](https://github.com/solana-labs/solana/pull/34034/commits/1c99510796d019f42c209785390bf23aabaeba90): Similar to the previous commit but for range proof. For the case of range proof, the proof generation can fail, so I added `RangeProofGenerationError` and `RangeProofVerificationError`. The `RangeProofGenerationError` variants are added in a follow-up PR (https://github.com/solana-labs/solana/pull/34065).
- [4236779](https://github.com/solana-labs/solana/pull/34034/commits/42367793263584d8338325b32294a1800097739e): I missed updating the `convert` module, so I updated it.
- [609829d](https://github.com/solana-labs/solana/pull/34034/commits/609829d2ce1d62f658caee0052fc80434794c533): Finally, I divided the `ProofError` into `ProofGenerationError` and `ProofVerificationError` and updated the instruction module accordingly. I also added `InstructionError` to catch errors that are not related to proof generation or verification (e.g. instruction decryption).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
