### PR TITLE
[zk-token-proof] Feature gate transfer with fee related proofs

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -135,6 +135,11 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
     let native_programs_consume_cu = invoke_context
         .feature_set
         .is_active(&feature_set::native_programs_consume_cu::id());
+
+    let enable_zk_transfer_with_fee = invoke_context
+        .feature_set
+        .is_active(&feature_set::enable_zk_transfer_with_fee::id());
+
     let transaction_context = &invoke_context.transaction_context;
     let instruction_context = transaction_context.get_current_instruction_context()?;
     let instruction_data = instruction_context.get_instruction_data();
@@ -198,6 +203,11 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             process_verify_proof::<TransferData, TransferProofContext>(invoke_context)
         }
         ProofInstruction::VerifyTransferWithFee => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
             if native_programs_consume_cu {
                 invoke_context
                     .consume_checked(VERIFY_TRANSFER_WITH_FEE_COMPUTE_UNITS)
@@ -291,6 +301,11 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             >(invoke_context)
         }
         ProofInstruction::VerifyFeeSigma => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
             invoke_context
                 .consume_checked(VERIFY_FEE_SIGMA_COMPUTE_UNITS)
                 .map_err(|_| InstructionError::ComputationalBudgetExceeded)?;

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -728,6 +728,10 @@ pub mod disable_rent_fees_collection {
     solana_sdk::declare_id!("CJzY83ggJHqPGDq8VisV3U91jDJLuEaALZooBrXtnnLU");
 }
 
+pub mod enable_zk_transfer_with_fee {
+    solana_sdk::declare_id!("zkNLP7EQALfC1TYeB3biDU7akDckj8iPkvh9y2Mt2K3");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -905,6 +909,7 @@ lazy_static! {
         (update_hashes_per_tick6::id(), "Update desired hashes per tick to 10M"),
         (validate_fee_collector_account::id(), "validate fee collector account #33888"),
         (disable_rent_fees_collection::id(), "Disable rent fees collection #33945"),
+        (enable_zk_transfer_with_fee::id(), "enable Zk Token proof program transfer with fee"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
The confidential transfer with fee part of the token-2022 is targeting 1.18.

#### Summary of Changes
Add feature gate for processing zk token proof instructions related to transfer with fee.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
