### PR TITLE
Refactor assert in scan_snapshot_stores()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7638,10 +7638,12 @@ impl AccountsDb {
         config: &CalcAccountsHashConfig<'_>,
         filler_account_suffix: Option<&Pubkey>,
     ) -> Result<Vec<CacheHashDataFileReference>, AccountsHashVerificationError> {
+        assert!(bin_range.start < bins);
+        assert!(bin_range.end <= bins);
+        assert!(bin_range.start < bin_range.end);
         let _guard = self.active_stats.activate(ActiveStatItem::HashScan);
 
         let bin_calculator = PubkeyBinCalculator24::new(bins);
-        assert!(bin_range.start < bins && bin_range.end <= bins && bin_range.start < bin_range.end);
         let mut time = Measure::start("scan all accounts");
         stats.num_snapshot_storage = storages.storage_count();
         stats.num_slots = storages.slot_count();
@@ -10431,9 +10433,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "bin_range.start < bins && bin_range.end <= bins &&\\n    bin_range.start < bin_range.end"
-    )]
+    #[should_panic(expected = "bin_range.start < bins")]
     fn test_accountsdb_scan_snapshot_stores_illegal_range_start() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 2, end: 2 };
@@ -10444,9 +10444,7 @@ pub mod tests {
             .unwrap();
     }
     #[test]
-    #[should_panic(
-        expected = "bin_range.start < bins && bin_range.end <= bins &&\\n    bin_range.start < bin_range.end"
-    )]
+    #[should_panic(expected = "bin_range.end <= bins")]
     fn test_accountsdb_scan_snapshot_stores_illegal_range_end() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 1, end: 3 };
@@ -10458,9 +10456,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "bin_range.start < bins && bin_range.end <= bins &&\\n    bin_range.start < bin_range.end"
-    )]
+    #[should_panic(expected = "bin_range.start < bin_range.end")]
     fn test_accountsdb_scan_snapshot_stores_illegal_range_inverse() {
         let mut stats = HashStats::default();
         let bounds = Range { start: 1, end: 0 };


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/pull/34118 we are upgrading Rust. The way Rust *nightly* displays panic messages has changed. This can cause `should_panic` tests to fail if they specify an `expected` message. We're seeing that in the `accounts_db::tests::test_accountsdb_scan_snapshot_stores_illegal_range_xxx` tests.

Here's what the error looks like:

```
test accounts_db::tests::test_accountsdb_scan_snapshot_stores_illegal_range_end - should panic ... FAILED

failures:

---- accounts_db::tests::test_accountsdb_scan_snapshot_stores_illegal_range_end stdout ----
thread 'accounts_db::tests::test_accountsdb_scan_snapshot_stores_illegal_range_end' panicked at accounts-db/src/accounts_db.rs:7644:9:
assertion failed: bin_range.start < bins && bin_range.end <= bins &&
    bin_range.start < bin_range.end
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
note: panic did not contain expected string
      panic message: `"assertion failed: bin_range.start < bins && bin_range.end <= bins &&\n    bin_range.start < bin_range.end"`,
 expected substring: `"bin_range.start < bins && bin_range.end <= bins &&\\n    bin_range.start < bin_range.end"`
```

Here's the build log: https://buildkite.com/solana-labs/solana/builds/104653#018be0ac-278d-4621-9fd4-629956045713

Since the newlines seem to be an issue, we can split up the assert so that the panic message doesn't have any newlines. There will be no functional difference. 


#### Summary of Changes

Split the assert.