### PR TITLE
Disable adding copyfiles to tarred genesis on Macos

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4132,10 +4132,11 @@ pub fn create_new_ledger(
         blockstore_dir,
     ];
     let output = std::process::Command::new("tar")
+        .env("COPYFILE_DISABLE", "1")
         .args(args)
         .output()
         .unwrap();
-    if !output.status.success() {
+    if !output.stderr.is_empty() || !output.status.success() {
         use std::str::from_utf8;
         error!("tar stdout: {}", from_utf8(&output.stdout).unwrap_or("?"));
         error!("tar stderr: {}", from_utf8(&output.stderr).unwrap_or("?"));


### PR DESCRIPTION
Tar on Macos adds extra files to the tar as metadata by default. These extra files cause an error when unpacking the genesis later in the codebase.

As these files are not required, and are only added on macos, we should disable this behavior in-code by adding the env variable COPYFILE_DISABLE so it does not depend on OS configuration.

#### Problem
Error when unpacking hardened archive file because of metadata files added by tar on Macos

#### Summary of Changes
Disable adding the metadata copyfiles on mac by default. Also show and errors in stderr except only when it is exiting unsuccessful.
