### PR TITLE
Don't require program_id to passed down cpi call chain

### DIFF
--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -257,7 +257,7 @@ impl Message {
         address_lookup_table_accounts: &[AddressLookupTableAccount],
         recent_blockhash: Hash,
     ) -> Result<Self, CompileError> {
-        let mut compiled_keys = CompiledKeys::compile(instructions, Some(*payer));
+        let mut compiled_keys = CompiledKeys::compile(instructions, &[], Some(*payer));
 
         let mut address_table_lookups = Vec::with_capacity(address_lookup_table_accounts.len());
         let mut loaded_addresses_list = Vec::with_capacity(address_lookup_table_accounts.len());

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -755,7 +755,8 @@ pub fn create_is_signer_account_infos<'a>(
         })
         .collect()
 }
-+ /// Replacement for the executable flag: An account being owned by one of these contains a program.
+
+/// Replacement for the executable flag: An account being owned by one of these contains a program.
 pub const PROGRAM_OWNERS: &[Pubkey] = &[
     bpf_loader_upgradeable::id(),
     bpf_loader::id(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -732,6 +732,10 @@ pub mod enable_zk_transfer_with_fee {
     solana_sdk::declare_id!("zkNLP7EQALfC1TYeB3biDU7akDckj8iPkvh9y2Mt2K3");
 }
 
+pub mod no_need_for_program_key_in_parent_instruction {
+    solana_sdk::declare_id!("Sean2BxUmn4RLbqcoiJux3Ymij8SX2SsyjHWDCwJN5o");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -910,6 +914,7 @@ lazy_static! {
         (validate_fee_collector_account::id(), "validate fee collector account #33888"),
         (disable_rent_fees_collection::id(), "Disable rent fees collection #33945"),
         (enable_zk_transfer_with_fee::id(), "enable Zk Token proof program transfer with fee"),
+        (no_need_for_program_key_in_parent_instruction::id(), "Relax requirement that parent should have passed program id for CPI"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

When using cpi, the callee program id must be passed down the call chain.  Remove this restriction. See #34057

#### Summary of Changes

Find the program_id in the transaction context rather than in the instruction context.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
