### PR TITLE
[TieredStorage] Define OwnerOffset as u32

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -571,7 +571,9 @@ pub mod tests {
         let hot_storage = HotStorageReader::new_from_path(&path).unwrap();
         for (i, address) in addresses.iter().enumerate() {
             assert_eq!(
-                hot_storage.get_owner_address(OwnerOffset(i)).unwrap(),
+                hot_storage
+                    .get_owner_address(OwnerOffset(i as u32))
+                    .unwrap(),
                 address,
             );
         }


### PR DESCRIPTION
#### Problem
The current OwnerOffset is defined as usize, which actual size could be u32 or u64.
On the other hand, the OwnerOffset is used to access the ith owner in one
TieredStorageFile.  As a result, u32 is more than enough to represent the number of
owners inside one TieredStorageFile while u16 might not be always enough.

#### Summary of Changes
This PR defines OwnerOffset as u32.

#### Test Plan
Existing test cases.
