### PR TITLE
Off-chain message signing - compatibility fixes

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1752,6 +1752,7 @@ mod tests {
         },
         solana_transaction_status::TransactionConfirmationStatus,
     };
+    use solana_sdk::offchain_message::{ApplicationDomain, Version};
 
     fn make_tmp_path(name: &str) -> String {
         let out_dir = std::env::var("FARF_DIR").unwrap_or_else(|_| "farf".to_string());
@@ -2013,14 +2014,18 @@ mod tests {
             "sign-offchain-message",
             "Test Message",
         ]);
-        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+
+        let keypair_signers = read_keypair_file(&keypair_file).unwrap();
+
+        let message = OffchainMessage::new(Version::V0, b"Test Message", vec![keypair_signers.pubkey()], ApplicationDomain::default()).unwrap();
+
         assert_eq!(
             parse_command(&test_sign_offchain, &default_signer, &mut None).unwrap(),
             CliCommandInfo {
                 command: CliCommand::SignOffchainMessage {
                     message: message.clone()
                 },
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![keypair_signers.into()],
             }
         );
 
@@ -2403,7 +2408,7 @@ mod tests {
         config.command = CliCommand::GetTransactionCount;
         assert!(process_command(&config).is_err());
 
-        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+        let message = OffchainMessage::new(Version::V0, b"Test Message", vec![keypair.pubkey()], ApplicationDomain::default()).unwrap();
         config.command = CliCommand::SignOffchainMessage {
             message: message.clone(),
         };

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,14 +1,14 @@
 use {
-    clap::{crate_description, crate_name, value_t_or_exit, ArgMatches},
+    clap::{ArgMatches, crate_description, crate_name, value_t_or_exit},
     console::style,
     solana_clap_utils::{
+        DisplayError,
         input_validators::normalize_to_url_if_moniker,
         keypair::{CliSigners, DefaultSigner},
-        DisplayError,
     },
     solana_cli::{
         clap_app::get_clap_app,
-        cli::{parse_command, process_command, CliCommandInfo, CliConfig},
+        cli::{CliCommandInfo, CliConfig, parse_command, process_command},
     },
     solana_cli_config::{Config, ConfigInput},
     solana_cli_output::{
@@ -242,7 +242,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
         crate_description!(),
         solana_version::version!(),
     )
-    .get_matches();
+        .get_matches();
 
     do_main(&matches).map_err(|err| DisplayError::new_as_boxed(err).into())
 }

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -83,64 +83,64 @@ impl WalletSubCommands for App<'_, '_> {
                         .help("Display balance in lamports instead of SOL"),
                 ),
         )
-            .subcommand(
-                SubCommand::with_name("address")
-                    .about("Get your public key")
-                    .arg(
-                        Arg::with_name("confirm_key")
-                            .long("confirm-key")
-                            .takes_value(false)
-                            .help("Confirm key on device; only relevant if using remote wallet"),
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("airdrop")
-                    .about("Request SOL from a faucet")
-                    .arg(
-                        Arg::with_name("amount")
-                            .index(1)
-                            .value_name("AMOUNT")
-                            .takes_value(true)
-                            .validator(is_amount)
-                            .required(true)
-                            .help("The airdrop amount to request, in SOL"),
-                    )
-                    .arg(
-                        pubkey!(Arg::with_name("to")
+        .subcommand(
+            SubCommand::with_name("address")
+                .about("Get your public key")
+                .arg(
+                    Arg::with_name("confirm_key")
+                        .long("confirm-key")
+                        .takes_value(false)
+                        .help("Confirm key on device; only relevant if using remote wallet"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("airdrop")
+                .about("Request SOL from a faucet")
+                .arg(
+                    Arg::with_name("amount")
+                        .index(1)
+                        .value_name("AMOUNT")
+                        .takes_value(true)
+                        .validator(is_amount)
+                        .required(true)
+                        .help("The airdrop amount to request, in SOL"),
+                )
+                .arg(
+                    pubkey!(Arg::with_name("to")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS"),
                         "The account address of airdrop recipient. "),
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("balance")
-                    .about("Get your balance")
-                    .arg(
-                        pubkey!(Arg::with_name("pubkey")
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("balance")
+                .about("Get your balance")
+                .arg(
+                    pubkey!(Arg::with_name("pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS"),
                         "The account address of the balance to check. ")
-                    )
-                    .arg(
-                        Arg::with_name("lamports")
-                            .long("lamports")
-                            .takes_value(false)
-                            .help("Display balance in lamports instead of SOL"),
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("confirm")
-                    .about("Confirm transaction by signature")
-                    .arg(
-                        Arg::with_name("signature")
-                            .index(1)
-                            .value_name("TRANSACTION_SIGNATURE")
-                            .takes_value(true)
-                            .required(true)
-                            .help("The transaction signature to confirm"),
-                    )
-                    .after_help(// Formatted specifically for the manually-indented heredoc string
-                                "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
+                )
+                .arg(
+                    Arg::with_name("lamports")
+                        .long("lamports")
+                        .takes_value(false)
+                        .help("Display balance in lamports instead of SOL"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("confirm")
+                .about("Confirm transaction by signature")
+                .arg(
+                    Arg::with_name("signature")
+                        .index(1)
+                        .value_name("TRANSACTION_SIGNATURE")
+                        .takes_value(true)
+                        .required(true)
+                        .help("The transaction signature to confirm"),
+                )
+                .after_help(// Formatted specifically for the manually-indented heredoc string
+                   "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
                   \n\
                   \nAccount modes:\
                   \n  |srwx|\
@@ -149,56 +149,56 @@ impl WalletSubCommands for App<'_, '_> {
                   \n    w: writable\
                   \n    x: program account (inner instructions excluded)\
                    "
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("create-address-with-seed")
-                    .about(
-                        "Generate a derived account address with a seed. \
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("create-address-with-seed")
+                .about(
+                    "Generate a derived account address with a seed. \
                     For program derived addresses (PDAs), use the find-program-derived-address command instead"
-                    )
-                    .arg(
-                        Arg::with_name("seed")
-                            .index(1)
-                            .value_name("SEED_STRING")
-                            .takes_value(true)
-                            .required(true)
-                            .validator(is_derived_address_seed)
-                            .help("The seed.  Must not take more than 32 bytes to encode as utf-8"),
-                    )
-                    .arg(
-                        Arg::with_name("program_id")
-                            .index(2)
-                            .value_name("PROGRAM_ID")
-                            .takes_value(true)
-                            .required(true)
-                            .help(
-                                "The program_id that the address will ultimately be used for, \n\
+                )
+                .arg(
+                    Arg::with_name("seed")
+                        .index(1)
+                        .value_name("SEED_STRING")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_derived_address_seed)
+                        .help("The seed.  Must not take more than 32 bytes to encode as utf-8"),
+                )
+                .arg(
+                    Arg::with_name("program_id")
+                        .index(2)
+                        .value_name("PROGRAM_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help(
+                            "The program_id that the address will ultimately be used for, \n\
                              or one of NONCE, STAKE, and VOTE keywords",
-                            ),
-                    )
-                    .arg(
-                        pubkey!(Arg::with_name("from")
+                        ),
+                )
+                .arg(
+                    pubkey!(Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_PUBKEY")
                         .required(false),
                         "From (base) key, [default: cli config keypair]. "),
-                    ),
-            )
+                ),
+        )
             .subcommand(
                 SubCommand::with_name("find-program-derived-address")
                     .about("Generate a program derived account address with a seed")
                     .arg(
                         Arg::with_name("program_id")
-                            .index(1)
-                            .value_name("PROGRAM_ID")
-                            .takes_value(true)
-                            .required(true)
-                            .help(
-                                "The program_id that the address will ultimately be used for, \n\
+                                .index(1)
+                                .value_name("PROGRAM_ID")
+                                .takes_value(true)
+                                .required(true)
+                                .help(
+                                    "The program_id that the address will ultimately be used for, \n\
                                     or one of NONCE, STAKE, and VOTE keywords",
-                            ),
-                    )
+                                ),
+                        )
                     .arg(
                         Arg::with_name("seeds")
                             .min_values(0)
@@ -216,63 +216,63 @@ impl WalletSubCommands for App<'_, '_> {
                             ),
                     ),
             )
-            .subcommand(
-                SubCommand::with_name("decode-transaction")
-                    .about("Decode a serialized transaction")
-                    .arg(
-                        Arg::with_name("transaction")
-                            .index(1)
-                            .value_name("TRANSACTION")
-                            .takes_value(true)
-                            .required(true)
-                            .help("transaction to decode"),
-                    )
-                    .arg(
-                        Arg::with_name("encoding")
-                            .index(2)
-                            .value_name("ENCODING")
-                            .possible_values(&["base58", "base64"]) // Variants of `TransactionBinaryEncoding` enum
-                            .default_value("base58")
-                            .takes_value(true)
-                            .required(true)
-                            .help("transaction encoding"),
-                    ),
-            )
-            .subcommand(
-                SubCommand::with_name("resolve-signer")
-                    .about("Checks that a signer is valid, and returns its specific path; useful for signers that may be specified generally, eg. usb://ledger")
-                    .arg(
-                        Arg::with_name("signer")
-                            .index(1)
-                            .value_name("SIGNER_KEYPAIR")
-                            .takes_value(true)
-                            .required(true)
-                            .validator(is_valid_signer)
-                            .help("The signer path to resolve")
-                    )
-            )
-            .subcommand(
-                SubCommand::with_name("transfer")
-                    .about("Transfer funds between system accounts")
-                    .alias("pay")
-                    .arg(
-                        pubkey!(Arg::with_name("to")
+        .subcommand(
+            SubCommand::with_name("decode-transaction")
+                .about("Decode a serialized transaction")
+                .arg(
+                    Arg::with_name("transaction")
+                        .index(1)
+                        .value_name("TRANSACTION")
+                        .takes_value(true)
+                        .required(true)
+                        .help("transaction to decode"),
+                )
+                .arg(
+                    Arg::with_name("encoding")
+                        .index(2)
+                        .value_name("ENCODING")
+                        .possible_values(&["base58", "base64"]) // Variants of `TransactionBinaryEncoding` enum
+                        .default_value("base58")
+                        .takes_value(true)
+                        .required(true)
+                        .help("transaction encoding"),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("resolve-signer")
+                .about("Checks that a signer is valid, and returns its specific path; useful for signers that may be specified generally, eg. usb://ledger")
+                .arg(
+                    Arg::with_name("signer")
+                        .index(1)
+                        .value_name("SIGNER_KEYPAIR")
+                        .takes_value(true)
+                        .required(true)
+                        .validator(is_valid_signer)
+                        .help("The signer path to resolve")
+                )
+        )
+        .subcommand(
+            SubCommand::with_name("transfer")
+                .about("Transfer funds between system accounts")
+                .alias("pay")
+                .arg(
+                    pubkey!(Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
                         "The account address of recipient. "),
-                    )
-                    .arg(
-                        Arg::with_name("amount")
-                            .index(2)
-                            .value_name("AMOUNT")
-                            .takes_value(true)
-                            .validator(is_amount_or_all)
-                            .required(true)
-                            .help("The amount to send, in SOL; accepts keyword ALL"),
-                    )
-                    .arg(
-                        pubkey!(Arg::with_name("from")
+                )
+                .arg(
+                    Arg::with_name("amount")
+                        .index(2)
+                        .value_name("AMOUNT")
+                        .takes_value(true)
+                        .validator(is_amount_or_all)
+                        .required(true)
+                        .help("The amount to send, in SOL; accepts keyword ALL"),
+                )
+                .arg(
+                    pubkey!(Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_ADDRESS"),
                         "Source account of funds (if different from client local account). "),
@@ -385,8 +385,8 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .required(false),
                         "The pubkey of the message signer (if different from config default)")
-                    )
-            )
+                )
+        )
     }
 }
 
@@ -931,7 +931,7 @@ pub fn process_transfer(
                                 Add `--allow-unfunded-recipient` to complete the transfer \
                                "
             )
-                .into());
+            .into());
         }
     }
 
@@ -957,8 +957,8 @@ pub fn process_transfer(
                 to,
                 lamports,
             )]
-                .with_memo(memo)
-                .with_compute_unit_price(compute_unit_price)
+            .with_memo(memo)
+            .with_compute_unit_price(compute_unit_price)
         } else {
             vec![system_instruction::transfer(&from_pubkey, to, lamports)]
                 .with_memo(memo)

--- a/remote-wallet/src/ledger.rs
+++ b/remote-wallet/src/ledger.rs
@@ -16,6 +16,7 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signature},
     std::{cmp::min, convert::TryFrom},
 };
+use solana_sdk::offchain_message;
 
 static CHECK_MARK: Emoji = Emoji("✅ ", "");
 
@@ -526,8 +527,8 @@ impl RemoteWallet<hidapi::DeviceInfo> for LedgerWallet {
         message: &[u8],
     ) -> Result<Signature, RemoteWalletError> {
         if message.len()
-            > solana_sdk::offchain_message::v0::OffchainMessage::MAX_LEN_LEDGER
-                + solana_sdk::offchain_message::v0::OffchainMessage::HEADER_LEN
+            > offchain_message::v0::OffchainMessage::max_message_for_ledger(&vec![Pubkey::default()])
+                + offchain_message::v0::OffchainMessage::header_length(&vec![Pubkey::default()])
         {
             return Err(RemoteWalletError::InvalidInput(
                 "Off-chain message to sign is too long".to_string(),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -101,6 +101,7 @@ pub mod transaction;
 pub mod transaction_context;
 pub mod transport;
 pub mod wasm;
+pub mod string_utils;
 
 /// Same as `declare_id` except report that this id has been deprecated.
 pub use solana_sdk_macro::declare_deprecated_id;

--- a/sdk/src/offchain_message.rs
+++ b/sdk/src/offchain_message.rs
@@ -2,6 +2,10 @@
 
 #![cfg(feature = "full")]
 
+use std::str::FromStr;
+
+use thiserror::Error;
+
 use {
     crate::{
         hash::Hash,
@@ -11,28 +15,36 @@ use {
     },
     num_enum::{IntoPrimitive, TryFromPrimitive},
 };
+use solana_sdk::signer::SignerError;
 
-#[cfg(test)]
-static_assertions::const_assert_eq!(OffchainMessage::HEADER_LEN, 17);
-#[cfg(test)]
-static_assertions::const_assert_eq!(v0::OffchainMessage::MAX_LEN, 65515);
-#[cfg(test)]
-static_assertions::const_assert_eq!(v0::OffchainMessage::MAX_LEN_LEDGER, 1212);
-
-/// Check if given bytes contain only printable ASCII characters
-pub fn is_printable_ascii(data: &[u8]) -> bool {
-    for &char in data {
-        if !(0x20..=0x7e).contains(&char) {
-            return false;
-        }
-    }
-    true
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error("message is empty")]
+    MessageEmpty,
+    #[error("message is too long")]
+    MessageTooLong,
+    #[error("message candidate buffer is too short")]
+    BufferTooShort,
+    #[error("message candidate buffer is too long")]
+    BufferTooLong,
+    #[error("unexpected message format value: {0}")]
+    UnexpectedFormatDiscriminant(u8),
+    #[error("unexpected message encoding")]
+    UnexpectedMessageEncoding,
+    #[error("unexpected message version value: {0}")]
+    UnexpectedVersionDiscriminant(u8),
+    #[error("message is illegal for specified format")]
+    IllegalMessageFormat,
+    #[error(transparent)]
+    SignerError(#[from] SignerError),
+    #[error("at least one signer required")]
+    SignerRequired,
+    #[error("too many signers")]
+    TooManySigners,
+    #[error("invalid signing domain")]
+    InvalidSigningDomain,
 }
 
-/// Check if given bytes contain valid UTF8 string
-pub fn is_utf8(data: &[u8]) -> bool {
-    std::str::from_utf8(data).is_ok()
-}
 
 #[repr(u8)]
 #[derive(Debug, PartialEq, Eq, Copy, Clone, TryFromPrimitive, IntoPrimitive)]
@@ -42,112 +54,321 @@ pub enum MessageFormat {
     ExtendedUtf8,
 }
 
+impl MessageFormat {
+    const LEN: usize = std::mem::size_of::<Self>();
+}
+
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, TryFromPrimitive, IntoPrimitive)]
+pub enum Version {
+    V0 = 0,
+}
+
+impl Version {
+    const LEN: usize = std::mem::size_of::<Self>();
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+#[error("invalid value for offchain message version: `{0}`")]
+pub struct VersionFromStrError(String);
+
+impl FromStr for Version {
+    type Err = VersionFromStrError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(version) = s.parse::<<Self as TryFromPrimitive>::Primitive>() {
+            if let Ok(version) = Version::try_from_primitive(version) {
+                return Ok(version);
+            }
+        }
+        Err(VersionFromStrError(s.to_string()))
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ApplicationDomain([u8; Self::LEN]);
+
+impl ApplicationDomain {
+    const LEN: usize = 32;
+    pub fn new(domain: [u8; Self::LEN]) -> Self {
+        Self(domain)
+    }
+
+    ///Return current values
+    pub fn buffer(&self) -> [u8; Self::LEN] {
+        self.0
+    }
+
+    pub fn from_slice(domain: &[u8]) -> Self {
+        let mut application_domain = Self::default();
+        application_domain.0.copy_from_slice(domain);
+        application_domain
+    }
+}
+
 #[allow(clippy::arithmetic_side_effects)]
 pub mod v0 {
+    use num_enum::TryFromPrimitive;
+
     use {
-        super::{is_printable_ascii, is_utf8, MessageFormat, OffchainMessage as Base},
         crate::{
             hash::{Hash, Hasher},
             packet::PACKET_DATA_SIZE,
             sanitize::SanitizeError,
         },
+        super::MessageFormat,
     };
+    use solana_program::pubkey::{Pubkey, PUBKEY_BYTES};
+    use solana_sdk::offchain_message::{ApplicationDomain, Version};
+    use solana_sdk::string_utils::{is_printable_ascii, is_utf8};
+
+    use crate::offchain_message::Error;
+
+    pub const SIGNING_DOMAIN: &[u8; 16] = b"\xffsolana offchain";
 
     /// OffchainMessage Version 0.
     /// Struct always contains a non-empty valid message.
     #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct OffchainMessage {
+        //Max 16 bytes
+        signing_domain: [u8; 16],
+        header_version: Version,
+        //Max 32 bytes - can be arbitrary data
+        application_domain: ApplicationDomain,
         format: MessageFormat,
+        signer_count: u8,
+        signers: Vec<Pubkey>,
         message: Vec<u8>,
     }
 
-    impl OffchainMessage {
-        // Header Length = Message Format (1) + Message Length (2)
-        pub const HEADER_LEN: usize = 3;
-        // Max length of the OffchainMessage
-        pub const MAX_LEN: usize = u16::MAX as usize - Base::HEADER_LEN - Self::HEADER_LEN;
-        // Max Length of the OffchainMessage supported by the Ledger
-        pub const MAX_LEN_LEDGER: usize = PACKET_DATA_SIZE - Base::HEADER_LEN - Self::HEADER_LEN;
+    pub(crate) type MessageLen = u16;
+    pub(crate) type SignersLen = u8;
 
+    impl OffchainMessage {
         /// Construct a new OffchainMessage object from the given message
-        pub fn new(message: &[u8]) -> Result<Self, SanitizeError> {
+        pub fn new(message: &[u8], signers: Vec<Pubkey>, application_domain: ApplicationDomain) -> Result<Self, Error> {
             let format = if message.is_empty() {
-                return Err(SanitizeError::InvalidValue);
-            } else if message.len() <= OffchainMessage::MAX_LEN_LEDGER {
+                return Err(Error::MessageEmpty);
+            } else if message.len() <= Self::max_message_for_ledger(&signers) {
                 if is_printable_ascii(message) {
                     MessageFormat::RestrictedAscii
                 } else if is_utf8(message) {
                     MessageFormat::LimitedUtf8
                 } else {
-                    return Err(SanitizeError::InvalidValue);
+                    return Err(Error::UnexpectedMessageEncoding);
                 }
-            } else if message.len() <= OffchainMessage::MAX_LEN {
+            } else if message.len() <= Self::max_message(&signers) {
                 if is_utf8(message) {
                     MessageFormat::ExtendedUtf8
                 } else {
-                    return Err(SanitizeError::InvalidValue);
+                    return Err(Error::UnexpectedMessageEncoding);
                 }
             } else {
-                return Err(SanitizeError::ValueOutOfBounds);
+                return Err(Error::MessageTooLong);
             };
+
+            if signers.is_empty() {
+                return Err(Error::SignerRequired);
+            }
+            let _ = SignersLen::try_from(signers.len()).map_err(|_| Error::TooManySigners)?;
+
             Ok(Self {
+                signing_domain: *SIGNING_DOMAIN,
+                header_version: Version::V0,//This implementation is defined for V0 only
+                application_domain,
                 format,
+                signer_count: signers.len() as u8,
+                signers,
                 message: message.to_vec(),
             })
         }
 
+        /// Signing domain (16 bytes) + Header version (1 byte) + Application domain (32 bytes) +
+        /// + Message format (1 byte) + Signer count (1 bytes) + Signers (signer_count *  32 bytes) +
+        /// + Message length (2 bytes)
+        /// = 85 bytes
+        /// Current cli implementation uses single signer - header size can be estimated up front
+        pub const fn header_length(signers: &[Pubkey]) -> usize {
+            ApplicationDomain::LEN +
+                MessageFormat::LEN +
+                std::mem::size_of::<SignersLen>() +
+                signers.len() * std::mem::size_of::<Pubkey>() +
+                std::mem::size_of::<MessageLen>()
+        }
+
+        pub const fn min_header_length() -> usize {
+            let signer = Pubkey::new_from_array([0u8; PUBKEY_BYTES]);
+            Self::header_length(std::slice::from_ref(&signer))
+        }
+
+        // Max Length of the input message supported by the Ledger
+        pub fn max_message_for_ledger(signers: &[Pubkey]) -> usize {
+            PACKET_DATA_SIZE.saturating_sub(Self::header_length(signers))
+        }
+
+        // Max length of the input message
+        pub fn max_message(signers: &[Pubkey]) -> usize {
+            usize::from(MessageLen::MAX).saturating_sub(Self::header_length(signers))
+        }
+
+        pub fn max_message_with_header() -> usize {
+            usize::from(MessageLen::MAX)
+        }
+
         /// Serialize the message to bytes, including the full header
+        /// Message preamble data order:
+        /// 1. Signing domain (16 bytes)
+        /// 2. Header version (1 byte)
+        /// 3. Application domain (32 bytes)
+        /// 4. Message format (1 byte)
+        /// 5. Signer count (1 bytes)
+        /// 6. Signers (signer_count *  32 bytes)
+        /// 7. Message length (2 bytes)
         pub fn serialize(&self, data: &mut Vec<u8>) -> Result<(), SanitizeError> {
             // invalid messages shouldn't be possible, but a quick sanity check never hurts
-            assert!(!self.message.is_empty() && self.message.len() <= Self::MAX_LEN);
-            data.reserve(Self::HEADER_LEN.saturating_add(self.message.len()));
-            // format
+            assert!(!self.message.is_empty() && self.message.len() <= Self::max_message(self.get_signers()));
+
+            //Reserve space for header + message
+            data.reserve(
+                Self::header_length(self.get_signers()).saturating_add(self.message.len()),
+            );
+
+            //Signing domain
+            data.append(SIGNING_DOMAIN.to_vec().as_mut());
+
+            //Header version
+            data.push(0);
+
+            //Application domain
+            data.extend_from_slice(&self.application_domain.buffer());
+
+            //Message format
             data.push(self.format.into());
-            // message length
+
+            // Signer count
+            data.push(self.signer_count);
+
+            // Signers
+            for signer in self.signers.iter() {
+                data.extend_from_slice(signer.as_ref());
+            }
+
+            //Message length
             data.extend_from_slice(&(self.message.len() as u16).to_le_bytes());
-            // message
+
+            //Message
             data.extend_from_slice(&self.message);
+
             Ok(())
         }
 
         /// Deserialize the message from bytes that include a full header
-        pub fn deserialize(data: &[u8]) -> Result<Self, SanitizeError> {
+        pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
             // validate data length
-            if data.len() <= Self::HEADER_LEN || data.len() > Self::HEADER_LEN + Self::MAX_LEN {
-                return Err(SanitizeError::ValueOutOfBounds);
+            if data.len() <= Self::min_header_length() || data.len() > Self::max_message_with_header() {
+                return Err(Error::BufferTooShort);
             }
+            //We know that header is at least 85 bytes long and message is not empty - using raw indexes should be safe
+
             // decode header
-            let format =
-                MessageFormat::try_from(data[0]).map_err(|_| SanitizeError::InvalidValue)?;
-            let message_len = u16::from_le_bytes([data[1], data[2]]) as usize;
-            // check header
-            if Self::HEADER_LEN.saturating_add(message_len) != data.len() {
-                return Err(SanitizeError::InvalidValue);
+            let mut offset = 0;
+
+            let signing_domain_range = offset..SIGNING_DOMAIN.len();
+            let signing_domain: [u8; 16] = data[signing_domain_range].try_into().unwrap();
+
+            if signing_domain != *SIGNING_DOMAIN {
+                return Err(Error::InvalidSigningDomain);
             }
-            let message = &data[Self::HEADER_LEN..];
+
+            offset += SIGNING_DOMAIN.len();
+
+            if data[offset..].len() < Version::LEN {
+                return Err(Error::BufferTooShort);
+            }
+
+            let header_version: u8 = data[offset];
+            let header_version = Version::try_from_primitive(header_version)
+                .map_err(|e| Error::UnexpectedVersionDiscriminant(e.number))?;
+            offset += 1;
+
+            let mut application_domain = ApplicationDomain::default();
+            let application_domain_range = offset..offset + ApplicationDomain::LEN;
+            application_domain.0.copy_from_slice(&data[application_domain_range]);
+            offset += ApplicationDomain::LEN;
+
+            let format = MessageFormat::try_from(data[offset])
+                .map_err(|e| Error::UnexpectedFormatDiscriminant(e.number))?;
+            offset += 1;
+
+            let num_signers = usize::from(data[offset]);
+            offset += 1;
+            if num_signers == 0 {
+                return Err(Error::SignerRequired);
+            }
+            if data[offset..].len() < num_signers * PUBKEY_BYTES {
+                return Err(Error::BufferTooShort);
+            }
+
+            let mut signers = Vec::with_capacity(num_signers);
+            let signer_count: u8 = num_signers.try_into().unwrap();
+            for _ in 0..num_signers {
+                let signer_range = offset..offset + PUBKEY_BYTES;
+                offset += PUBKEY_BYTES;
+                let signer = Pubkey::try_from(&data[signer_range])
+                    .expect("buffer contains enough data to represent all signers");
+                signers.push(signer);
+            }
+
+            const MESSAGE_LEN_LEN: usize = std::mem::size_of::<MessageLen>();
+            if data[offset..].len() < MESSAGE_LEN_LEN {
+                return Err(Error::BufferTooShort);
+            }
+            let message_len_range = offset..offset + MESSAGE_LEN_LEN;
+            let message_len_bytes =
+                <[u8; MESSAGE_LEN_LEN]>::try_from(&data[message_len_range]).unwrap();
+            let message_len = usize::from(MessageLen::from_le_bytes(message_len_bytes));
+            offset += MESSAGE_LEN_LEN;
+
+            let message = &data[offset..];
+            let expected_remaining_buffer = message_len;
+            let actual_remaining_buffer = message.len();
+            println!("off: {offset}, exp: {expected_remaining_buffer}, act: {actual_remaining_buffer}");
+            if actual_remaining_buffer > expected_remaining_buffer {
+                return Err(Error::BufferTooLong);
+            }
+            println!("4");
+            if actual_remaining_buffer < expected_remaining_buffer {
+                return Err(Error::BufferTooShort);
+            }
+
             // check format
             let is_valid = match format {
                 MessageFormat::RestrictedAscii => {
-                    (message.len() <= Self::MAX_LEN_LEDGER) && is_printable_ascii(message)
+                    (message.len() <= Self::max_message_for_ledger(&signers)) && is_printable_ascii(message)
                 }
                 MessageFormat::LimitedUtf8 => {
-                    (message.len() <= Self::MAX_LEN_LEDGER) && is_utf8(message)
+                    (message.len() <= Self::max_message_for_ledger(&signers)) && is_utf8(message)
                 }
-                MessageFormat::ExtendedUtf8 => (message.len() <= Self::MAX_LEN) && is_utf8(message),
+                MessageFormat::ExtendedUtf8 => (message.len() <= Self::max_message(&signers)) && is_utf8(message),
             };
 
             if is_valid {
                 Ok(Self {
+                    signing_domain,
+                    header_version,
+                    application_domain,
                     format,
+                    signer_count,
+                    signers,
                     message: message.to_vec(),
                 })
             } else {
-                Err(SanitizeError::InvalidValue)
+                Err(Error::IllegalMessageFormat)
             }
         }
 
         /// Compute the SHA256 hash of the serialized off-chain message
-        pub fn hash(serialized_message: &[u8]) -> Result<Hash, SanitizeError> {
+        pub fn hash(serialized_message: &[u8]) -> Result<Hash, Error> {
             let mut hasher = Hasher::default();
             hasher.hash(serialized_message);
             Ok(hasher.result())
@@ -160,6 +381,10 @@ pub mod v0 {
         pub fn get_message(&self) -> &Vec<u8> {
             &self.message
         }
+
+        pub fn get_signers(&self) -> &[Pubkey] {
+            &self.signers
+        }
     }
 }
 
@@ -169,50 +394,39 @@ pub enum OffchainMessage {
 }
 
 impl OffchainMessage {
-    pub const SIGNING_DOMAIN: &'static [u8] = b"\xffsolana offchain";
-    // Header Length = Signing Domain (16) + Header Version (1)
-    pub const HEADER_LEN: usize = Self::SIGNING_DOMAIN.len() + 1;
-
     /// Construct a new OffchainMessage object from the given version and message
-    pub fn new(version: u8, message: &[u8]) -> Result<Self, SanitizeError> {
+    pub fn new(version: Version, message: &[u8], signers: Vec<Pubkey>, application_domain: ApplicationDomain) -> Result<Self, Error> {
         match version {
-            0 => Ok(Self::V0(v0::OffchainMessage::new(message)?)),
-            _ => Err(SanitizeError::ValueOutOfBounds),
+            Version::V0 => Ok(Self::V0(v0::OffchainMessage::new(message, signers, application_domain)?)),
         }
     }
 
     /// Serialize the off-chain message to bytes including full header
-    pub fn serialize(&self) -> Result<Vec<u8>, SanitizeError> {
-        // serialize signing domain
-        let mut data = Self::SIGNING_DOMAIN.to_vec();
+    pub fn serialize(&self) -> Result<Vec<u8>, Error> {
+        let mut data = Vec::new();
 
         // serialize version and call version specific serializer
         match self {
             Self::V0(msg) => {
-                data.push(0);
-                msg.serialize(&mut data)?;
+                msg.serialize(&mut data).unwrap();
             }
         }
         Ok(data)
     }
 
     /// Deserialize the off-chain message from bytes that include full header
-    pub fn deserialize(data: &[u8]) -> Result<Self, SanitizeError> {
-        if data.len() <= Self::HEADER_LEN {
-            return Err(SanitizeError::ValueOutOfBounds);
-        }
-        let version = data[Self::SIGNING_DOMAIN.len()];
-        let data = &data[Self::SIGNING_DOMAIN.len().saturating_add(1)..];
+    /// Used only in tests
+    pub fn deserialize(version: Version, data: &[u8]) -> Result<Self, Error> {
         match version {
-            0 => Ok(Self::V0(v0::OffchainMessage::deserialize(data)?)),
-            _ => Err(SanitizeError::ValueOutOfBounds),
+            Version::V0 => Ok(Self::V0(v0::OffchainMessage::deserialize(data)?)),
         }
     }
 
     /// Compute the hash of the off-chain message
-    pub fn hash(&self) -> Result<Hash, SanitizeError> {
+    pub fn hash(&self) -> Result<Hash, Error> {
         match self {
-            Self::V0(_) => v0::OffchainMessage::hash(&self.serialize()?),
+            // Hash input message contents
+            Self::V0(_) => v0::OffchainMessage::hash(self.get_message()),
         }
     }
 
@@ -228,6 +442,12 @@ impl OffchainMessage {
         }
     }
 
+    pub fn get_signers(&self) -> &[Pubkey] {
+        match self {
+            Self::V0(msg) => &msg.get_signers(),
+        }
+    }
+
     pub fn get_message(&self) -> &Vec<u8> {
         match self {
             Self::V0(msg) => msg.get_message(),
@@ -236,22 +456,62 @@ impl OffchainMessage {
 
     /// Sign the message with provided keypair
     pub fn sign(&self, signer: &dyn Signer) -> Result<Signature, SanitizeError> {
-        Ok(signer.sign_message(&self.serialize()?))
+        Ok(signer.sign_message(&self.serialize().unwrap()))
     }
 
     /// Verify that the message signature is valid for the given public key
     pub fn verify(&self, signer: &Pubkey, signature: &Signature) -> Result<bool, SanitizeError> {
-        Ok(signature.verify(signer.as_ref(), &self.serialize()?))
+        Ok(signature.verify(signer.as_ref(), &self.serialize().unwrap()))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::signature::Keypair, std::str::FromStr};
+    use {crate::signature::Keypair, std::str::FromStr, super::*};
+
+    #[test]
+    fn test_offchain_message_extended_utf8() {
+        let signers = vec![Pubkey::default()];
+        let text_message = "Ł".repeat(v0::OffchainMessage::max_message_for_ledger(&signers).saturating_add(1));
+        let message = OffchainMessage::new(Version::V0, text_message.as_ref(), signers, ApplicationDomain::default()).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::ExtendedUtf8);
+    }
+
+    #[test]
+    fn test_offchain_message_empty_message() {
+        let message = OffchainMessage::new(Version::V0, b"", vec![Pubkey::default()], ApplicationDomain::default());
+        assert!(matches!(message, Err(Error::MessageEmpty)));
+    }
+
+    #[test]
+    fn test_offchain_message_too_long_utf8() {
+        let signers = vec![Pubkey::default()];
+        let msg_size = v0::OffchainMessage::max_message(&signers);
+        let message = &vec![0_u8; msg_size.saturating_add(1)];
+        let message = OffchainMessage::new(Version::V0, message, signers, ApplicationDomain::default());
+        assert!(matches!(message, Err(Error::MessageTooLong)));
+    }
+
+    #[test]
+    fn test_offchain_message_invalid_utf8() {
+        let message = OffchainMessage::new(Version::V0, &[0xF1], vec![Pubkey::default()], ApplicationDomain::default());
+        assert!(matches!(message, Err(Error::UnexpectedMessageEncoding)));
+    }
+
+    #[test]
+    fn test_offchain_message_utf8_long_message() {
+        let signers = vec![Pubkey::default()];
+        let msg_size = v0::OffchainMessage::max_message_for_ledger(&signers);
+        let message = &vec![0_u8; msg_size.saturating_add(1)];
+        let message = OffchainMessage::new(Version::V0, message, signers, ApplicationDomain::default());
+
+        assert_eq!(message.unwrap().get_format(), MessageFormat::ExtendedUtf8);
+    }
 
     #[test]
     fn test_offchain_message_ascii() {
-        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+        let message = OffchainMessage::new(Version::V0, b"Test Message", vec![Pubkey::default()], ApplicationDomain::default()).unwrap();
+
         assert_eq!(message.get_version(), 0);
         assert_eq!(message.get_format(), MessageFormat::RestrictedAscii);
         assert_eq!(message.get_message().as_slice(), b"Test Message");
@@ -259,18 +519,20 @@ mod tests {
             matches!(message, OffchainMessage::V0(ref msg) if msg.get_format() == MessageFormat::RestrictedAscii)
         );
         let serialized = [
-            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 0, 12, 0,
-            84, 101, 115, 116, 32, 77, 101, 115, 115, 97, 103, 101,
+            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12,
+            0, 84, 101, 115, 116, 32, 77, 101, 115, 115, 97, 103, 101
         ];
-        let hash = Hash::from_str("HG5JydBGjtjTfD3sSn21ys5NTWPpXzmqifiGC2BVUjkD").unwrap();
+        let hash = Hash::from_str("DHMr3vK1BJ5RzfwAmjzkayGyEs3ouKUhHzZdYRG5migZ").unwrap();
         assert_eq!(message.serialize().unwrap(), serialized);
         assert_eq!(message.hash().unwrap(), hash);
-        assert_eq!(message, OffchainMessage::deserialize(&serialized).unwrap());
+        assert_eq!(message, OffchainMessage::deserialize(Version::V0, &serialized).unwrap());
     }
 
     #[test]
     fn test_offchain_message_utf8() {
-        let message = OffchainMessage::new(0, "Тестовое сообщение".as_bytes()).unwrap();
+        let message = OffchainMessage::new(Version::V0, "Тестовое сообщение".as_bytes(), vec![Pubkey::default()], ApplicationDomain::default()).unwrap();
         assert_eq!(message.get_version(), 0);
         assert_eq!(message.get_format(), MessageFormat::LimitedUtf8);
         assert_eq!(
@@ -281,22 +543,318 @@ mod tests {
             matches!(message, OffchainMessage::V0(ref msg) if msg.get_format() == MessageFormat::LimitedUtf8)
         );
         let serialized = [
-            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 1, 35, 0,
-            208, 162, 208, 181, 209, 129, 209, 130, 208, 190, 208, 178, 208, 190, 208, 181, 32,
-            209, 129, 208, 190, 208, 190, 208, 177, 209, 137, 208, 181, 208, 189, 208, 184, 208,
-            181,
+            255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 35,
+            0, 208, 162, 208, 181, 209, 129, 209, 130, 208, 190, 208, 178, 208, 190, 208, 181, 32, 209, 129,
+            208, 190, 208, 190, 208, 177, 209, 137, 208, 181, 208, 189, 208, 184, 208, 181
         ];
-        let hash = Hash::from_str("6GXTveatZQLexkX4WeTpJ3E7uk1UojRXpKp43c4ArSun").unwrap();
+        let hash = Hash::from_str("GTARP1PJqT7JoqnjN5TCJDzzoxB7MqtsBvA2b5hbNc7c").unwrap();
         assert_eq!(message.serialize().unwrap(), serialized);
         assert_eq!(message.hash().unwrap(), hash);
-        assert_eq!(message, OffchainMessage::deserialize(&serialized).unwrap());
+        assert_eq!(message, OffchainMessage::deserialize(Version::V0, &serialized).unwrap());
     }
 
     #[test]
     fn test_offchain_message_sign_and_verify() {
-        let message = OffchainMessage::new(0, b"Test Message").unwrap();
+        let message = OffchainMessage::new(Version::V0, b"Test Message", vec![Pubkey::default()], ApplicationDomain::default()).unwrap();
         let keypair = Keypair::new();
         let signature = message.sign(&keypair).unwrap();
         assert!(message.verify(&keypair.pubkey(), &signature).unwrap());
     }
+
+    #[test]
+    fn test_version_from_str() {
+        assert!(matches!(Version::from_str("0"), Ok(Version::V0)));
+        assert_eq!(
+            Version::from_str(""),
+            Err(VersionFromStrError(String::new()))
+        );
+        assert_eq!(
+            Version::from_str("1"),
+            Err(VersionFromStrError(String::from("1")))
+        );
+        assert_eq!(
+            Version::from_str("~"),
+            Err(VersionFromStrError(String::from("~")))
+        );
+    }
+
+    #[test]
+    fn test_message_len_boundaries() {
+        let signers = vec![Pubkey::from([1u8; 32])];
+        let application_domain = ApplicationDomain::new([2u8; 32]);
+
+        // empty message
+        let empty_message_result = OffchainMessage::new(
+            Version::V0,
+            "".as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        );
+        assert_eq!(empty_message_result, Err(Error::MessageEmpty));
+
+        let c_ascii = 'T'; // 0x54
+        let c_utf8 = 'Т';  // 0xd0a2
+
+        // min for Format::RestrictedAscii
+        let min_message = [c_ascii].iter().collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&min_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::RestrictedAscii);
+        assert_eq!(message.get_message(), min_message.as_bytes());
+
+        // min for Format::LimitedUtf8
+        let min_message = [c_utf8].iter().collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&min_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::LimitedUtf8);
+        assert_eq!(message.get_message(), min_message.as_bytes());
+
+        // min for Format::ExtendedUtf8
+        let max_message_for_ledger = v0::OffchainMessage::max_message_for_ledger(&signers);
+        let min_message = std::iter::repeat(c_ascii).take(max_message_for_ledger + 1).collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&min_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::ExtendedUtf8);
+        assert_eq!(message.get_message(), min_message.as_bytes());
+
+        // max for Format::LimitedAscii
+        let max_message = std::iter::repeat(c_ascii).take(max_message_for_ledger).collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&max_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::RestrictedAscii);
+        assert_eq!(message.get_message(), max_message.as_bytes());
+
+        // max for Format::RestrictedUtf8
+        // one utf8 char to flip the format, then pad out to max with ascii chars
+        let max_message = [c_utf8]
+            .into_iter()
+            .chain(std::iter::repeat(c_ascii).take(max_message_for_ledger - c_utf8.len_utf8()))
+            .collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&max_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::LimitedUtf8);
+        assert_eq!(message.get_message(), max_message.as_bytes());
+
+        // max for Format::ExtendedUtf8
+        let max_message_len = v0::OffchainMessage::max_message(&signers);
+        let max_message = std::iter::repeat(c_ascii).take(max_message_len).collect::<String>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            (&max_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_format(), MessageFormat::ExtendedUtf8);
+        assert_eq!(message.get_message(), max_message.as_bytes());
+
+        // overflow
+        let overflow_message = std::iter::repeat(c_ascii).take(max_message_len + 1).collect::<String>();
+        let message_result = OffchainMessage::new(
+            Version::V0,
+            (&overflow_message).as_ref(),
+            signers.clone(),
+            application_domain.clone(),
+        );
+        assert_eq!(message_result, Err(Error::MessageTooLong));
+    }
+
+    #[test]
+    fn test_signers_len_boundaries() {
+        let application_domain = ApplicationDomain::new([2u8; 32]);
+
+        // empty signers
+        let empty_message_result = OffchainMessage::new(
+            Version::V0,
+            "test message".as_ref(),
+            Vec::new(),
+            application_domain.clone(),
+        );
+        assert_eq!(empty_message_result, Err(Error::SignerRequired));
+
+        // min signers
+        let min_signers = vec![Pubkey::new_unique()];
+        let message = OffchainMessage::new(
+            Version::V0,
+            "test message".as_ref(),
+            min_signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_signers(), min_signers);
+
+        // max signers
+        let max_signers_len = usize::from(u8::MAX);
+        let max_signers = std::iter::repeat_with(Pubkey::new_unique).take(max_signers_len).collect::<Vec<_>>();
+        let message = OffchainMessage::new(
+            Version::V0,
+            "test message".as_ref(),
+            max_signers.clone(),
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(message.get_signers(), max_signers);
+
+        // overflow
+        let overflow_signers = std::iter::repeat_with(Pubkey::new_unique).take(max_signers_len + 1).collect::<Vec<_>>();
+        let message_result = OffchainMessage::new(
+            Version::V0,
+            "test message".as_ref(),
+            overflow_signers.clone(),
+            application_domain.clone(),
+        );
+        assert_eq!(message_result, Err(Error::TooManySigners));
+    }
+
+    #[test]
+    fn test_deserialize_bounds() {
+        let test_serialized: Vec<u8> = vec![255, 115, 111, 108, 97, 110, 97, 32, 111, 102, 102, 99, 104, 97, 105, 110, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 12, 0, 116, 101, 115, 116, 32, 109, 101, 115, 115, 97, 103, 101];
+
+        // assert test bytes inputs
+        let signers = vec![Pubkey::from([1u8; 32]), Pubkey::from([2u8; 32])];
+        let application_domain = ApplicationDomain::new([3u8; 32]);
+        let message = OffchainMessage::new(
+            Version::V0,
+            "test message".as_ref(),
+            signers,
+            application_domain.clone(),
+        ).unwrap();
+        assert_eq!(test_serialized, message.serialize().unwrap());
+        assert_eq!(OffchainMessage::deserialize(Version::V0, &test_serialized), Ok(message));
+
+        let mut next_field_offset = v0::SIGNING_DOMAIN.len();
+
+        // too short for signing domain
+        let data = &test_serialized[..next_field_offset - 1];
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, data),
+            Err(Error::BufferTooShort),
+        );
+
+        // wrong signing domain
+        let mut data_cpy = test_serialized.clone();
+        data_cpy[1] += 1;
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, &data_cpy),
+            Err(Error::InvalidSigningDomain),
+        );
+
+        // too short for version
+        let data = &test_serialized[..next_field_offset];
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, data),
+            Err(Error::BufferTooShort),
+        );
+
+        // wrong version
+        let mut data_cpy = test_serialized.clone();
+        data_cpy[v0::SIGNING_DOMAIN.len()] = 21;//Set invalid version
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, &data_cpy),
+            Err(Error::UnexpectedVersionDiscriminant(21)),
+        );
+
+        // too short for v0 header
+        let data = &test_serialized[..v0::OffchainMessage::min_header_length() - 1];
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, data),
+            Err(Error::BufferTooShort),
+        );
+
+        next_field_offset += ApplicationDomain::LEN;
+
+        // invalid v0 message format
+        assert_eq!(MessageFormat::LEN, std::mem::size_of::<u8>());
+        let mut data_cpy = test_serialized.clone();
+        data_cpy[v0::SIGNING_DOMAIN.len() + Version::LEN + ApplicationDomain::LEN] = u8::MAX;
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, &data_cpy),
+            Err(Error::UnexpectedFormatDiscriminant(u8::MAX))
+        );
+
+        next_field_offset += MessageFormat::LEN;
+
+        // empty v0 signers
+        let mut data_cpy = test_serialized.clone();
+        data_cpy[v0::SIGNING_DOMAIN.len() + Version::LEN + ApplicationDomain::LEN + MessageFormat::LEN] = 0;
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, &data_cpy),
+            Err(Error::SignerRequired),
+        );
+
+        // v0 too short for all signers
+        let mut data_cpy = test_serialized.clone();
+        data_cpy[v0::SIGNING_DOMAIN.len() + Version::LEN + ApplicationDomain::LEN + MessageFormat::LEN] = 10;
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, &data_cpy),
+            Err(Error::BufferTooShort),
+        );
+
+        // v0 too short for message len
+        let data = &test_serialized[..next_field_offset - 1];
+        assert_eq!(
+            OffchainMessage::deserialize(Version::V0, data),
+            Err(Error::BufferTooShort),
+        );
+    }
+
+    #[test]
+    fn test_application_domain_from_slice_empty_buffer(){
+        let input_params = [0_u8; 32];
+
+        let app_domain: ApplicationDomain = ApplicationDomain::from_slice(&input_params);
+
+        assert_eq!(app_domain.buffer(), input_params);
+    }
+
+    #[test]
+    fn test_application_domain_from_slice_key(){
+        let input_params_base58: &str = "9tjwwvfJssteUgJXs6uj6WYCXABCfcwhtzhbeXrhgBzc";
+        let input_params_decoded = bs58::decode(input_params_base58).into_vec().unwrap();
+
+        let app_domain = ApplicationDomain::from_slice(input_params_decoded.as_ref());
+
+        assert_eq!(app_domain.buffer(), input_params_decoded.as_ref());
+    }
+
+    #[test]
+    fn test_application_domain_invalid_utf8_message(){
+        let signers = vec![Pubkey::from([1u8; 32]), Pubkey::from([2u8; 32])];
+        let application_domain = ApplicationDomain::new([3u8; 32]);
+
+        //Generate invalid utf8 message
+        let mut message_data = Vec::from([0xc3, 0x28]);
+        message_data.resize(v0::OffchainMessage::max_message(&signers) - 10, 0);
+
+
+        let message_result = OffchainMessage::new(
+            Version::V0,
+            message_data.as_ref(),
+            signers,
+            application_domain.clone(),
+        );
+
+        assert_eq!(message_result, Err(Error::UnexpectedMessageEncoding));
+
+    }
+
 }

--- a/sdk/src/string_utils.rs
+++ b/sdk/src/string_utils.rs
@@ -1,0 +1,66 @@
+/// Check if given bytes contain only printable ASCII characters
+pub fn is_printable_ascii(data: &[u8]) -> bool {
+    for &char in data {
+        if !(0x20..=0x7e).contains(&char) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Check if given bytes contain valid UTF8 string
+pub fn is_utf8(data: &[u8]) -> bool {
+    std::str::from_utf8(data).is_ok()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::string_utils::is_utf8;
+    use crate::string_utils::is_printable_ascii;
+
+    #[test]
+    fn test_is_utf8(){
+        let data = "hello world".as_bytes();
+        assert!(is_utf8(data));
+    }
+
+    #[test]
+    fn test_is_utf8_invalid_sequence_identifier(){
+        let data: [u8; 2] = [0xA0, 0xA1];
+        assert!(!is_utf8(data.as_ref()));
+    }
+
+    #[test]
+    fn test_is_utf8_special_chars(){
+        let data = "żółty".as_bytes();
+        assert!(is_utf8(data));
+    }
+
+    #[test]
+    fn test_is_printable_ascii(){
+        let data = "hello world".as_bytes();
+        assert!(is_printable_ascii(data));
+    }
+
+    #[test]
+    fn test_is_printable_ascii_empty(){
+        let data = b"";
+        assert!(is_printable_ascii(data));
+    }
+
+    #[test]
+    fn test_is_utf8_empty(){
+        let data = b"";
+        assert!(is_utf8(data));
+    }
+
+    #[test]
+    fn test_is_utf8_invalid(){
+        let mut data = Vec::from([0xc3, 0x28]);
+        data.resize(32,0);
+        assert!(!is_utf8(data.as_ref()));
+    }
+
+
+}


### PR DESCRIPTION
#### Problem
Current version of the off-chain message signing was not fully compliant with the specification.

#### Summary of Changes
* Fixed support for off-chain message signing
* Application domain param validation moved to input_validators 
* Added tests for string_utils and odd-chain messages


