### PR TITLE
Support logging in geyser plugins

### DIFF
--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -322,8 +322,8 @@ pub type Result<T> = std::result::Result<T, GeyserPluginError>;
 /// as well as how they will handle streamed data.
 pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// The callback to allow the plugin to setup the logging configuration using the logger
-    /// and log level specified by the validator. Will be called the first before all other
-    /// callback and only once.
+    /// and log level specified by the validator. Will be called first on load/reload, before any other
+    /// callback, and only called once.
     #[allow(unused_variables)]
     fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
         Ok(())

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -324,6 +324,17 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// The callback to allow the plugin to setup the logging configuration using the logger
     /// and log level specified by the validator. Will be called first on load/reload, before any other
     /// callback, and only called once.
+    /// # Examples
+    ///
+    /// ```
+    /// fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
+    ///    log::set_max_level(level);
+    ///    if let Err(err) = log::set_logger(logger) {
+    ///        return Err(GeyserPluginError::Custom(Box::new(err)));
+    ///    }
+    ///    Ok(())
+    /// }
+    /// ```
     #[allow(unused_variables)]
     fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
         Ok(())

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -321,6 +321,12 @@ pub type Result<T> = std::result::Result<T, GeyserPluginError>;
 /// Geyser plugins must describe desired behavior for load and unload,
 /// as well as how they will handle streamed data.
 pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
+    /// Will be called the first and only once
+    #[allow(unused_variables)]
+    fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
+        Ok(())
+    }
+
     fn name(&self) -> &'static str;
 
     /// The callback called when a plugin is loaded by the system,

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -327,12 +327,22 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     /// # Examples
     ///
     /// ```
-    /// fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
-    ///    log::set_max_level(level);
-    ///    if let Err(err) = log::set_logger(logger) {
-    ///        return Err(GeyserPluginError::Custom(Box::new(err)));
-    ///    }
-    ///    Ok(())
+    /// use solana_geyser_plugin_interface::geyser_plugin_interface::{GeyserPlugin,
+    /// GeyserPluginError, Result};
+    ///
+    /// #[derive(Debug)]
+    /// struct SamplePlugin;
+    /// impl GeyserPlugin for SamplePlugin {
+    ///     fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
+    ///        log::set_max_level(level);
+    ///        if let Err(err) = log::set_logger(logger) {
+    ///            return Err(GeyserPluginError::Custom(Box::new(err)));
+    ///        }
+    ///        Ok(())
+    ///     }
+    ///     fn name(&self) -> &'static str {
+    ///         &"sample"
+    ///     }
     /// }
     /// ```
     #[allow(unused_variables)]

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -321,7 +321,9 @@ pub type Result<T> = std::result::Result<T, GeyserPluginError>;
 /// Geyser plugins must describe desired behavior for load and unload,
 /// as well as how they will handle streamed data.
 pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
-    /// Will be called the first and only once
+    /// The callback to allow the plugin to setup the logging configuration using the logger
+    /// and log level specified by the validator. Will be called the first before all other
+    /// callback and only once.
     #[allow(unused_variables)]
     fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
         Ok(())

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -225,7 +225,6 @@ impl GeyserPluginManager {
         let mut current_plugin = self.plugins.remove(idx);
         let name = current_plugin.name().to_string();
         current_plugin.on_unload();
-        // The plugin must be first dropped before dropping the library to avoid crash.
         drop(current_plugin);
         drop(current_lib);
         info!("Unloaded plugin {name} at idx {idx}");

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -107,6 +107,18 @@ impl GeyserPluginManager {
             });
         }
 
+        // Initialize logging for the plugin
+        new_plugin
+            .setup_logger(log::logger(), log::max_level())
+            .map_err(|on_load_err| jsonrpc_core::Error {
+                code: ErrorCode::InvalidRequest,
+                message: format!(
+                    "setup_logger method of plugin {} failed: {on_load_err}",
+                    new_plugin.name()
+                ),
+                data: None,
+            })?;
+
         // Call on_load and push plugin
         new_plugin
             .on_load(new_config_file, false)
@@ -193,6 +205,18 @@ impl GeyserPluginManager {
             });
         }
 
+        // Initialize logging for the plugin
+        new_plugin
+            .setup_logger(log::logger(), log::max_level())
+            .map_err(|on_load_err| jsonrpc_core::Error {
+                code: ErrorCode::InvalidRequest,
+                message: format!(
+                    "setup_logger method of plugin {} failed: {on_load_err}",
+                    new_plugin.name()
+                ),
+                data: None,
+            })?;
+
         // Attempt to on_load with new plugin
         match new_plugin.on_load(new_parsed_config_file, true) {
             // On success, push plugin and library
@@ -221,6 +245,7 @@ impl GeyserPluginManager {
         let mut current_plugin = self.plugins.remove(idx);
         let name = current_plugin.name().to_string();
         current_plugin.on_unload();
+        // The plugin must be first dropped before dropping the library to avoid crash.
         drop(current_plugin);
         drop(current_lib);
         info!("Unloaded plugin {name} at idx {idx}");

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -107,17 +107,7 @@ impl GeyserPluginManager {
             });
         }
 
-        // Initialize logging for the plugin
-        new_plugin
-            .setup_logger(log::logger(), log::max_level())
-            .map_err(|setup_logger_err| jsonrpc_core::Error {
-                code: ErrorCode::InvalidRequest,
-                message: format!(
-                    "setup_logger method of plugin {} failed: {setup_logger_err}",
-                    new_plugin.name()
-                ),
-                data: None,
-            })?;
+        setup_logger_for_plugin(&*new_plugin)?;
 
         // Call on_load and push plugin
         new_plugin
@@ -205,17 +195,7 @@ impl GeyserPluginManager {
             });
         }
 
-        // Initialize logging for the plugin
-        new_plugin
-            .setup_logger(log::logger(), log::max_level())
-            .map_err(|setup_logger_err| jsonrpc_core::Error {
-                code: ErrorCode::InvalidRequest,
-                message: format!(
-                    "setup_logger method of plugin {} failed: {setup_logger_err}",
-                    new_plugin.name()
-                ),
-                data: None,
-            })?;
+        setup_logger_for_plugin(&*new_plugin)?;
 
         // Attempt to on_load with new plugin
         match new_plugin.on_load(new_parsed_config_file, true) {
@@ -250,6 +230,20 @@ impl GeyserPluginManager {
         drop(current_lib);
         info!("Unloaded plugin {name} at idx {idx}");
     }
+}
+
+// Initialize logging for the plugin
+fn setup_logger_for_plugin(new_plugin: &dyn GeyserPlugin) -> Result<(), jsonrpc_core::Error> {
+    new_plugin
+        .setup_logger(log::logger(), log::max_level())
+        .map_err(|setup_logger_err| jsonrpc_core::Error {
+            code: ErrorCode::InvalidRequest,
+            message: format!(
+                "setup_logger method of plugin {} failed: {setup_logger_err}",
+                new_plugin.name()
+            ),
+            data: None,
+        })
 }
 
 #[derive(Debug)]

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -110,10 +110,10 @@ impl GeyserPluginManager {
         // Initialize logging for the plugin
         new_plugin
             .setup_logger(log::logger(), log::max_level())
-            .map_err(|on_load_err| jsonrpc_core::Error {
+            .map_err(|setup_logger_err| jsonrpc_core::Error {
                 code: ErrorCode::InvalidRequest,
                 message: format!(
-                    "setup_logger method of plugin {} failed: {on_load_err}",
+                    "setup_logger method of plugin {} failed: {setup_logger_err}",
                     new_plugin.name()
                 ),
                 data: None,
@@ -208,10 +208,10 @@ impl GeyserPluginManager {
         // Initialize logging for the plugin
         new_plugin
             .setup_logger(log::logger(), log::max_level())
-            .map_err(|on_load_err| jsonrpc_core::Error {
+            .map_err(|setup_logger_err| jsonrpc_core::Error {
                 code: ErrorCode::InvalidRequest,
                 message: format!(
-                    "setup_logger method of plugin {} failed: {on_load_err}",
+                    "setup_logger method of plugin {} failed: {setup_logger_err}",
                     new_plugin.name()
                 ),
                 data: None,


### PR DESCRIPTION
#### Problem
The plugins need to be able to log as the rest of the validator in the validator logs.  The plugin could use solana_logger::setup_with_defaul, unfortunately it is found doing that will cause the plugin not be unloaded from memory when the Library was dropped.

#### Summary of Changes
The change creates a new interface in the GeyserPlugin interface to allow the runtime to pass the logging configuration to the plugin.

`    fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()>;
`
Which the plugin can choose to set it up:
```
    fn setup_logger(&self, logger: &'static dyn log::Log, level: log::LevelFilter) -> Result<()> {
        log::set_max_level(level);
        if let Err(err) = log::set_logger(logger) {
            return Err(GeyserPluginError::Custom(Box::new(err)));
        }
        Ok(())
    }

```
 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
