### PR TITLE
Update CHANGELOG for new scheduler support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Release channels have their own copy of this changelog:
   * Added a github check to support `changelog` label
   * The default for `--use-snapshot-archives-at-startup` is now `when-newest` (#33883)
     * The default for `solana-ledger-tool`, however, remains `always` (#34228)
+  * Added `central-scheduler` option for `--block-production-method` (#33890)
 * Upgrade Notes
 
 ## [1.17.0]


### PR DESCRIPTION
#### Problem
I did not update the CHANGELOG in #33890, which enabled this option, because I was waiting to merge a few metrics PRs first.
Those have been merged, so updating the change log now.

#### Summary of Changes
Add changelog line which lists new `--block-production-method central-scheduler` option

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
