### PR TITLE
Log datapoints and counters before sending to MetricsAgent

### DIFF
--- a/metrics/src/metrics.rs
+++ b/metrics/src/metrics.rs
@@ -279,12 +279,10 @@ impl MetricsAgent {
                         last_write_time = Instant::now();
                         barrier.wait();
                     }
-                    MetricsCommand::Submit(point, level) => {
-                        log!(level, "{}", point);
+                    MetricsCommand::Submit(point, _level) => {
                         points.push(point);
                     }
                     MetricsCommand::SubmitCounter(counter, _level, bucket) => {
-                        debug!("{:?}", counter);
                         let key = (counter.name, bucket);
                         if let Some(value) = counters.get_mut(&key) {
                             value.count += counter.count;
@@ -374,6 +372,7 @@ pub fn set_host_id(host_id: String) {
 /// Submits a new point from any thread.  Note that points are internally queued
 /// and transmitted periodically in batches.
 pub fn submit(point: DataPoint, level: log::Level) {
+    log!(level, "{}", point);
     let agent = get_singleton_agent();
     agent.submit(point, level);
 }
@@ -381,6 +380,7 @@ pub fn submit(point: DataPoint, level: log::Level) {
 /// Submits a new counter or updates an existing counter from any thread.  Note that points are
 /// internally queued and transmitted periodically in batches.
 pub(crate) fn submit_counter(point: CounterPoint, level: log::Level, bucket: u64) {
+    debug!("{:?}", point);
     let agent = get_singleton_agent();
     agent.submit_counter(point, level, bucket);
 }


### PR DESCRIPTION
#### Problem
The MetricsAgent has a crossbeam channel that receives datapoints from all over the codebase. Currently, a datapoint or counter is logged once it has been popped off the crossbeam channel. This is not ideal in that it could introduce a delay in the timestamp observable in logs vs. when it actually occurred

#### Summary of Changes
To mitigate the issue, log the datapoints / counters before sending to the crossbeam channel. This removes the possibility of any latency being introduced waiting for the agent to handle the datapoint.

Note that the datapoints themselves have the timestamp recorded at the time of creation, so the timestamps reported to the metrics database is correct.

Lastly, while this change will make the reporting better, I think there is work to be done in debugging to figure out why the backup is occurring. If the backup is a result of us slamming the metrics agent with too much, that is a case of noisy metrics. If the system is getting inundated in general (potentially the case with the startup traffic spike), then we need to debug that as well