### PR TITLE
storage-bigtable: Return error if attempting to write to table NotFound

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -274,7 +274,8 @@ impl BigTableConnection {
     {
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
-            Ok(client.put_bincode_cells(table, cells).await?)
+            let result = client.put_bincode_cells(table, cells).await;
+            check_table_not_found(result)
         })
         .await
     }
@@ -312,7 +313,8 @@ impl BigTableConnection {
     {
         retry(ExponentialBackoff::default(), || async {
             let mut client = self.client();
-            Ok(client.put_protobuf_cells(table, cells).await?)
+            let result = client.put_protobuf_cells(table, cells).await;
+            check_table_not_found(result)
         })
         .await
     }

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -6,7 +6,7 @@ use {
         compression::{compress_best, decompress},
         root_ca_certificate, CredentialType,
     },
-    backoff::{future::retry, ExponentialBackoff},
+    backoff::{future::retry, Error as BackoffError, ExponentialBackoff},
     log::*,
     std::{
         str::FromStr,
@@ -82,6 +82,15 @@ pub enum Error {
 
     #[error("Timeout")]
     Timeout,
+}
+
+fn check_table_not_found<T>(result: Result<T>) -> std::result::Result<T, BackoffError<Error>> {
+    if let Err(Error::Rpc(ref err)) = result {
+        if err.code() == tonic::Code::NotFound && err.message().starts_with("table") {
+            return Err(BackoffError::Permanent(Error::Rpc(err.clone())));
+        }
+    }
+    Ok(result?)
 }
 
 impl std::convert::From<std::io::Error> for Error {


### PR DESCRIPTION
#### Problem
I'm working on adding support for bigtable uploads to include entries. This will require users to add an `entries` table to their bigtable instances. Currently, our storage-bigtable write apis retry with exponential backoff, and will retry forever without reporting errors. This means that users who run the new entries upload code without having prepped the table will see their bigtable-uploader hang with no indication why.

#### Summary of Changes
Return `backoff::Error::Permanent` when a table isn't found so that retry halts and an error is actually printed.
Some kind of general error tracing across all the places we use `retry` would probably be helpful, but this seems like a reasonable short circuit.
