### PR TITLE
Uses Display in TieredStorageFile::new_readonly() panic message

### DIFF
--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -15,11 +15,10 @@ impl TieredStorageFile {
                 .read(true)
                 .create(false)
                 .open(&file_path)
-                .unwrap_or_else(|e| {
+                .unwrap_or_else(|err| {
                     panic!(
-                        "[TieredStorageError] Unable to open {:?} as read-only: {:?}",
+                        "[TieredStorageError] Unable to open {} as read-only: {err}",
                         file_path.as_ref().display(),
-                        e
                     );
                 }),
         )


### PR DESCRIPTION
#### Problem

The panic message is user facing, and `Display` should be used instead of `Debug` when possible. This is not the case in `TieredStorageFile::new_readonly()`.


#### Summary of Changes

Use Display instead of Debug