### PR TITLE
[zk-token-sdk] Add range proof generation error types

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
@@ -47,7 +47,7 @@ impl BatchedRangeProofU128Data {
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))
             .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
 
-        // `u64::BITS` is 128, which fits in a single byte and should not overflow to `usize` for
+        // `u128::BITS` is 128, which fits in a single byte and should not overflow to `usize` for
         // an overwhelming number of platforms. However, to be extra cautious, use `try_from` and
         // `unwrap` here. A simple case `u128::BITS as usize` can silently overflow.
         let expected_bit_length = usize::try_from(u128::BITS).unwrap();

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -11,6 +11,8 @@ pub enum RangeProofGenerationError {
     InvalidBitSize,
     #[error("insufficient generators for the proof")]
     GeneratorLengthMismatch,
+    #[error("inner product length mismatch")]
+    InnerProductLengthMismatch,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -5,6 +5,8 @@ use {crate::errors::TranscriptError, thiserror::Error};
 pub enum RangeProofGenerationError {
     #[error("maximum generator length exceeded")]
     MaximumGeneratorLengthExceeded,
+    #[error("amounts, commitments, openings, or bit lengths vectors have different lengths")]
+    VectorLengthMismatch,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]
@@ -25,6 +27,8 @@ pub enum RangeProofVerificationError {
     InvalidGeneratorsLength,
     #[error("maximum generator length exceeded")]
     MaximumGeneratorLengthExceeded,
+    #[error("commitments and bit lengths vectors have different lengths")]
+    VectorLengthMismatch,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -9,6 +9,8 @@ pub enum RangeProofGenerationError {
     VectorLengthMismatch,
     #[error("invalid bit size")]
     InvalidBitSize,
+    #[error("insufficient generators for the proof")]
+    GeneratorLengthMismatch,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/range_proof/errors.rs
+++ b/zk-token-sdk/src/range_proof/errors.rs
@@ -7,6 +7,8 @@ pub enum RangeProofGenerationError {
     MaximumGeneratorLengthExceeded,
     #[error("amounts, commitments, openings, or bit lengths vectors have different lengths")]
     VectorLengthMismatch,
+    #[error("invalid bit size")]
+    InvalidBitSize,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -97,6 +97,7 @@ impl InnerProductProof {
 
             let L = RistrettoPoint::multiscalar_mul(
                 a_L.iter()
+                    // `n` was previously divided in half and therefore, it cannot overflow.
                     .zip(G_factors[n..n.checked_mul(2).unwrap()].iter())
                     .map(|(a_L_i, g)| a_L_i * g)
                     .chain(

--- a/zk-token-sdk/src/range_proof/inner_product.rs
+++ b/zk-token-sdk/src/range_proof/inner_product.rs
@@ -90,8 +90,10 @@ impl InnerProductProof {
             let (G_L, G_R) = G.split_at_mut(n);
             let (H_L, H_R) = H.split_at_mut(n);
 
-            let c_L = util::inner_product(a_L, b_R);
-            let c_R = util::inner_product(a_R, b_L);
+            let c_L = util::inner_product(a_L, b_R)
+                .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
+            let c_R = util::inner_product(a_R, b_L)
+                .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
             let L = RistrettoPoint::multiscalar_mul(
                 a_L.iter()
@@ -162,8 +164,10 @@ impl InnerProductProof {
             let (G_L, G_R) = G.split_at_mut(n);
             let (H_L, H_R) = H.split_at_mut(n);
 
-            let c_L = util::inner_product(a_L, b_R);
-            let c_R = util::inner_product(a_R, b_L);
+            let c_L = util::inner_product(a_L, b_R)
+                .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
+            let c_R = util::inner_product(a_R, b_L)
+                .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
             let L = RistrettoPoint::multiscalar_mul(
                 a_L.iter().chain(b_R.iter()).chain(iter::once(&c_L)),
@@ -435,7 +439,7 @@ mod tests {
 
         let a: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
         let b: Vec<_> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
-        let c = util::inner_product(&a, &b);
+        let c = util::inner_product(&a, &b).unwrap();
 
         let G_factors: Vec<Scalar> = iter::repeat(Scalar::one()).take(n).collect();
 

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -79,6 +79,14 @@ impl RangeProof {
             return Err(RangeProofGenerationError::VectorLengthMismatch);
         }
 
+        // each bit length must be greater than 0 for the proof to make sense
+        if bit_lengths
+            .iter()
+            .any(|bit_length| *bit_length == 0 || *bit_length > u64::BITS as usize)
+        {
+            return Err(RangeProofGenerationError::InvalidBitSize);
+        }
+
         // total vector dimension to compute the ultimate inner product proof for
         let nm: usize = bit_lengths.iter().sum();
         if !nm.is_power_of_two() {

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -75,12 +75,15 @@ impl RangeProof {
     ) -> Result<Self, RangeProofGenerationError> {
         // amounts, bit-lengths, openings must be same length vectors
         let m = amounts.len();
-        assert_eq!(bit_lengths.len(), m);
-        assert_eq!(openings.len(), m);
+        if bit_lengths.len() != m || openings.len() != m {
+            return Err(RangeProofGenerationError::VectorLengthMismatch);
+        }
 
         // total vector dimension to compute the ultimate inner product proof for
         let nm: usize = bit_lengths.iter().sum();
-        assert!(nm.is_power_of_two());
+        if !nm.is_power_of_two() {
+            return Err(RangeProofGenerationError::VectorLengthMismatch);
+        }
 
         let bp_gens = BulletproofGens::new(nm)
             .map_err(|_| RangeProofGenerationError::MaximumGeneratorLengthExceeded)?;
@@ -238,7 +241,9 @@ impl RangeProof {
         transcript: &mut Transcript,
     ) -> Result<(), RangeProofVerificationError> {
         // commitments and bit-lengths must be same length vectors
-        assert_eq!(comms.len(), bit_lengths.len());
+        if comms.len() != bit_lengths.len() {
+            return Err(RangeProofVerificationError::VectorLengthMismatch);
+        }
 
         let m = bit_lengths.len();
         let nm: usize = bit_lengths.iter().sum();

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -227,7 +227,7 @@ impl RangeProof {
             l_vec,
             r_vec,
             transcript,
-        );
+        )?;
 
         Ok(RangeProof {
             A,

--- a/zk-token-sdk/src/range_proof/mod.rs
+++ b/zk-token-sdk/src/range_proof/mod.rs
@@ -172,7 +172,9 @@ impl RangeProof {
         }
 
         // define t(x) = <l(x), r(x)> = t_0 + t_1*x + t_2*x
-        let t_poly = l_poly.inner_product(&r_poly);
+        let t_poly = l_poly
+            .inner_product(&r_poly)
+            .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
         // generate Pedersen commitment for the coefficients t_1 and t_2
         let (T_1, t_1_blinding) = Pedersen::new(t_poly.1);

--- a/zk-token-sdk/src/range_proof/util.rs
+++ b/zk-token-sdk/src/range_proof/util.rs
@@ -98,7 +98,7 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 /// \\[
 ///    {\langle {\mathbf{a}}, {\mathbf{b}} \rangle} = \sum\_{i=0}^{n-1} a\_i \cdot b\_i.
 /// \\]
-/// Panics if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
+/// Errors if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
 pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Option<Scalar> {
     let mut out = Scalar::zero();
     if a.len() != b.len() {

--- a/zk-token-sdk/src/range_proof/util.rs
+++ b/zk-token-sdk/src/range_proof/util.rs
@@ -11,20 +11,20 @@ impl VecPoly1 {
         VecPoly1(vec![Scalar::zero(); n], vec![Scalar::zero(); n])
     }
 
-    pub fn inner_product(&self, rhs: &VecPoly1) -> Poly2 {
+    pub fn inner_product(&self, rhs: &VecPoly1) -> Option<Poly2> {
         // Uses Karatsuba's method
         let l = self;
         let r = rhs;
 
-        let t0 = inner_product(&l.0, &r.0);
-        let t2 = inner_product(&l.1, &r.1);
+        let t0 = inner_product(&l.0, &r.0)?;
+        let t2 = inner_product(&l.1, &r.1)?;
 
         let l0_plus_l1 = add_vec(&l.0, &l.1);
         let r0_plus_r1 = add_vec(&r.0, &r.1);
 
-        let t1 = inner_product(&l0_plus_l1, &r0_plus_r1) - t0 - t2;
+        let t1 = inner_product(&l0_plus_l1, &r0_plus_r1)? - t0 - t2;
 
-        Poly2(t0, t1, t2)
+        Some(Poly2(t0, t1, t2))
     }
 
     pub fn eval(&self, x: Scalar) -> Vec<Scalar> {
@@ -99,15 +99,15 @@ pub fn read32(data: &[u8]) -> [u8; 32] {
 ///    {\langle {\mathbf{a}}, {\mathbf{b}} \rangle} = \sum\_{i=0}^{n-1} a\_i \cdot b\_i.
 /// \\]
 /// Panics if the lengths of \\(\mathbf{a}\\) and \\(\mathbf{b}\\) are not equal.
-pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Scalar {
+pub fn inner_product(a: &[Scalar], b: &[Scalar]) -> Option<Scalar> {
     let mut out = Scalar::zero();
     if a.len() != b.len() {
-        panic!("inner_product(a,b): lengths of vectors do not match");
+        return None;
     }
     for i in 0..a.len() {
         out += a[i] * b[i];
     }
-    out
+    Some(out)
 }
 
 /// Takes the sum of all the powers of `x`, up to `n`


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/issues/33507, https://github.com/solana-labs/solana/issues/33509, https://github.com/solana-labs/solana/issues/33510, and https://github.com/solana-labs/solana/issues/33525.

#### Summary of Changes
- [96020b3](https://github.com/solana-labs/solana/pull/34065/commits/96020b394505a72969f2a37a3f02914e1d9ab418): Previously, mismatch on vector lengths used in range proof was addressed by assert statements. This commit replaces them with `RangeProofGenerationError::VectorLengthMismatch`.
- [782b617](https://github.com/solana-labs/solana/pull/34065/commits/782b6173c4c3c0d7809d2f1decb92f94bdc40660): Range proof on 0-bit numbers does not really make sense, but we did not specifically take care of this case. This commit takes care of this special case. 
- [9f923da](https://github.com/solana-labs/solana/pull/34065/commits/9f923daf1cde7f4400d3c85936057fe2bed8c920): Replaced assert statements related to generator length mismatch with `RangeProofGenerationError::GeneratorLengthMismatch`.
- [d55d048](https://github.com/solana-labs/solana/pull/34065/commits/d55d048ae4ac997e4e25e5641ab80b2acc3b1359): Removed unchecked arithmetic with checked arithmetic and unwraps. For places that are not obvious whether it is safe, I added comments. Addresses https://github.com/solana-labs/solana/issues/33507.
- [9b18167](https://github.com/solana-labs/solana/pull/34065/commits/9b1816701c1f092a5ce66faea9f0929323582f25): When the input to the range proof generator become very large, then this could lead to expected behavior. I added a cap of 2^32, which should be plenty for all practical use cases. Addresses https://github.com/solana-labs/solana/issues/33509.
- [962ae00](https://github.com/solana-labs/solana/pull/34065/commits/962ae00c6e7fd9e747cfe320afeb68eae84292f4): Made inner product to return `RangeProofGenerationError::InnerProductLengthMismatch` when invoked on vectors of different lengths. Addresses https://github.com/solana-labs/solana/issues/33510.
- [5f03de9](https://github.com/solana-labs/solana/pull/34065/commits/5f03de905cf0a4581032e2db14439d85191a3e14): When verifying range proof, I added a condition to check that the number of commitments are capped at `MAX_COMMITMENTS`. Addresses https://github.com/solana-labs/solana/issues/33525.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
