### PR TITLE
clean feature: no_overflow_rent_distribution

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7876,11 +7876,6 @@ impl Bank {
             .shrink_ancient_slots(self.epoch_schedule())
     }
 
-    pub fn no_overflow_rent_distribution_enabled(&self) -> bool {
-        self.feature_set
-            .is_active(&feature_set::no_overflow_rent_distribution::id())
-    }
-
     pub fn prevent_rent_paying_rent_recipients(&self) -> bool {
         self.feature_set
             .is_active(&feature_set::prevent_rent_paying_rent_recipients::id())


### PR DESCRIPTION
#### Problem
`no_overflow_rent_distribution` (https://github.com/solana-labs/solana/pull/12112) is activated on all clusters and should be cleaned up. I noticed it when doing some other fee related changes.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
