### PR TITLE
clippy: Allow enum variant names in generated google.bigtable.v2

### DIFF
--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -16,7 +16,7 @@ use {
     tonic::{codegen::InterceptedService, transport::ClientTlsConfig, Request, Status},
 };
 
-#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::derive_partial_eq_without_eq, clippy::enum_variant_names)]
 mod google {
     mod rpc {
         include!(concat!(


### PR DESCRIPTION
#### Problem

New clippy lints are preventing us from upgrading our nightly rust in #34118. Here's the build: https://buildkite.com/solana-labs/solana/builds/104515#018bd9d3-5bfd-41b5-9cc2-2a9d810c0360. Here's what the error looks like:

```
error: variant name ends with the enum's name
   --> /solana/storage-bigtable/proto/google.bigtable.v2.rs:418:9
    |
418 |         PassAllFilter(bool),
    |         ^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#enum_variant_names
    = note: `-D clippy::enum-variant-names` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::enum_variant_names)]`

```


#### Summary of Changes

Explicitly allow this clippy lint.