### PR TITLE
clippy: Remove unused import

### DIFF
--- a/zk-token-sdk/src/zk_token_elgamal/convert.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/convert.rs
@@ -1,4 +1,3 @@
-pub use target_arch::*;
 use {super::pod, crate::curve25519::ristretto::PodRistrettoPoint};
 
 impl From<(pod::PedersenCommitment, pod::DecryptHandle)> for pod::ElGamalCiphertext {


### PR DESCRIPTION
#### Problem

There are nightly clippy warnings that will prevent upgrading our stable Rust version.

For this PR, it's this one: 
```
warning: unused import: `target_arch::*`
 --> zk-token-sdk/src/zk_token_elgamal/convert.rs:1:9
  |
1 | pub use target_arch::*;
  |         ^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```


#### Summary of Changes

Removes unused import.