### PR TITLE
clippy: Uses .into() when .try_into() is infallible

### DIFF
--- a/sdk/program/src/alt_bn128/mod.rs
+++ b/sdk/program/src/alt_bn128/mod.rs
@@ -181,9 +181,7 @@ mod target_arch {
         let result_point = p + q;
 
         let mut result_point_data = [0u8; ALT_BN128_ADDITION_OUTPUT_LEN];
-        let result_point_affine: G1 = result_point
-            .try_into()
-            .map_err(|_| AltBn128Error::ProjectiveToG1Failed)?;
+        let result_point_affine: G1 = result_point.into();
         result_point_affine
             .x
             .serialize_with_mode(&mut result_point_data[..32], Compress::No)


### PR DESCRIPTION
#### Problem

There are nightly clippy warnings that will prevent upgrading our stable Rust version[^1].

For this PR, it's this one: https://rust-lang.github.io/rust-clippy/master/index.html#/try_into

[^1]: Here's the build failure: https://buildkite.com/solana-labs/solana/builds/104503#018bd970-26af-4b69-9fbb-29dea2681e4e

#### Summary of Changes

Replaces `.try_into()` with `.into()`.