### PR TITLE
clippy: Uses .from() when .try_from() is infallible

### DIFF
--- a/gossip/src/crds_value.rs
+++ b/gossip/src/crds_value.rs
@@ -523,17 +523,14 @@ impl RunLengthEncoding {
     }
 
     fn num_encoded_slots(&self) -> usize {
-        self.0
-            .iter()
-            .map(|x| usize::try_from(x.0).unwrap())
-            .sum::<usize>()
+        self.0.iter().map(|x| usize::from(x.0)).sum()
     }
 
     fn to_slots(&self, last_slot: Slot, min_slot: Slot) -> Vec<Slot> {
         let mut slots: Vec<Slot> = self
             .0
             .iter()
-            .map_while(|bit_count| usize::try_from(bit_count.0).ok())
+            .map(|bit_count| usize::from(bit_count.0))
             .zip([1, 0].iter().cycle())
             .flat_map(|(bit_count, bit)| std::iter::repeat(bit).take(bit_count))
             .enumerate()


### PR DESCRIPTION
#### Problem

There are nightly clippy warnings that will prevent upgrading our stable Rust version[^1].

For this PR, it's `unnecessary_fallible_conversions`:

```
warning: use of a fallible conversion when an infallible one could be used
   --> gossip/src/crds_value.rs:528:22
    |
528 |             .map(|x| usize::try_from(x.0).unwrap())
    |                      ^^^^^^^^^^^^^^^ help: use: `From::from`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fallible_conversions
    = note: `#[warn(clippy::unnecessary_fallible_conversions)]` on by default
```

#### Summary of Changes

Replaces `.try_from()` with `.from()`.


[^1]: https://github.com/solana-labs/solana/pull/34118