### PR TITLE
add transaction receipts to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",
+ "solana-transaction-receipt",
  "solana-vote-program",
  "static_assertions",
  "strum",
@@ -5929,6 +5930,7 @@ dependencies = [
  "solana-stake-program",
  "solana-streamer",
  "solana-tpu-client",
+ "solana-transaction-receipt",
  "solana-transaction-status",
  "solana-turbine",
  "solana-version",
@@ -7049,6 +7051,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",
+ "solana-transaction-receipt",
  "solana-version",
  "solana-vote",
  "solana-vote-program",
@@ -7425,6 +7428,14 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
+]
+
+[[package]]
+name = "solana-transaction-receipt"
+version = "1.18.0"
+dependencies = [
+ "solana-merkle-tree",
+ "solana-program",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ members = [
     "wen-restart",
     "zk-keygen",
     "zk-token-sdk",
+    "transaction-receipt"
 ]
 
 exclude = ["programs/sbf"]
@@ -374,6 +375,7 @@ solana-system-program = { path = "programs/system", version = "=1.18.0" }
 solana-test-validator = { path = "test-validator", version = "=1.18.0" }
 solana-thin-client = { path = "thin-client", version = "=1.18.0" }
 solana-tpu-client = { path = "tpu-client", version = "=1.18.0", default-features = false }
+solana-transaction-receipt = { path = "transaction-receipt", version = "=1.18.0" }
 solana-transaction-status = { path = "transaction-status", version = "=1.18.0" }
 solana-turbine = { path = "turbine", version = "=1.18.0" }
 solana-udp-client = { path = "udp-client", version = "=1.18.0" }

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -57,6 +57,7 @@ solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }
 solana-vote-program = { workspace = true }
+solana-transaction-receipt = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -5,18 +5,21 @@ use {
     },
     solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
     solana_sdk::{
+        hash::Hash,
         instruction::{CompiledInstruction, TRANSACTION_LEVEL_STACK_HEIGHT},
         transaction::{self, TransactionError},
         transaction_context::{TransactionContext, TransactionReturnData},
     },
+    solana_transaction_receipt::TransactionReceiptData,
 };
 
 pub type TransactionCheckResult = (transaction::Result<()>, Option<NoncePartial>);
-
+pub type TransactionReceiptQueueEntry = (Hash, TransactionReceiptData);
 pub struct TransactionResults {
     pub fee_collection_results: Vec<transaction::Result<()>>,
     pub execution_results: Vec<TransactionExecutionResult>,
     pub rent_debits: Vec<RentDebits>,
+    pub transaction_receipts: Vec<TransactionReceiptQueueEntry>,
 }
 
 /// Type safe representation of a transaction execution attempt which

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,6 +67,7 @@ solana-sdk = { workspace = true }
 solana-send-transaction-service = { workspace = true }
 solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction-receipt = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true }
 solana-version = { workspace = true }

--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -1,3 +1,5 @@
+use solana_accounts_db::transaction_results::TransactionReceiptQueueEntry;
+
 use {
     super::leader_slot_timing_metrics::LeaderExecuteAndCommitTimings,
     itertools::Itertools,
@@ -66,6 +68,7 @@ impl Committer {
         batch: &TransactionBatch,
         loaded_transactions: &mut [TransactionLoadResult],
         execution_results: Vec<TransactionExecutionResult>,
+        transaction_receipts: Vec<TransactionReceiptQueueEntry>,
         starting_transaction_index: Option<usize>,
         bank: &Arc<Bank>,
         pre_balance_info: &mut PreBalanceInfo,
@@ -88,6 +91,7 @@ impl Committer {
             batch.sanitized_transactions(),
             loaded_transactions,
             execution_results,
+            transaction_receipts,
             last_blockhash,
             lamports_per_signature,
             CommitTransactionCounts {

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -135,6 +135,41 @@ impl MerkleTree {
         mt
     }
 
+    pub fn new_from_leaves(leaves: Vec<Hash>) -> Self {
+        let leaf_count = leaves.len();
+
+        let mut mt = MerkleTree {
+            leaf_count,
+            nodes: leaves,
+        };
+
+        let mut level_len = MerkleTree::next_level_len(leaf_count);
+        let mut level_start = leaf_count;
+        let mut prev_level_len = leaf_count;
+        let mut prev_level_start = 0;
+        while level_len > 0 {
+            for i in 0..level_len {
+                let prev_level_idx = 2 * i;
+                let lsib = &mt.nodes[prev_level_start + prev_level_idx];
+                let rsib = if prev_level_idx + 1 < prev_level_len {
+                    &mt.nodes[prev_level_start + prev_level_idx + 1]
+                } else {
+                    // Duplicate last entry if the level length is odd
+                    &mt.nodes[prev_level_start + prev_level_idx]
+                };
+
+                let hash = hash_intermediate!(lsib, rsib);
+                mt.nodes.push(hash);
+            }
+            prev_level_start = level_start;
+            prev_level_len = level_len;
+            level_start += level_len;
+            level_len = MerkleTree::next_level_len(level_len);
+        }
+
+        mt
+    }
+
     pub fn get_root(&self) -> Option<&Hash> {
         self.nodes.iter().last()
     }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -72,6 +72,7 @@ solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-zk-token-proof-program = { workspace = true }
 solana-zk-token-sdk = { workspace = true }
+solana-transaction-receipt = { workspace = true }
 static_assertions = { workspace = true }
 strum = { workspace = true, features = ["derive"] }
 strum_macros = { workspace = true }

--- a/transaction-receipt/Cargo.toml
+++ b/transaction-receipt/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "solana-transaction-receipt"
+version.workspace = true
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+edition.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+solana-merkle-tree = { workspace = true }
+solana-program = { workspace = true }

--- a/transaction-receipt/src/lib.rs
+++ b/transaction-receipt/src/lib.rs
@@ -1,0 +1,96 @@
+use solana_merkle_tree::MerkleTree;
+use solana_program::hash::{hashv, Hash};
+
+pub const RECEIPT_VERSION: u64 = 0x1;
+
+pub const RECEIPT_STATUS_SUCCESS: u8 = 0x0;
+pub const RECEIPT_STATUS_FAILURE: u8 = 0x1;
+
+pub const ROOT_PREFIX: &[u8] = &[0x80];
+pub const LEAF_PREFIX: &[u8] = &[0x0];
+
+pub const SENTINEL_ROOT: [u8; 32] = [0u8; 32];
+
+#[macro_export]
+macro_rules! hash_intermediate_root {
+    {$d:ident, $n:expr} => {
+        hashv(&[ROOT_PREFIX, $d.as_ref(), $n])
+    }
+}
+
+#[macro_export]
+macro_rules! hash_leaf {
+    {$s:expr,$m:expr} => {
+        hashv(&[LEAF_PREFIX, RECEIPT_VERSION.to_le_bytes().as_ref(),$s,$m])
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct TransactionReceiptData {
+    pub version: u64,
+    pub message_hash: [u8; 32],
+    pub status: u8,
+}
+
+pub enum ReceiptStatus {
+    ReceiptStatusSuccess,
+    ReceiptStatusFailure,
+}
+
+impl TransactionReceiptData {
+    pub fn new(message_hash: [u8; 32], status: ReceiptStatus) -> Self {
+        let status = match status {
+            ReceiptStatus::ReceiptStatusSuccess => RECEIPT_STATUS_SUCCESS,
+            ReceiptStatus::ReceiptStatusFailure => RECEIPT_STATUS_FAILURE,
+        };
+        Self {
+            version: RECEIPT_VERSION,
+            message_hash,
+            status,
+        }
+    }
+
+    pub fn get_leaf(&self) -> Hash {
+        hash_leaf!(
+            self.status.to_le_bytes().as_ref(),
+            self.message_hash.as_slice()
+        )
+    }
+}
+
+pub struct TransactionReceiptTree {
+    pub leaf_count: usize,
+    pub tree: MerkleTree,
+}
+
+impl TransactionReceiptTree {
+    pub fn new(leaves: Vec<Hash>) -> Self {
+        let leaf_count = leaves.len();
+        let tree = MerkleTree::new_from_leaves(leaves);
+        Self { tree, leaf_count }
+    }
+
+    pub fn get_root(&self) -> Hash {
+        let maybe_inter_root = self.tree.get_root();
+
+        let final_root = match maybe_inter_root {
+            Some(inter_root) => {
+                hash_intermediate_root!(inter_root, &u64::to_le_bytes(self.leaf_count as u64))
+            }
+            None => hash_intermediate_root!(SENTINEL_ROOT, u64::to_le_bytes(0).as_slice()),
+        };
+
+        final_root
+    }
+}
+
+impl Default for TransactionReceiptTree {
+    fn default() -> Self {
+        let leaves: Vec<Hash> = Vec::default();
+        let tree = MerkleTree::new_from_leaves(leaves);
+        Self {
+            leaf_count: 0,
+            tree,
+        }
+    }
+}


### PR DESCRIPTION
#### Problem
Solana lacks support for receipts in it's runtime, a feature required for light clients. As described in [SIMD-64](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0064-transaction-receipt.md) and [SIMD-52](https://github.com/solana-foundation/solana-improvement-documents/pull/52), this PR adds a feature to bring support for light clients using transaction receipts.

#### Summary of Changes
- A new crate `solana-transaction-receipt` contains a wrapper of the solana-merkle-tree that implements the properties of the `TransactionReceiptTree` and `TransactionReceiptData` data structure.
- The Bankhash has been extended to contain the merkle root of the `TransactionReceiptTree`
- The Bank has been updated to have a transaction receipt queue to store the receipts of all the transaction batches once executed.
- When batches are executed, they now return the receipts for all in the result, this is done so the receipt leaves can be calculated in parallel as the transactions are processed. 
