### PR TITLE
log when appending exceeds available space

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6310,6 +6310,14 @@ impl AccountsDb {
                     .unwrap_or_default();
                 let data_len = (data_len + STORE_META_OVERHEAD) as u64;
                 if !self.has_space_available(slot, data_len) {
+                    info!(
+                        "write_accounts_to_storage, no space: {}, {}, {}, {}, {}",
+                        storage.accounts.capacity(),
+                        storage.accounts.remaining_bytes(),
+                        data_len,
+                        infos.len(),
+                        accounts_and_meta_to_store.len()
+                    );
                     let special_store_size = std::cmp::max(data_len * 2, self.file_size);
                     if self
                         .try_recycle_and_insert_store(slot, special_store_size, std::u64::MAX)


### PR DESCRIPTION
#### Problem
Some ancient append vec code triggered the old code in append vecs that previously allowed multiple append vecs per slot. This code will shortly result in an assert. It would be nice to remove this code path at some point.
In the meantime, it would help with diagnosing what caused the situation if we logged some information about what was going on.

#### Summary of Changes
Add some logging when appending accounts exhausts all space in an append vec.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
