### PR TITLE
clippy: Replaces .get(0) with .first()

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -97,7 +97,7 @@ fn process_transaction_and_record_inner(
     Vec<Vec<InnerInstruction>>,
     Vec<String>,
 ) {
-    let signature = tx.signatures.get(0).unwrap().clone();
+    let signature = tx.signatures.first().unwrap().clone();
     let txs = vec![tx];
     let tx_batch = bank.prepare_batch_for_tests(txs);
     let mut results = bank


### PR DESCRIPTION
#### Problem

There are nightly clippy warnings that will prevent upgrading our stable Rust version.

For this PR, it's this one: https://rust-lang.github.io/rust-clippy/master/index.html#/get(0)


#### Summary of Changes

Replaces `.get(0)` with `.first()`.