### PR TITLE
CI: automatically add a warning comment to PRs with backport labels

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -106,9 +106,11 @@ pull_request_rules:
         message: >
           Backports to the stable branch are to be avoided unless absolutely
           necessary for fixing bugs, security issues, and perf regressions.
-          Backported changes should be reduced to the smallest viable change,
-          refactoring should be done in a separate change that is not
-          backported.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule.
   - name: v1.17 feature-gate backport
     conditions:
       - label=v1.17

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -143,10 +143,13 @@ pull_request_rules:
         message: >
           Backports to the beta branch are to be avoided unless absolutely
           necessary for fixing bugs, security issues, and perf regressions.
-          Backported changes should be reduced to the smallest viable change,
-          refactoring should be done in a separate change that is not
-          backported. Exceptions include CI/metrics changes, CLI improvements,
-          and documentation updates.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule. Exceptions
+          include CI/metrics changes, CLI improvements and documentation
+          updates on a case by case basis.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -98,6 +98,17 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v1.16
+  - name: v1.16 backport warning comment
+    conditions:
+      - label=v1.16
+    actions:
+      comment:
+        message: >
+          Backports to the stable branch are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Backported changes should be reduced to the smallest viable change,
+          refactoring should be done in a separate change that is not
+          backported.
   - name: v1.17 feature-gate backport
     conditions:
       - label=v1.17
@@ -122,6 +133,18 @@ pull_request_rules:
         ignore_conflicts: true
         branches:
           - v1.17
+  - name: v1.17 backport warning comment
+    conditions:
+      - label=v1.17
+    actions:
+      comment:
+        message: >
+          Backports to the beta branch are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Backported changes should be reduced to the smallest viable change,
+          refactoring should be done in a separate change that is not
+          backported. Exceptions include CI/metrics changes, CLI improvements,
+          and documentation updates.
 
 commands_restrictions:
   # The author of copied PRs is the Mergify user.


### PR DESCRIPTION
#### Problem
Core contributors are not all aligned and informed on what is acceptable to backport to stable and beta branches

#### Summary of Changes
Add a mergify action that will add a comment whenever a PR is labeled a `v1.16` or `v1.17` label. This extra comment will remind contributors and reviewers what the guidelines for backports are.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
