### PR TITLE
[TieredStorage] Make IndexBlock persist u32 offsets

### DIFF
--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -243,7 +243,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::AddressAndOffset,
+            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -26,7 +26,7 @@ pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
     account_meta_format: AccountMetaFormat::Hot,
     owners_block_format: OwnersBlockFormat::LocalIndex,
-    index_block_format: IndexBlockFormat::AddressAndOffset,
+    index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
     account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
@@ -407,7 +407,7 @@ pub mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::AddressAndOffset,
+            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 16,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -503,7 +503,7 @@ pub mod tests {
             .iter()
             .map(|address| AccountIndexWriterEntry {
                 address,
-                block_offset: rng.gen_range(0..u64::MAX),
+                block_offset: rng.gen_range(0..u32::MAX),
                 intra_block_offset: rng.gen_range(0..4096),
             })
             .collect();
@@ -532,7 +532,7 @@ pub mod tests {
         let hot_storage = HotStorageReader::new_from_path(&path).unwrap();
         for (i, index_writer_entry) in index_writer_entries.iter().enumerate() {
             let account_offset = hot_storage.get_account_offset(IndexOffset(i)).unwrap();
-            assert_eq!(account_offset.block as u64, index_writer_entry.block_offset);
+            assert_eq!(account_offset.block as u32, index_writer_entry.block_offset);
 
             let account_address = hot_storage.get_account_address(IndexOffset(i)).unwrap();
             assert_eq!(account_address, index_writer_entry.address);


### PR DESCRIPTION
#### Problem
In TieredStorage, we want to make AccountOffset and IndexOffset u32 instead
of usize just like OwnerOffset.  However, we need to first change what we persist
in the storage.  Currently, IndexBlock persists offsets as u64 instead of u32. 

#### Summary of Changes
This PR makes IndexBlock persist u32 offsets.

#### Test Plan
Existing test cases.
