### PR TITLE
storage-bigtable: Upload entries

### DIFF
--- a/ledger/src/bigtable_upload.rs
+++ b/ledger/src/bigtable_upload.rs
@@ -4,7 +4,6 @@ use {
     log::*,
     solana_measure::measure::Measure,
     solana_sdk::clock::Slot,
-    solana_transaction_status::VersionedConfirmedBlockWithEntries,
     std::{
         cmp::{max, min},
         collections::HashSet,
@@ -225,13 +224,11 @@ pub async fn upload_confirmed_blocks(
                 num_blocks -= 1;
                 None
             }
-            Some(VersionedConfirmedBlockWithEntries {
-                block: confirmed_block,
-                ..
-            }) => {
+            Some(confirmed_block) => {
                 let bt = bigtable.clone();
                 Some(tokio::spawn(async move {
-                    bt.upload_confirmed_block(slot, confirmed_block).await
+                    bt.upload_confirmed_block_with_entries(slot, confirmed_block)
+                        .await
                 }))
             }
         });

--- a/storage-bigtable/init-bigtable.sh
+++ b/storage-bigtable/init-bigtable.sh
@@ -16,7 +16,7 @@ if [[ -n $BIGTABLE_EMULATOR_HOST ]]; then
   cbt+=(-project emulator)
 fi
 
-for table in blocks tx tx-by-addr; do
+for table in blocks entries tx tx-by-addr; do
   (
     set -x
     "${cbt[@]}" createtable $table

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -20,7 +20,8 @@ use {
         extract_and_fmt_memos, ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
         ConfirmedTransactionWithStatusMeta, Reward, TransactionByAddrInfo,
         TransactionConfirmationStatus, TransactionStatus, TransactionStatusMeta,
-        TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedTransactionWithStatusMeta,
+        TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedConfirmedBlockWithEntries,
+        VersionedTransactionWithStatusMeta,
     },
     std::{
         collections::{HashMap, HashSet},
@@ -883,7 +884,27 @@ impl LedgerStorage {
             "LedgerStorage::upload_confirmed_block request received: {:?}",
             slot
         );
+        self.upload_confirmed_block_with_entries(
+            slot,
+            VersionedConfirmedBlockWithEntries {
+                block: confirmed_block,
+                entries: vec![],
+            },
+        )
+        .await
+    }
+
+    pub async fn upload_confirmed_block_with_entries(
+        &self,
+        slot: Slot,
+        confirmed_block: VersionedConfirmedBlockWithEntries,
+    ) -> Result<()> {
+        trace!(
+            "LedgerStorage::upload_confirmed_block_with_entries request received: {:?}",
+            slot
+        );
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
+        let confirmed_block = confirmed_block.block;
 
         let mut tx_cells = vec![];
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {

--- a/storage-proto/build.rs
+++ b/storage-proto/build.rs
@@ -6,7 +6,11 @@ fn main() -> Result<(), std::io::Error> {
     }
 
     let proto_base_path = std::path::PathBuf::from("proto");
-    let proto_files = ["confirmed_block.proto", "transaction_by_addr.proto"];
+    let proto_files = [
+        "confirmed_block.proto",
+        "entries.proto",
+        "transaction_by_addr.proto",
+    ];
     let mut protos = Vec::new();
     for proto_file in &proto_files {
         let proto = proto_base_path.join(proto_file);

--- a/storage-proto/proto/entries.proto
+++ b/storage-proto/proto/entries.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package solana.storage.Entries;
+
+message Entries {
+    repeated Entry entries = 1;
+}
+
+message Entry {
+    uint32 index = 1;
+    uint64 num_hashes = 2;
+    bytes hash = 3;
+    uint64 num_transactions = 4;
+    uint32 starting_transaction_index = 5;
+}

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -15,7 +15,7 @@ use {
         transaction_context::TransactionReturnData,
     },
     solana_transaction_status::{
-        ConfirmedBlock, InnerInstruction, InnerInstructions, Reward, RewardType,
+        ConfirmedBlock, EntrySummary, InnerInstruction, InnerInstructions, Reward, RewardType,
         TransactionByAddrInfo, TransactionStatusMeta, TransactionTokenBalance,
         TransactionWithStatusMeta, VersionedConfirmedBlock, VersionedTransactionWithStatusMeta,
     },
@@ -39,6 +39,11 @@ pub mod tx_by_addr {
         env!("OUT_DIR"),
         "/solana.storage.transaction_by_addr.rs"
     ));
+}
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+pub mod entries {
+    include!(concat!(env!("OUT_DIR"), "/solana.storage.entries.rs"));
 }
 
 impl From<Vec<Reward>> for generated::Rewards {
@@ -1186,6 +1191,18 @@ impl TryFrom<tx_by_addr::TransactionByAddr> for Vec<TransactionByAddrInfo> {
             .into_iter()
             .map(|tx_by_addr| tx_by_addr.try_into())
             .collect::<Result<Vec<TransactionByAddrInfo>, Self::Error>>()
+    }
+}
+
+impl From<(usize, EntrySummary)> for entries::Entry {
+    fn from((index, entry_summary): (usize, EntrySummary)) -> Self {
+        entries::Entry {
+            index: index as u32,
+            num_hashes: entry_summary.num_hashes,
+            hash: entry_summary.hash.as_ref().into(),
+            num_transactions: entry_summary.num_transactions,
+            starting_transaction_index: entry_summary.starting_transaction_index as u32,
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
Blocks stored on bigtable are flattened, so they don't include the entry data that would allow block hashes to be verified.
Other historical ledger archives (like foundation storage buckets and [Old Faithful](https://github.com/rpcpool/yellowstone-faithful)) do include entry data, but it would provide additional redundancy if the bigtable store were made complete.

#### Summary of Changes
Add entries table to default bigtable setup
Upload entry summary data in `bigtable_upload` (used by both `solana-ledger-tool bigtable upload` and the BigtableUploadService). Entry-summary data is the entry data minus the actual transactions, plus a little extra indexing data to make it easy to regenerate entries from the flattened list of transactions. (This parallels geyser Entry notifications.)

✅ ~~Needs rebase on https://github.com/solana-labs/solana/pull/34098~~
Handling for deleting entries (on block delete) and warehousing docs will be PRed separately.
