### PR TITLE
[TieredStorage] Make AccountOffset use u32

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -228,7 +228,7 @@ impl HotStorageReader {
         &self,
         account_offset: AccountOffset,
     ) -> TieredStorageResult<&HotAccountMeta> {
-        let (meta, _) = get_type::<HotAccountMeta>(&self.mmap, account_offset.block)?;
+        let (meta, _) = get_type::<HotAccountMeta>(&self.mmap, account_offset.block as usize)?;
         Ok(meta)
     }
 
@@ -467,7 +467,7 @@ pub mod tests {
                 .iter()
                 .map(|meta| {
                     let prev_offset = current_offset;
-                    current_offset += file.write_type(meta).unwrap();
+                    current_offset += file.write_type(meta).unwrap() as u32;
                     AccountOffset { block: prev_offset }
                 })
                 .collect();
@@ -534,7 +534,7 @@ pub mod tests {
             let account_offset = hot_storage
                 .get_account_offset(IndexOffset(i as u32))
                 .unwrap();
-            assert_eq!(account_offset.block as u32, index_writer_entry.block_offset);
+            assert_eq!(account_offset.block, index_writer_entry.block_offset);
 
             let account_address = hot_storage
                 .get_account_address(IndexOffset(i as u32))

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -23,7 +23,7 @@ pub struct AccountIndexWriterEntry<'a> {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AccountOffset {
     /// The offset to the accounts block that contains the account meta/data.
-    pub block: usize,
+    pub block: u32,
 }
 
 /// The offset to an account/address entry in the accounts index block.
@@ -104,10 +104,10 @@ impl IndexBlockFormat {
                 let account_offset = footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
                     + std::mem::size_of::<u32>() * index_offset.0 as usize;
-                let (block_offset, _) = get_type::<u32>(mmap, account_offset)?;
+                let (block_offset, _) = get_type(mmap, account_offset)?;
 
                 Ok(AccountOffset {
-                    block: *block_offset as usize,
+                    block: *block_offset,
                 })
             }
         }
@@ -169,7 +169,7 @@ mod tests {
             let account_offset = indexer
                 .get_account_offset(&mmap, &footer, IndexOffset(i as u32))
                 .unwrap();
-            assert_eq!(index_entry.block_offset, account_offset.block as u32);
+            assert_eq!(index_entry.block_offset, account_offset.block);
             let address = indexer
                 .get_account_address(&mmap, &footer, IndexOffset(i as u32))
                 .unwrap();


### PR DESCRIPTION
#### Problem
AccountOffset currently uses `usize`, which size is platform dependent.
We want a fixed size type that is consist to what we persist in the tiered-storage file.

#### Summary of Changes
This PR makes AccountOffset use u32.

