### PR TITLE
Update genesis processing to have a fallback collector id for tests

### DIFF
--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -794,6 +794,7 @@ pub(crate) fn process_blockstore_for_bank_0(
         false,
         opts.accounts_db_config.clone(),
         accounts_update_notifier,
+        None,
         exit,
     );
     let bank0_slot = bank0.slot();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -834,6 +834,7 @@ impl ProgramTest {
             false,
             None,
             None,
+            None,
             Arc::default(),
         );
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1041,6 +1041,7 @@ impl Bank {
         debug_do_not_add_builtins: bool,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
+        test_collector_id: Option<Pubkey>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts_db = AccountsDb::new_with_config(
@@ -1059,7 +1060,7 @@ impl Bank {
         bank.runtime_config = runtime_config;
         bank.cluster_type = Some(genesis_config.cluster_type);
 
-        bank.process_genesis_config(genesis_config);
+        bank.process_genesis_config(genesis_config, test_collector_id);
         bank.finish_init(
             genesis_config,
             additional_builtins,
@@ -3745,7 +3746,11 @@ impl Bank {
         self.parent_hash
     }
 
-    fn process_genesis_config(&mut self, genesis_config: &GenesisConfig) {
+    fn process_genesis_config(
+        &mut self,
+        genesis_config: &GenesisConfig,
+        test_collector_id: Option<Pubkey>,
+    ) {
         // Bootstrap validator collects fees until `new_from_parent` is called.
         self.fee_rate_governor = genesis_config.fee_rate_governor.clone();
 
@@ -3771,14 +3776,16 @@ impl Bank {
             self.accounts_data_size_initial += account.data().len() as u64;
         }
 
-        // Highest staked node is the first collector but if a genesis config
-        // doesn't define any staked nodes, we assume this genesis config is for
-        // testing and set the collector id to a unique pubkey.
+        // After storing genesis accounts, the bank stakes cache will be warmed
+        // up and can be used to set the collector id to the highest staked
+        // node. If no staked nodes exist, allow fallback to an unstaked test
+        // collector id during tests.
         self.collector_id = self
             .stakes_cache
             .stakes()
             .highest_staked_node()
-            .unwrap_or_else(Pubkey::new_unique);
+            .or(test_collector_id)
+            .expect("genesis processing failed because no staked nodes exist");
 
         self.blockhash_queue.write().unwrap().genesis_hash(
             &genesis_config.hash(),
@@ -8212,6 +8219,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
             None,
+            Some(Pubkey::new_unique()),
             Arc::default(),
         )
     }
@@ -8234,6 +8242,7 @@ impl Bank {
             false,
             Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
             None,
+            Some(Pubkey::new_unique()),
             Arc::default(),
         )
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1041,7 +1041,7 @@ impl Bank {
         debug_do_not_add_builtins: bool,
         accounts_db_config: Option<AccountsDbConfig>,
         accounts_update_notifier: Option<AccountsUpdateNotifier>,
-        #[cfg(feature = "dev-context-only-utils")] collector_id_for_tests: Option<Pubkey>,
+        #[allow(unused)] collector_id_for_tests: Option<Pubkey>,
         exit: Arc<AtomicBool>,
     ) -> Self {
         let accounts_db = AccountsDb::new_with_config(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9035,6 +9035,7 @@ where
         false,
         Some(ACCOUNTS_DB_CONFIG_FOR_TESTING),
         None,
+        None,
         Arc::default(),
     ));
     let vote_and_stake_accounts =
@@ -12666,6 +12667,7 @@ fn test_rewards_computation_and_partitioned_distribution_two_blocks() {
         false,
         Some(accounts_db_config),
         None,
+        None,
         Arc::default(),
     );
 
@@ -13385,6 +13387,7 @@ fn test_get_reward_distribution_num_blocks_cap() {
         false,
         Some(accounts_db_config),
         None,
+        Some(Pubkey::new_unique()),
         Arc::default(),
     );
 
@@ -13852,6 +13855,7 @@ fn test_rehash_with_skipped_rewrites() {
         false,
         Some(accounts_db_config),
         None,
+        Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
     ));
     // This test is only meaningful while the bank hash contains rewrites.
@@ -13912,6 +13916,7 @@ fn test_rebuild_skipped_rewrites() {
         false,
         Some(accounts_db_config.clone()),
         None,
+        Some(Pubkey::new_unique()),
         Arc::new(AtomicBool::new(false)),
     ));
     // This test is only meaningful while the bank hash contains rewrites.


### PR DESCRIPTION
#### Problem
When creating bank 0 for tests, oftentimes the genesis config doesn't include a staked node. This means that bank creation has to arbitrarily pick a node id for block 0 in order for bank creation to succeed. The arbitrary node id was recently updated to be a random unique pubkey in https://github.com/solana-labs/solana/pull/33887 but as discussed [here](https://github.com/solana-labs/solana/pull/33887#discussion_r1394732271) we need to make sure this path is never hit by tests.

#### Summary of Changes
- Add the arg `test_collector_id: Option<Pubkey>` to `Bank::new_with_paths` which can be used as a fallback collector id if no staked nodes are defined in the genesis. This arg is set to `None` in call-sites that aren't related to testing or benchmarks.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
