### PR TITLE
RuntimeTransaction: Minor Cleanup

### DIFF
--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -22,12 +22,8 @@ use {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RuntimeTransactionStatic {
-    // sanitized signatures
     signatures: Vec<Signature>,
-
-    // sanitized message
     message: SanitizedVersionedMessage,
-
     // transaction meta is a collection of fields, it is updated
     // during message state transition
     meta: TransactionMeta,
@@ -70,12 +66,8 @@ impl RuntimeTransactionStatic {
 /// address_loader, to load accounts from on-chain ALT, then resolve dynamic metadata
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct RuntimeTransactionDynamic {
-    // sanitized signatures
     signatures: Vec<Signature>,
-
-    // sanitized message
     message: SanitizedMessage,
-
     // transaction meta is a collection of fields, it is updated
     // during message state transition
     meta: TransactionMeta,
@@ -110,7 +102,6 @@ impl RuntimeTransactionDynamic {
         Ok(tx)
     }
 
-    // private helpers
     fn load_dynamic_metadata(&mut self) -> Result<()> {
         Ok(())
     }

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -1,14 +1,14 @@
-/// RuntimeTransaction is `runtime` facing representation of transaction, while
-/// solana_sdk::SanitizedTransaction is client facing representation.
-///
-/// It has two states:
-/// 1. Statically Loaded: after receiving `packet` from sigverify and deserializing
-///    it into `solana_sdk::VersionedTransaction`, then sanitizing into
-///    `solana_sdk::SanitizedVersionedTransaction`, `RuntimeTransactionStatic`
-///    can be created from it with static transaction metadata extracted.
-/// 2. Dynamically Loaded: after successfully loaded account addresses from onchain
-///    ALT, RuntimeTransaction transits into Dynamically Loaded state, with
-///    its dynamic metadata loaded.
+//! RuntimeTransaction is `runtime` facing representation of transaction, while
+//! solana_sdk::SanitizedTransaction is client facing representation.
+//!
+//! It has two states:
+//! 1. Statically Loaded: after receiving `packet` from sigverify and deserializing
+//!    it into `solana_sdk::VersionedTransaction`, then sanitizing into
+//!    `solana_sdk::SanitizedVersionedTransaction`, `RuntimeTransactionStatic`
+//!    can be created from it with static transaction metadata extracted.
+//! 2. Dynamically Loaded: after successfully loaded account addresses from onchain
+//!    ALT, RuntimeTransaction transits into Dynamically Loaded state, with
+//!    its dynamic metadata loaded.
 use {
     crate::transaction_meta::{DynamicMeta, StaticMeta, TransactionMeta},
     solana_sdk::{

--- a/runtime-transaction/src/transaction_meta.rs
+++ b/runtime-transaction/src/transaction_meta.rs
@@ -34,11 +34,11 @@ pub struct TransactionMeta {
 }
 
 impl TransactionMeta {
-    pub fn set_message_hash(&mut self, message_hash: Hash) {
+    pub(crate) fn set_message_hash(&mut self, message_hash: Hash) {
         self.message_hash = message_hash;
     }
 
-    pub fn set_is_simple_vote_tx(&mut self, is_simple_vote_tx: bool) {
+    pub(crate) fn set_is_simple_vote_tx(&mut self, is_simple_vote_tx: bool) {
         self.is_simple_vote_tx = is_simple_vote_tx;
     }
 }


### PR DESCRIPTION
#### Problem
Following up on some minor thoughts I had from #33471.

#### Summary of Changes
- Remove simple comments which repeat field names
- TransactionMeta setters become `pub(crate)`
- Module level comment using //! instead of ///

The change of visibility on the TransactionMeta setters helps us, because if we forget to set a field in either `try_from` of the `Static` or `Dynamic` `RuntimeTransaction` the compiler will mark these as unused/dead code and warn us the field isn't ever being set.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
