### PR TITLE
clippy: Uses .into() when .try_into() is infallible

### DIFF
--- a/zk-token-sdk/src/instruction/withdraw.rs
+++ b/zk-token-sdk/src/instruction/withdraw.rs
@@ -161,7 +161,7 @@ impl WithdrawProof {
 
         Self {
             commitment: pod_commitment,
-            equality_proof: equality_proof.try_into().expect("equality proof"),
+            equality_proof: equality_proof.into(),
             range_proof: range_proof.try_into().expect("range proof"),
         }
     }


### PR DESCRIPTION
#### Problem

There are nightly clippy warnings that will prevent upgrading our stable Rust version.

For this PR, it's this one: https://rust-lang.github.io/rust-clippy/master/index.html#/try_into


#### Summary of Changes

Replaces `.try_into()` with `.into()`.