### PR TITLE
refactor AccountsToStore

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -378,7 +378,7 @@ impl CurrentAncientAppendVec {
         let accounts = accounts_to_store.get(storage_selector);
 
         db.store_accounts_frozen(
-            (self.slot(), accounts, accounts_to_store.slot),
+            (self.slot(), accounts, accounts_to_store.slot()),
             None::<Vec<AccountHash>>,
             self.append_vec(),
             None,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -867,7 +867,7 @@ pub struct AccountsToStore<'a> {
     /// if 'accounts' contains more items than can be contained in the primary storage, then we have to split these accounts.
     /// 'index_first_item_overflow' specifies the index of the first item in 'accounts' that will go into the overflow storage
     index_first_item_overflow: usize,
-    pub slot: Slot,
+    slot: Slot,
 }
 
 impl<'a> AccountsToStore<'a> {
@@ -914,6 +914,10 @@ impl<'a> AccountsToStore<'a> {
             StorageSelector::Overflow => self.index_first_item_overflow..self.accounts.len(),
         };
         &self.accounts[range]
+    }
+
+    pub fn slot(&self) -> Slot {
+        self.slot
     }
 }
 


### PR DESCRIPTION
#### Problem

AccountsToStore, once created, its member "slot" should not be changed. However,
because pub member slot, it could be changed when holding a mut&. 

Refactor pub member slot from AccountsToStore into a readonly fn.


#### Summary of Changes

Refactor pub member slot from AccountsToStore into a readonly fn.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
