### PR TITLE
blockstore: make merkle root Optional in MerkleRootMeta column

### DIFF
--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -140,8 +140,8 @@ pub(crate) struct ErasureConfig {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MerkleRootMeta {
-    /// The merkle root
-    merkle_root: Hash,
+    /// The merkle root, `None` for legacy shreds
+    merkle_root: Option<Hash>,
     /// The first received shred index
     first_received_shred_index: u32,
     /// The shred type of the first received shred


### PR DESCRIPTION
#### Problem
After discussion, it seems like legacy shreds should be supported for a while longer. To avoid having to use `unwrap_or_default()` and mess around with `Hash::default()`, we change the type of the yet to be used column to optional. 

#### Summary of Changes
Change type. This will be backported to the same branches as #33979  
Contributes to #33644 

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
