### PR TITLE
[zk-token-sdk] Use checked arithmetic when processing transfer amount

### DIFF
--- a/zk-token-sdk/src/errors.rs
+++ b/zk-token-sdk/src/errors.rs
@@ -38,6 +38,8 @@ pub enum ProofVerificationError {
     ProofContext,
     #[error("illegal commitment length")]
     IllegalCommitmentLength,
+    #[error("illegal amount bit length")]
+    IllegalAmountBitLength,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/zk-token-sdk/src/instruction/errors.rs
+++ b/zk-token-sdk/src/instruction/errors.rs
@@ -8,4 +8,6 @@ pub enum InstructionError {
     Decryption,
     #[error("missing ciphertext")]
     MissingCiphertext,
+    #[error("illegal amount bit length")]
+    IllegalAmountBitLength,
 }

--- a/zk-token-sdk/src/instruction/errors.rs
+++ b/zk-token-sdk/src/instruction/errors.rs
@@ -10,4 +10,6 @@ pub enum InstructionError {
     MissingCiphertext,
     #[error("illegal amount bit length")]
     IllegalAmountBitLength,
+    #[error("arithmetic overflow")]
+    Overflow,
 }

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -113,6 +113,20 @@ fn combine_lo_hi_ciphertexts(
 }
 
 #[cfg(not(target_os = "solana"))]
+fn try_combine_lo_hi_ciphertexts(
+    ciphertext_lo: &ElGamalCiphertext,
+    ciphertext_hi: &ElGamalCiphertext,
+    bit_length: usize,
+) -> Result<ElGamalCiphertext, InstructionError> {
+    let two_power = if bit_length < u64::BITS as usize {
+        1_u64.checked_shl(bit_length as u32).unwrap()
+    } else {
+        return Err(InstructionError::IllegalAmountBitLength);
+    };
+    Ok(ciphertext_lo + &(ciphertext_hi * &Scalar::from(two_power)))
+}
+
+#[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_commitments(
     comm_lo: &PedersenCommitment,
     comm_hi: &PedersenCommitment,
@@ -123,6 +137,20 @@ pub fn combine_lo_hi_commitments(
 }
 
 #[cfg(not(target_os = "solana"))]
+pub fn try_combine_lo_hi_commitments(
+    comm_lo: &PedersenCommitment,
+    comm_hi: &PedersenCommitment,
+    bit_length: usize,
+) -> Result<PedersenCommitment, InstructionError> {
+    let two_power = if bit_length < u64::BITS as usize {
+        1_u64.checked_shl(bit_length as u32).unwrap()
+    } else {
+        return Err(InstructionError::IllegalAmountBitLength);
+    };
+    Ok(comm_lo + comm_hi * &Scalar::from(two_power))
+}
+
+#[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_openings(
     opening_lo: &PedersenOpening,
     opening_hi: &PedersenOpening,
@@ -130,6 +158,20 @@ pub fn combine_lo_hi_openings(
 ) -> PedersenOpening {
     let two_power = (1_u64) << bit_length;
     opening_lo + opening_hi * &Scalar::from(two_power)
+}
+
+#[cfg(not(target_os = "solana"))]
+pub fn try_combine_lo_hi_openings(
+    opening_lo: &PedersenOpening,
+    opening_hi: &PedersenOpening,
+    bit_length: usize,
+) -> Result<PedersenOpening, InstructionError> {
+    let two_power = if bit_length < u64::BITS as usize {
+        1_u64.checked_shl(bit_length as u32).unwrap()
+    } else {
+        return Err(InstructionError::IllegalAmountBitLength);
+    };
+    Ok(opening_lo + opening_hi * &Scalar::from(two_power))
 }
 
 #[derive(Clone, Copy)]

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -120,7 +120,7 @@ fn try_combine_lo_hi_ciphertexts(
 
 #[deprecated(
     since = "1.18.0",
-    note = "please use `combine_lo_hi_commitments` instead"
+    note = "please use `try_combine_lo_hi_commitments` instead"
 )]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_commitments(
@@ -146,7 +146,7 @@ pub fn try_combine_lo_hi_commitments(
     Ok(comm_lo + comm_hi * &Scalar::from(two_power))
 }
 
-#[deprecated(since = "1.18.0", note = "please use `combine_lo_hi_openings` instead")]
+#[deprecated(since = "1.18.0", note = "please use `try_combine_lo_hi_openings` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_openings(
     opening_lo: &PedersenOpening,

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -103,16 +103,6 @@ pub fn try_combine_lo_hi_u64(
 }
 
 #[cfg(not(target_os = "solana"))]
-fn combine_lo_hi_ciphertexts(
-    ciphertext_lo: &ElGamalCiphertext,
-    ciphertext_hi: &ElGamalCiphertext,
-    bit_length: usize,
-) -> ElGamalCiphertext {
-    let two_power = (1_u64) << bit_length;
-    ciphertext_lo + &(ciphertext_hi * &Scalar::from(two_power))
-}
-
-#[cfg(not(target_os = "solana"))]
 fn try_combine_lo_hi_ciphertexts(
     ciphertext_lo: &ElGamalCiphertext,
     ciphertext_hi: &ElGamalCiphertext,

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -36,6 +36,7 @@ pub enum Role {
 /// Takes in a 64-bit number `amount` and a bit length `bit_length`. It returns:
 ///  - the `bit_length` low bits of `amount` interpreted as u64
 ///  - the (64 - `bit_length`) high bits of `amount` interpreted as u64
+#[deprecated(since = "1.18.0", note = "please use `try_split_u64` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn split_u64(amount: u64, bit_length: usize) -> (u64, u64) {
     if bit_length == 64 {
@@ -70,6 +71,7 @@ pub fn try_split_u64(amount: u64, bit_length: usize) -> Result<(u64, u64), Instr
     }
 }
 
+#[deprecated(since = "1.18.0", note = "please use `try_combine_lo_hi_u64` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_u64(amount_lo: u64, amount_hi: u64, bit_length: usize) -> u64 {
     if bit_length == 64 {
@@ -116,6 +118,10 @@ fn try_combine_lo_hi_ciphertexts(
     Ok(ciphertext_lo + &(ciphertext_hi * &Scalar::from(two_power)))
 }
 
+#[deprecated(
+    since = "1.18.0",
+    note = "please use `combine_lo_hi_commitments` instead"
+)]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_commitments(
     comm_lo: &PedersenCommitment,
@@ -140,6 +146,7 @@ pub fn try_combine_lo_hi_commitments(
     Ok(comm_lo + comm_hi * &Scalar::from(two_power))
 }
 
+#[deprecated(since = "1.18.0", note = "please use `combine_lo_hi_openings` instead")]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_openings(
     opening_lo: &PedersenOpening,

--- a/zk-token-sdk/src/instruction/transfer/mod.rs
+++ b/zk-token-sdk/src/instruction/transfer/mod.rs
@@ -146,7 +146,10 @@ pub fn try_combine_lo_hi_commitments(
     Ok(comm_lo + comm_hi * &Scalar::from(two_power))
 }
 
-#[deprecated(since = "1.18.0", note = "please use `try_combine_lo_hi_openings` instead")]
+#[deprecated(
+    since = "1.18.0",
+    note = "please use `try_combine_lo_hi_openings` instead"
+)]
 #[cfg(not(target_os = "solana"))]
 pub fn combine_lo_hi_openings(
     opening_lo: &PedersenOpening,

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -570,11 +570,12 @@ impl TransferWithFeeProof {
         // generate the range proof
         let opening_claimed_negated = &PedersenOpening::default() - &opening_claimed;
 
-        let combined_amount = combine_lo_hi_u64(
+        let combined_amount = try_combine_lo_hi_u64(
             transfer_amount_lo,
             transfer_amount_hi,
             TRANSFER_AMOUNT_LO_BITS,
-        );
+        )
+        .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
         let amount_sub_fee = combined_amount
             .checked_sub(combined_fee_amount)
             .ok_or(ProofGenerationError::FeeCalculation)?;

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -9,10 +9,10 @@ use {
         instruction::{
             errors::InstructionError,
             transfer::{
-                combine_lo_hi_ciphertexts, combine_lo_hi_commitments, combine_lo_hi_openings,
-                combine_lo_hi_u64,
                 encryption::{FeeEncryption, TransferAmountCiphertext},
-                split_u64, FeeParameters, Role,
+                try_combine_lo_hi_ciphertexts, try_combine_lo_hi_commitments,
+                try_combine_lo_hi_openings, try_combine_lo_hi_u64, try_split_u64, FeeParameters,
+                Role,
             },
         },
         range_proof::RangeProof,
@@ -128,7 +128,8 @@ impl TransferWithFeeData {
         withdraw_withheld_authority_pubkey: &ElGamalPubkey,
     ) -> Result<Self, ProofGenerationError> {
         // split and encrypt transfer amount
-        let (amount_lo, amount_hi) = split_u64(transfer_amount, TRANSFER_AMOUNT_LO_BITS);
+        let (amount_lo, amount_hi) = try_split_u64(transfer_amount, TRANSFER_AMOUNT_LO_BITS)
+            .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
 
         let (ciphertext_lo, opening_lo) = TransferAmountCiphertext::new(
             amount_lo,
@@ -159,11 +160,12 @@ impl TransferWithFeeData {
         };
 
         let new_source_ciphertext = old_source_ciphertext
-            - combine_lo_hi_ciphertexts(
+            - try_combine_lo_hi_ciphertexts(
                 &transfer_amount_lo_source,
                 &transfer_amount_hi_source,
                 TRANSFER_AMOUNT_LO_BITS,
-            );
+            )
+            .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
 
         // calculate fee
         //
@@ -177,7 +179,9 @@ impl TransferWithFeeData {
             u64::conditional_select(&fee_parameters.maximum_fee, &fee_amount, below_max);
 
         // split and encrypt fee
-        let (fee_to_encrypt_lo, fee_to_encrypt_hi) = split_u64(fee_to_encrypt, FEE_AMOUNT_LO_BITS);
+        let (fee_to_encrypt_lo, fee_to_encrypt_hi) =
+            try_split_u64(fee_to_encrypt, FEE_AMOUNT_LO_BITS)
+                .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
 
         let (fee_ciphertext_lo, opening_fee_lo) = FeeEncryption::new(
             fee_to_encrypt_lo,
@@ -510,23 +514,28 @@ impl TransferWithFeeProof {
         let pod_claimed_commitment: pod::PedersenCommitment = claimed_commitment.into();
         transcript.append_commitment(b"commitment-claimed", &pod_claimed_commitment);
 
-        let combined_commitment = combine_lo_hi_commitments(
+        let combined_commitment = try_combine_lo_hi_commitments(
             ciphertext_lo.get_commitment(),
             ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
-        );
+        )
+        .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
         let combined_opening =
-            combine_lo_hi_openings(opening_lo, opening_hi, TRANSFER_AMOUNT_LO_BITS);
+            try_combine_lo_hi_openings(opening_lo, opening_hi, TRANSFER_AMOUNT_LO_BITS)
+                .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
 
         let combined_fee_amount =
-            combine_lo_hi_u64(fee_amount_lo, fee_amount_hi, TRANSFER_AMOUNT_LO_BITS);
-        let combined_fee_commitment = combine_lo_hi_commitments(
+            try_combine_lo_hi_u64(fee_amount_lo, fee_amount_hi, TRANSFER_AMOUNT_LO_BITS)
+                .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
+        let combined_fee_commitment = try_combine_lo_hi_commitments(
             fee_ciphertext_lo.get_commitment(),
             fee_ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
-        );
+        )
+        .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
         let combined_fee_opening =
-            combine_lo_hi_openings(opening_fee_lo, opening_fee_hi, TRANSFER_AMOUNT_LO_BITS);
+            try_combine_lo_hi_openings(opening_fee_lo, opening_fee_hi, TRANSFER_AMOUNT_LO_BITS)
+                .map_err(|_| ProofGenerationError::IllegalAmountBitLength)?;
 
         // compute real delta commitment
         let (delta_commitment, opening_delta) = compute_delta_commitment_and_opening(
@@ -680,16 +689,18 @@ impl TransferWithFeeProof {
         // verify fee sigma proof
         transcript.append_commitment(b"commitment-claimed", &self.claimed_commitment);
 
-        let combined_commitment = combine_lo_hi_commitments(
+        let combined_commitment = try_combine_lo_hi_commitments(
             ciphertext_lo.get_commitment(),
             ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
-        );
-        let combined_fee_commitment = combine_lo_hi_commitments(
+        )
+        .map_err(|_| ProofVerificationError::IllegalAmountBitLength)?;
+        let combined_fee_commitment = try_combine_lo_hi_commitments(
             fee_ciphertext_lo.get_commitment(),
             fee_ciphertext_hi.get_commitment(),
             TRANSFER_AMOUNT_LO_BITS,
-        );
+        )
+        .map_err(|_| ProofVerificationError::IllegalAmountBitLength)?;
 
         let delta_commitment = compute_delta_commitment(
             &combined_commitment,

--- a/zk-token-sdk/src/zk_token_elgamal/ops.rs
+++ b/zk-token-sdk/src/zk_token_elgamal/ops.rs
@@ -134,7 +134,7 @@ mod tests {
                 elgamal::{ElGamalCiphertext, ElGamalKeypair},
                 pedersen::{Pedersen, PedersenOpening},
             },
-            instruction::transfer::split_u64,
+            instruction::transfer::try_split_u64,
             zk_token_elgamal::{ops, pod},
         },
         bytemuck::Zeroable,
@@ -204,7 +204,7 @@ mod tests {
     fn test_transfer_arithmetic() {
         // transfer amount
         let transfer_amount: u64 = 55;
-        let (amount_lo, amount_hi) = split_u64(transfer_amount, 16);
+        let (amount_lo, amount_hi) = try_split_u64(transfer_amount, 16).unwrap();
 
         // generate public keys
         let source_keypair = ElGamalKeypair::new_rand();


### PR DESCRIPTION
#### Problem
The `split_u64`, `combine_lo_hi_u64`, `combine_lo_hi_ciphertexts`, `combine_lo_hi_commitments`, and `combine_lo_hi_openings` functions use unchecked bit shift operations that can cause a panic.

#### Summary of Changes
Deprecate these functions and replace them with `try_` versions that return a `Result`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
