### PR TITLE
tune ancient append vec size to 128M

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -918,16 +918,13 @@ impl<'a> AccountsToStore<'a> {
 }
 
 /// capacity of an ancient append vec
-#[allow(clippy::assertions_on_constants)]
 pub const fn get_ancient_append_vec_capacity() -> u64 {
-    use crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE;
     const PAGE_SIZE: u64 = 4 * 1024;
 
     // There is a trade-off for selecting the ancient append vec size. Too small size will result in
     // too many ancient append vec memory mapped files. Too big size will make it difficult to clean and shrink.
     // Hence, we choose approximately 130MB (i.e. 134,217,728 bytes) for the ancient append vec size.
     const RESULT: u64 = PAGE_SIZE * 32768;
-    const _: () = assert!(RESULT < MAXIMUM_APPEND_VEC_FILE_SIZE);
     RESULT
 }
 
@@ -2055,10 +2052,7 @@ pub mod tests {
 
     #[test]
     fn test_get_ancient_append_vec_capacity() {
-        assert_eq!(
-            get_ancient_append_vec_capacity(),
-            crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE / 10 - 2048
-        );
+        assert_eq!(get_ancient_append_vec_capacity(), 134217728);
     }
 
     #[test]

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -926,6 +926,11 @@ pub const fn get_ancient_append_vec_capacity() -> u64 {
     // 128MB for the ancient append vec size.
     const RESULT: u64 = 128 * 1024 * 1024;
 
+    use crate::append_vec::MAXIMUM_APPEND_VEC_FILE_SIZE;
+    const _: () = assert!(
+        RESULT < MAXIMUM_APPEND_VEC_FILE_SIZE,
+        "ancient append vec size should be less than the maximum append vec size"
+    );
     const PAGE_SIZE: u64 = 4 * 1024;
     const _: () = assert!(
         RESULT % PAGE_SIZE == 0,


### PR DESCRIPTION
#### Problem
     
There is a trade-off for selecting the ancient append vec size. Too small size will result in
too many ancient append vec memory mapped files. Too big size will make it difficult to clean and shrink.
Here, we choose 128M bytes for the ancient append vec size.

#### Summary of Changes

set ancient append vec size to 128M


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
