### PR TITLE
test cleanup: remove reference to verify_tx_signatures_len feature

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9662,11 +9662,8 @@ fn test_verify_and_hash_transaction_sig_len() {
         mut genesis_config, ..
     } = create_genesis_config_with_leader(42, &solana_sdk::pubkey::new_rand(), 42);
 
-    // activate all features but verify_tx_signatures_len
+    // activate all features
     activate_all_features(&mut genesis_config);
-    genesis_config
-        .accounts
-        .remove(&feature_set::verify_tx_signatures_len::id());
     let bank = Bank::new_for_tests(&genesis_config);
 
     let recent_blockhash = Hash::new_unique();


### PR DESCRIPTION
#### Problem
The `verify_tx_signatures_len` feature is always active now but there's still a test that tries to disable it for no reason

#### Summary of Changes
Stop disabling `verify_tx_signatures_len` feature in tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
