### PR TITLE
move PROGRAM_OWNERS to sdk

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -125,9 +125,9 @@ use {
         account::{
             create_account_shared_data_with_fields as create_account, from_account, Account,
             AccountSharedData, InheritableAccountFields, ReadableAccount, WritableAccount,
+            PROGRAM_OWNERS,
         },
         account_utils::StateMut,
-        bpf_loader, bpf_loader_deprecated,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{
             BankId, Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_HASHES_PER_TICK,
@@ -5229,12 +5229,6 @@ impl Bank {
         );
         check_time.stop();
 
-        const PROGRAM_OWNERS: &[Pubkey] = &[
-            bpf_loader_upgradeable::id(),
-            bpf_loader::id(),
-            bpf_loader_deprecated::id(),
-            loader_v4::id(),
-        ];
         let mut program_accounts_map = self.filter_executable_program_accounts(
             &self.ancestors,
             sanitized_txs,

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -4,8 +4,10 @@
 use qualifier_attr::qualifiers;
 use {
     crate::{
+        bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
         clock::{Epoch, INITIAL_RENT_EPOCH},
         lamports::LamportsError,
+        loader_v4,
         pubkey::Pubkey,
     },
     serde::{
@@ -753,6 +755,13 @@ pub fn create_is_signer_account_infos<'a>(
         })
         .collect()
 }
+
+pub const PROGRAM_OWNERS: &[Pubkey] = &[
+    bpf_loader_upgradeable::id(),
+    bpf_loader::id(),
+    bpf_loader_deprecated::id(),
+    loader_v4::id(),
+];
 
 #[cfg(test)]
 pub mod tests {

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -755,7 +755,7 @@ pub fn create_is_signer_account_infos<'a>(
         })
         .collect()
 }
-
++ /// Replacement for the executable flag: An account being owned by one of these contains a program.
 pub const PROGRAM_OWNERS: &[Pubkey] = &[
     bpf_loader_upgradeable::id(),
     bpf_loader::id(),


### PR DESCRIPTION
#### Problem

Part of effort for https://github.com/solana-labs/solana/issues/33970

We are going to deprecate executable flags on account. Instead of relying on
executable flag on account to determine whether the account is execuable, we
are going to check the owner of the account is a variant of bpf-loader.

This change moves `PROGRAM_OWNERS` from runtime to sdk, so that it can be
shared for the upcoming work.


#### Summary of Changes

Move PROGRAM_OWNERS list to sdk


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
