### PR TITLE
Support zstd genesis archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6347,12 +6347,14 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "test-case",
  "thiserror",
  "tokio",
  "tokio-stream",
  "trees",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5341,6 +5341,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -63,6 +63,7 @@ strum_macros = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
+zstd = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -62,11 +62,13 @@ spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }
+tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-stream = { workspace = true }
 trees = { workspace = true }
+zstd = { workspace = true }
 
 [dependencies.rocksdb]
 # Avoid the vendored bzip2 within rocksdb-sys that can cause linker conflicts

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4126,7 +4126,7 @@ pub fn create_new_ledger(
         zstd::Encoder::auto_finish(zstd::Encoder::new(File::create(&archive_path)?, 0)?);
     let mut archive = tar::Builder::new(archive_stream);
     archive.append_path_with_name(ledger_path.join(DEFAULT_GENESIS_FILE), DEFAULT_GENESIS_FILE)?;
-    archive.append_dir_all("rocksdb", ledger_path.join(blockstore_dir))?;
+    archive.append_dir_all(blockstore_dir, ledger_path.join(blockstore_dir))?;
     archive.finish()?;
     drop(archive);
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4693,6 +4693,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -5276,11 +5277,13 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "tar",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
  "trees",
+ "zstd",
 ]
 
 [[package]]

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -36,7 +36,9 @@ use {
         snapshot_utils,
     },
     solana_sdk::{
-        exit::Exit, genesis_config::DEFAULT_GENESIS_DOWNLOAD_PATH, hash::Hash,
+        exit::Exit,
+        genesis_config::{DEFAULT_GENESIS_DOWNLOAD_PATH, ZSTD_GENESIS_DOWNLOAD_PATH},
+        hash::Hash,
         native_token::lamports_to_sol,
     },
     solana_send_transaction_service::send_transaction_service::{self, SendTransactionService},
@@ -126,7 +128,7 @@ impl RpcRequestMiddleware {
     }
 
     fn is_file_get_path(&self, path: &str) -> bool {
-        if path == DEFAULT_GENESIS_DOWNLOAD_PATH {
+        if path == DEFAULT_GENESIS_DOWNLOAD_PATH || path == ZSTD_GENESIS_DOWNLOAD_PATH {
             return true;
         }
 
@@ -194,6 +196,10 @@ impl RpcRequestMiddleware {
             match path {
                 DEFAULT_GENESIS_DOWNLOAD_PATH => {
                     inc_new_counter_info!("rpc-get_genesis", 1);
+                    self.ledger_path.join(stem)
+                }
+                ZSTD_GENESIS_DOWNLOAD_PATH => {
+                    inc_new_counter_info!("rpc-get_zstd_genesis", 1);
                     self.ledger_path.join(stem)
                 }
                 _ => {
@@ -744,6 +750,7 @@ mod tests {
         assert!(!rrm.is_file_get_path(DEFAULT_GENESIS_ARCHIVE));
         assert!(!rrm.is_file_get_path("//genesis.tar.bz2"));
         assert!(!rrm.is_file_get_path("/../genesis.tar.bz2"));
+        assert!(rrm.is_file_get_path(ZSTD_GENESIS_DOWNLOAD_PATH));
 
         // These two are redirects
         assert!(!rrm.is_file_get_path("/snapshot.tar.bz2"));

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -36,6 +36,7 @@ use {
 pub const DEFAULT_GENESIS_FILE: &str = "genesis.bin";
 pub const DEFAULT_GENESIS_ARCHIVE: &str = "genesis.tar.bz2";
 pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
+pub const ZSTD_GENESIS_ARCHIVE: &str = "genesis.tar.zst";
 
 // deprecated default that is no longer used
 pub const UNUSED_DEFAULT: u64 = 1024;

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_GENESIS_FILE: &str = "genesis.bin";
 pub const DEFAULT_GENESIS_ARCHIVE: &str = "genesis.tar.bz2";
 pub const DEFAULT_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.bz2";
 pub const ZSTD_GENESIS_ARCHIVE: &str = "genesis.tar.zst";
+pub const ZSTD_GENESIS_DOWNLOAD_PATH: &str = "/genesis.tar.zst";
 
 // deprecated default that is no longer used
 pub const UNUSED_DEFAULT: u64 = 1024;


### PR DESCRIPTION
Taking over https://github.com/solana-labs/solana/pull/33614 from @ripatel-fd - we exchanged some DM's and agreed I could take this off his hands to drive to completion.

#### Problem
- BZip2 is deprecated in most of the Solana protocol.
- Genesis archives are one of the few places where BZip2 is still the main compression algorithm.
- solana-test-validator creates a tar subprocess when creating new ledgers.

#### Summary of Changes
- Allows the validator to discover and load genesis.tar.zst archives (continues to support genesis.tar.bz2)
- Uses the tar crate instead of a subprocess to create new genesis archives.
- Uses genesis.tar.zst when creating new ledgers

The force pushes were to rebase to tip of master in order to run against latest changes