### PR TITLE
shred: expose merkle root for use in blockstore

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -406,6 +406,29 @@ impl ErasureMeta {
     }
 }
 
+#[allow(dead_code)]
+impl MerkleRootMeta {
+    pub(crate) fn from_shred(shred: &Shred) -> Self {
+        Self {
+            merkle_root: shred.merkle_root().unwrap_or_default(),
+            first_received_shred_index: shred.index(),
+            first_received_shred_type: shred.shred_type(),
+        }
+    }
+
+    pub(crate) fn merkle_root(&self) -> Hash {
+        self.merkle_root
+    }
+
+    pub(crate) fn first_received_shred_index(&self) -> u32 {
+        self.first_received_shred_index
+    }
+
+    pub(crate) fn first_received_shred_type(&self) -> ShredType {
+        self.first_received_shred_type
+    }
+}
+
 impl DuplicateSlotProof {
     pub(crate) fn new(shred1: Vec<u8>, shred2: Vec<u8>) -> Self {
         DuplicateSlotProof { shred1, shred2 }

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -410,13 +410,19 @@ impl ErasureMeta {
 impl MerkleRootMeta {
     pub(crate) fn from_shred(shred: &Shred) -> Self {
         Self {
-            merkle_root: shred.merkle_root().unwrap_or_default(),
+            // An error here after the shred has already sigverified
+            // can only indicate that the leader is sending
+            // legacy or malformed shreds. We should still store
+            // `None` for those cases in blockstore, as a later
+            // shred that contains a proper merkle root would constitute
+            // a valid duplicate shred proof.
+            merkle_root: shred.merkle_root().ok(),
             first_received_shred_index: shred.index(),
             first_received_shred_type: shred.shred_type(),
         }
     }
 
-    pub(crate) fn merkle_root(&self) -> Hash {
+    pub(crate) fn merkle_root(&self) -> Option<Hash> {
         self.merkle_root
     }
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -337,6 +337,8 @@ impl Shred {
     dispatch!(pub fn payload(&self) -> &Vec<u8>);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
 
+    dispatch!(pub fn merkle_root(&self) -> Option<Hash>);
+
     // Only for tests.
     dispatch!(pub fn set_index(&mut self, index: u32));
     dispatch!(pub fn set_slot(&mut self, slot: Slot));

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -334,10 +334,9 @@ impl Shred {
     dispatch!(pub(crate) fn erasure_shard_index(&self) -> Result<usize, Error>);
 
     dispatch!(pub fn into_payload(self) -> Vec<u8>);
+    dispatch!(pub fn merkle_root(&self) -> Result<Hash, Error>);
     dispatch!(pub fn payload(&self) -> &Vec<u8>);
     dispatch!(pub fn sanitize(&self) -> Result<(), Error>);
-
-    dispatch!(pub fn merkle_root(&self) -> Option<Hash>);
 
     // Only for tests.
     dispatch!(pub fn set_index(&mut self, index: u32));

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -154,7 +154,7 @@ impl ShredData {
         Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size)?)
     }
 
-    fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         let proof_size = self.proof_size()?;
         let index = self.erasure_shard_index()?;
         let proof_offset = Self::proof_offset(proof_size)?;
@@ -266,7 +266,7 @@ impl ShredCode {
         Ok(Self::SIZE_OF_HEADERS + Self::capacity(proof_size)?)
     }
 
-    fn merkle_root(&self) -> Result<Hash, Error> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         let proof_size = self.proof_size()?;
         let index = self.erasure_shard_index()?;
         let proof_offset = Self::proof_offset(proof_size)?;

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -47,10 +47,10 @@ impl ShredCode {
         }
     }
 
-    pub(super) fn merkle_root(&self) -> Option<Hash> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         match self {
-            Self::Legacy(_) => None,
-            Self::Merkle(shred) => shred.merkle_root().ok(),
+            Self::Legacy(_) => Err(Error::InvalidShredType),
+            Self::Merkle(shred) => shred.merkle_root(),
         }
     }
 

--- a/ledger/src/shred/shred_code.rs
+++ b/ledger/src/shred/shred_code.rs
@@ -6,7 +6,7 @@ use {
         CodingShredHeader, Error, ShredCommonHeader, ShredType, SignedData,
         DATA_SHREDS_PER_FEC_BLOCK, MAX_DATA_SHREDS_PER_SLOT, SIZE_OF_NONCE,
     },
-    solana_sdk::{clock::Slot, packet::PACKET_DATA_SIZE, signature::Signature},
+    solana_sdk::{clock::Slot, hash::Hash, packet::PACKET_DATA_SIZE, signature::Signature},
     static_assertions::const_assert_eq,
 };
 
@@ -44,6 +44,13 @@ impl ShredCode {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
             Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
+
+    pub(super) fn merkle_root(&self) -> Option<Hash> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Merkle(shred) => shred.merkle_root().ok(),
         }
     }
 

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -41,10 +41,10 @@ impl ShredData {
         }
     }
 
-    pub(super) fn merkle_root(&self) -> Option<Hash> {
+    pub(super) fn merkle_root(&self) -> Result<Hash, Error> {
         match self {
-            Self::Legacy(_) => None,
-            Self::Merkle(shred) => shred.merkle_root().ok(),
+            Self::Legacy(_) => Err(Error::InvalidShredType),
+            Self::Merkle(shred) => shred.merkle_root(),
         }
     }
 

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -7,7 +7,7 @@ use {
         DataShredHeader, Error, ShredCommonHeader, ShredFlags, ShredType, ShredVariant, SignedData,
         MAX_DATA_SHREDS_PER_SLOT,
     },
-    solana_sdk::{clock::Slot, signature::Signature},
+    solana_sdk::{clock::Slot, hash::Hash, signature::Signature},
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -38,6 +38,13 @@ impl ShredData {
         match self {
             Self::Legacy(shred) => Ok(SignedData::Chunk(shred.signed_data()?)),
             Self::Merkle(shred) => Ok(SignedData::MerkleRoot(shred.signed_data()?)),
+        }
+    }
+
+    pub(super) fn merkle_root(&self) -> Option<Hash> {
+        match self {
+            Self::Legacy(_) => None,
+            Self::Merkle(shred) => shred.merkle_root().ok(),
         }
     }
 


### PR DESCRIPTION
#### Problem
We need to access the `merkle_root` for merkle shreds in blockstore.

#### Summary of Changes
Dispatch to it, return `None` for legacy shreds.

Split from #33889
Contributes to #33644  
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
