### PR TITLE
remaining_bytes aligns len since all writes will align first

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5752,7 +5752,7 @@ impl AccountsDb {
     fn has_space_available(&self, slot: Slot, size: u64) -> bool {
         let store = self.storage.get_slot_storage_entry(slot).unwrap();
         if store.status() == AccountStorageStatus::Available
-            && (store.accounts.capacity() - store.accounts.len() as u64) > size
+            && store.accounts.remaining_bytes() > size
         {
             return true;
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5752,7 +5752,7 @@ impl AccountsDb {
     fn has_space_available(&self, slot: Slot, size: u64) -> bool {
         let store = self.storage.get_slot_storage_entry(slot).unwrap();
         if store.status() == AccountStorageStatus::Available
-            && store.accounts.remaining_bytes() > size
+            && store.accounts.remaining_bytes() >= size
         {
             return true;
         }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -327,7 +327,8 @@ impl AppendVec {
 
     /// how many more bytes can be stored in this append vec
     pub fn remaining_bytes(&self) -> u64 {
-        (self.capacity()).saturating_sub(self.len() as u64)
+        self.capacity()
+            .saturating_sub(u64_align!(self.len()) as u64)
     }
 
     pub fn len(&self) -> usize {

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -1003,10 +1003,36 @@ pub mod tests {
         let av = AppendVec::new(&path.path, true, sz);
         assert_eq!(av.capacity(), sz64);
         assert_eq!(av.remaining_bytes(), sz64);
+
+        // append first account, an u64 aligned account (136 bytes)
+        let mut av_len = 0;
         let account = create_test_account(0);
         av.append_account_test(&account).unwrap();
+        av_len += STORE_META_OVERHEAD;
         assert_eq!(av.capacity(), sz64);
         assert_eq!(av.remaining_bytes(), sz64 - (STORE_META_OVERHEAD as u64));
+        assert_eq!(av.len(), av_len);
+
+        // append second account, a *not* u64 aligned account (137 bytes)
+        let account = create_test_account(1);
+        let account_storage_len = STORE_META_OVERHEAD + 1;
+        av_len += account_storage_len;
+        av.append_account_test(&account).unwrap();
+        assert_eq!(av.capacity(), sz64);
+        assert_eq!(av.len(), av_len);
+        let alignment_bytes = u64_align!(av_len) - av_len; // bytes used for alignment (7 bytes)
+        assert_eq!(alignment_bytes, 7);
+        assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
+
+        // append third account, a *not* u64 aligned account (137 bytes)
+        let account = create_test_account(1);
+        av.append_account_test(&account).unwrap();
+        let account_storage_len = STORE_META_OVERHEAD + 1;
+        av_len += alignment_bytes; // bytes used for alignment at the end of previous account
+        av_len += account_storage_len;
+        assert_eq!(av.capacity(), sz64);
+        assert_eq!(av.len(), av_len);
+        assert_eq!(av.remaining_bytes(), sz64 - u64_align!(av_len) as u64);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
ancient append vec appending relies on a reliable count of remaining bytes. It turns out that the append vec's `len()` is up to the last written byte. This can be non-u64 aligned. The result is if we are to append more to the file, the first operation will be a `u64_align!`. This means that `remaining_bytes` was reporting too many bytes. Not all those bytes could be written to, thanks to the bytes wasted for alignment. The result was that writes could fail, causing an attempt at creating a second append vec for the slot. This is no longer allowed and will fail with an assert.

#### Summary of Changes
Align `len()` so that remaining bytes returns an accurate number.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
