### PR TITLE
Include datapoint timestamp when logging datapoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6507,6 +6507,7 @@ dependencies = [
 name = "solana-metrics"
 version = "1.18.0"
 dependencies = [
+ "chrono",
  "crossbeam-channel",
  "env_logger",
  "gethostname",

--- a/metrics/Cargo.toml
+++ b/metrics/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+chrono.workspace = true
 crossbeam-channel = { workspace = true }
 gethostname = { workspace = true }
 lazy_static = { workspace = true }

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -40,7 +40,7 @@
 //! );
 //!
 use {
-    chrono::{DateTime, SecondsFormat, Utc},
+    chrono::{DateTime, Utc},
     std::{fmt, time::SystemTime},
 };
 

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -39,9 +39,10 @@
 //!     ("some-string", "field-value", String),
 //! );
 //!
-use chrono::{DateTime, Utc};
-use std::{fmt, time::SystemTime};
-
+use {
+    chrono::{DateTime, SecondsFormat, Utc},
+    std::{fmt, time::SystemTime},
+};
 
 #[derive(Clone, Debug)]
 pub struct DataPoint {
@@ -92,7 +93,12 @@ impl DataPoint {
 impl fmt::Display for DataPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let datetime: DateTime<Utc> = self.timestamp.into();
-        write!(f, "datapoint: {}, timestamp: {}", self.name, datetime.to_rfc3339())?;
+        write!(
+            f,
+            "datapoint: {}, timestamp: {}",
+            self.name,
+            datetime.to_rfc3339_opts(SecondsFormat::Secs, true)
+        )?;
         for tag in &self.tags {
             write!(f, ",{}={}", tag.0, tag.1)?;
         }

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -39,7 +39,9 @@
 //!     ("some-string", "field-value", String),
 //! );
 //!
+use chrono::{DateTime, Utc};
 use std::{fmt, time::SystemTime};
+
 
 #[derive(Clone, Debug)]
 pub struct DataPoint {
@@ -89,7 +91,8 @@ impl DataPoint {
 
 impl fmt::Display for DataPoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "datapoint: {}", self.name)?;
+        let datetime: DateTime<Utc> = self.timestamp.into();
+        write!(f, "datapoint: {}, timestamp: {}", self.name, datetime.to_rfc3339())?;
         for tag in &self.tags {
             write!(f, ",{}={}", tag.0, tag.1)?;
         }

--- a/metrics/src/datapoint.rs
+++ b/metrics/src/datapoint.rs
@@ -95,9 +95,9 @@ impl fmt::Display for DataPoint {
         let datetime: DateTime<Utc> = self.timestamp.into();
         write!(
             f,
-            "datapoint: {}, timestamp: {}",
-            self.name,
-            datetime.to_rfc3339_opts(SecondsFormat::Secs, true)
+            "{} datapoint: {}",
+            datetime.format("%H:%M:%S %Z"),
+            self.name
         )?;
         for tag in &self.tags {
             write!(f, ",{}={}", tag.0, tag.1)?;


### PR DESCRIPTION
#### Problem
Datapoints are logged (info level) but don't include the timestamp. The logger adds its own timestamp, but if there's a delay in processing datapoints the logging timestamp can be misleading. Delays happen during resource contention, which is one of the times when we're likely to be examining logs.

#### Summary of Changes
Add the datapoint timestamp to the Display so it is included in the logs.

Since the timestamp is mostly redundant I'm including the time but not the date. Log output looks like this now:
```
[2023-11-21T19:03:44.447890664Z INFO  solana_metrics::metrics] 19:03:44 UTC datapoint: bank-timestamp get_timestamp_estimate_us=622i
[2023-11-21T19:03:44.447899440Z INFO  solana_metrics::metrics] 19:03:44 UTC datapoint: bank-timestamp-correction slot=231416166i from_genesis=1676935406i corrected=1700593424i ancestor_timestamp=1700593423i
[2023-11-21T19:03:44.447982178Z INFO  solana_metrics::metrics] 19:03:44 UTC datapoint: bank-new_from_parent-heights slot=231416166i block_height=213158265i parent_slot=231416165i bank_rc_creation_us=1i total_elapsed_us=897i status_cache_us=0i fee_components_us=0i blockhash_queue_us=6i stakes_cache_us=1i epoch_stakes_time_us=0i builtin_programs_us=0i rewards_pool_pubkeys_us=0i executor_cache_us=0i transaction_debug_keys_us=0i transaction_log_collector_config_us=0i feature_set_us=0i ancestors_us=8i update_epoch_us=1i recompilation_time_us=0i update_sysvars_us=797i fill_sysvar_cache_us=72i
[2023-11-21T19:03:44.448014710Z INFO  solana_metrics::metrics] 19:03:44 UTC datapoint: loaded-programs-cache-stats slot=231416165i hits=3191i misses=0i evictions=0i insertions=0i replacements=0i one_hit_wonders=0i prunes_orphan=0i prunes_expired=0i prunes_environment=0i empty_entries=0i
```

This adds 13 characters to each datapoint line. I see about 8M datapoint entries per day, so this change will increase log sizes by about 100MB/day.