### PR TITLE
Clean up: simplify asserts

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9710,18 +9710,16 @@ fn test_verify_and_hash_transaction_sig_len() {
     {
         let tx = make_transaction(TestCase::RemoveSignature);
         assert_eq!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .err(),
-            Some(TransactionError::SanitizeFailure),
+            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            Err(TransactionError::SanitizeFailure),
         );
     }
     // Too many signatures: Sanitization failure
     {
         let tx = make_transaction(TestCase::AddSignature);
         assert_eq!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .err(),
-            Some(TransactionError::SanitizeFailure),
+            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            Err(TransactionError::SanitizeFailure),
         );
     }
 }
@@ -9757,9 +9755,8 @@ fn test_verify_transactions_packet_data_size() {
         let tx = make_transaction(25);
         assert!(bincode::serialized_size(&tx).unwrap() > PACKET_DATA_SIZE as u64);
         assert_eq!(
-            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification)
-                .err(),
-            Some(TransactionError::SanitizeFailure),
+            bank.verify_transaction(tx.into(), TransactionVerificationMode::FullVerification),
+            Err(TransactionError::SanitizeFailure),
         );
     }
     // Assert that verify fails as soon as serialized


### PR DESCRIPTION
#### Problem
Noticed some weird usage of `.err()` to compare against `Some(ErrorKind)` in some of the tests while reviewing #34078

#### Summary of Changes
Just compare agains `Err(ErrorKind)`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
