### PR TITLE
Move `RewardInterval` to runtime

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -57,14 +57,6 @@ pub struct AccountLocks {
     readonly_locks: HashMap<Pubkey, u64>,
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub enum RewardInterval {
-    /// the slot within the epoch is INSIDE the reward distribution interval
-    InsideInterval,
-    /// the slot within the epoch is OUTSIDE the reward distribution interval
-    OutsideInterval,
-}
-
 impl AccountLocks {
     fn is_locked_readonly(&self, key: &Pubkey) -> bool {
         self.readonly_locks

--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -1,12 +1,15 @@
 pub mod account_rent_state;
 
 use {
-    crate::accounts::account_rent_state::{check_rent_state_with_account, RentState},
+    crate::{
+        accounts::account_rent_state::{check_rent_state_with_account, RentState},
+        bank::RewardInterval,
+    },
     itertools::Itertools,
     log::warn,
     solana_accounts_db::{
         account_overrides::AccountOverrides,
-        accounts::{LoadedTransaction, RewardInterval, TransactionLoadResult, TransactionRent},
+        accounts::{LoadedTransaction, TransactionLoadResult, TransactionRent},
         accounts_db::AccountsDb,
         ancestors::Ancestors,
         blockhash_queue::BlockhashQueue,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -70,7 +70,7 @@ use {
     solana_accounts_db::{
         account_overrides::AccountOverrides,
         accounts::{
-            AccountAddressFilter, Accounts, LoadedTransaction, PubkeyAccountSlot, RewardInterval,
+            AccountAddressFilter, Accounts, LoadedTransaction, PubkeyAccountSlot,
             TransactionLoadResult,
         },
         accounts_db::{
@@ -955,6 +955,14 @@ struct StakeRewardCalculation {
     stake_rewards: StakeRewards,
     /// total lamports across all `stake_rewards`
     total_stake_rewards_lamports: u64,
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub(super) enum RewardInterval {
+    /// the slot within the epoch is INSIDE the reward distribution interval
+    InsideInterval,
+    /// the slot within the epoch is OUTSIDE the reward distribution interval
+    OutsideInterval,
 }
 
 impl Bank {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -25,7 +25,7 @@ use {
     rayon::ThreadPoolBuilder,
     serde::{Deserialize, Serialize},
     solana_accounts_db::{
-        accounts::{AccountAddressFilter, RewardInterval},
+        accounts::AccountAddressFilter,
         accounts_db::{AccountShrinkThreshold, DEFAULT_ACCOUNTS_SHRINK_RATIO},
         accounts_index::{
             AccountIndex, AccountSecondaryIndexes, IndexKey, ScanConfig, ScanError, ITER_BATCH_SIZE,


### PR DESCRIPTION
#### Problem

`enum RewardInterval` is only used in runtime, but it is declared in `accounts-db`.

#### Summary of Changes

I moved the enum to `runtime/src/bank.rs`, closer to its usage.

