### PR TITLE
Uses `RENT_EXEMPT_RENT_EPOCH` to mark account as rent exempt

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -14,7 +14,7 @@ use {
         ancestors::Ancestors,
         blockhash_queue::BlockhashQueue,
         nonce_info::{NonceFull, NonceInfo},
-        rent_collector::RentCollector,
+        rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
         rent_debits::RentDebits,
         storable_accounts::StorableAccounts,
         transaction_error_metrics::TransactionErrorMetrics,
@@ -402,7 +402,7 @@ impl Accounts {
                                     // All new accounts must be rent-exempt (enforced in Bank::execute_loaded_transaction).
                                     // Currently, rent collection sets rent_epoch to u64::MAX, but initializing the account
                                     // with this field already set would allow us to skip rent collection for these accounts.
-                                    default_account.set_rent_epoch(u64::MAX);
+                                    default_account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
                                 }
                                 (default_account.data().len(), default_account, 0)
                             })


### PR DESCRIPTION
#### Problem

While reviewing #33945, I noticed that when we set a new account's rent epoch to be rent exempt, we aren't using the `RENT_EXEMPT_RENT_EPOCH` constant. This isn't a correctness problem, but I did initially miss this usage in my search because I was grepping for the constant. Maybe this has happened to others as well.


#### Summary of Changes

Use the constant instead.