### PR TITLE
don't sign X.509 certs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,12 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "base64ct"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874f8444adcb4952a8bc51305c8be95c8ec8237bb0d2e78d2e039f771f8828a0"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,12 +1229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
 name = "const_format"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,15 +1530,6 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid",
-]
 
 [[package]]
 name = "der-parser"
@@ -3869,17 +3848,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der",
- "spki",
- "zeroize",
-]
 
 [[package]]
 name = "pkg-config"
@@ -7273,7 +7241,6 @@ dependencies = [
  "nix 0.26.4",
  "pem",
  "percentage",
- "pkcs8",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
@@ -7774,16 +7741,6 @@ name = "spin"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
-
-[[package]]
-name = "spki"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "spl-associated-token-account"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4349,18 +4349,6 @@ name = "rbpf-cli"
 version = "1.18.0"
 
 [[package]]
-name = "rcgen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
-dependencies = [
- "pem",
- "ring 0.16.20",
- "time",
- "yasna",
-]
-
-[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5822,7 +5810,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rcgen",
  "solana-logger",
  "solana-measure",
  "solana-metrics",
@@ -5861,7 +5848,6 @@ dependencies = [
  "rand_chacha 0.3.1",
  "raptorq",
  "rayon",
- "rcgen",
  "rolling-file",
  "rustc_version 0.4.0",
  "rustls",
@@ -6755,7 +6741,6 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rcgen",
  "rustls",
  "solana-connection-cache",
  "solana-logger",
@@ -7244,7 +7229,6 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rcgen",
  "rustls",
  "solana-logger",
  "solana-metrics",
@@ -7434,7 +7418,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rcgen",
  "rustls",
  "solana-entry",
  "solana-gossip",
@@ -9225,15 +9208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
-dependencies = [
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,6 @@ pbkdf2 = { version = "0.11.0", default-features = false }
 pem = "1.1.1"
 percentage = "0.1.0"
 pickledb = { version = "0.5.1", default-features = false }
-pkcs8 = "0.8.0"
 predicates = "2.1"
 pretty-hex = "0.3.0"
 prio-graph = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,7 +278,6 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 raptorq = "1.8.0"
 rayon = "1.8.0"
-rcgen = "0.10.0"
 reed-solomon-erasure = "6.0.0"
 regex = "1.10.2"
 reqwest = { version = "0.11.22", default-features = false }

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -79,9 +79,7 @@ impl ConnectionCache {
             config.update_client_endpoint(client_endpoint);
         }
         if let Some(cert_info) = cert_info {
-            config
-                .update_client_certificate(cert_info.0, cert_info.1)
-                .unwrap();
+            config.update_client_certificate(cert_info.0, cert_info.1);
         }
         if let Some(stake_info) = stake_info {
             config.set_staked_nodes(stake_info.0, stake_info.1);
@@ -240,7 +238,7 @@ mod tests {
     #[test]
     fn test_connection_with_specified_client_endpoint() {
         // Start a response receiver:
-        let (response_recv_socket, response_recv_exit, keypair2, response_recv_ip) = server_args();
+        let (response_recv_socket, response_recv_exit, keypair2, _) = server_args();
         let (sender2, _receiver2) = unbounded();
 
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
@@ -249,7 +247,6 @@ mod tests {
             "quic_streamer_test",
             response_recv_socket,
             &keypair2,
-            response_recv_ip,
             sender2,
             response_recv_exit.clone(),
             1,

--- a/connection-cache/Cargo.toml
+++ b/connection-cache/Cargo.toml
@@ -19,7 +19,6 @@ indicatif = { workspace = true, optional = true }
 log = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-rcgen = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-sdk = { workspace = true }

--- a/connection-cache/src/connection_cache.rs
+++ b/connection-cache/src/connection_cache.rs
@@ -406,9 +406,6 @@ pub enum ConnectionPoolError {
 
 #[derive(Error, Debug)]
 pub enum ClientError {
-    #[error("Certificate error: {0}")]
-    CertificateError(#[from] rcgen::RcgenError),
-
     #[error("IO error: {0:?}")]
     IoError(#[from] std::io::Error),
 }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -36,7 +36,6 @@ quinn = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-rcgen = { workspace = true }
 rolling-file = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true }

--- a/core/src/repair/quic_endpoint.rs
+++ b/core/src/repair/quic_endpoint.rs
@@ -9,20 +9,17 @@ use {
         EndpointConfig, IdleTimeout, ReadError, ReadToEndError, RecvStream, SendStream,
         ServerConfig, TokioRuntime, TransportConfig, VarInt, WriteError,
     },
-    rcgen::RcgenError,
     rustls::{Certificate, PrivateKey},
     serde_bytes::ByteBuf,
     solana_quic_client::nonblocking::quic_client::SkipServerVerification,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{packet::PACKET_DATA_SIZE, pubkey::Pubkey, signature::Keypair},
-    solana_streamer::{
-        quic::SkipClientVerification, tls_certificates::new_self_signed_tls_certificate,
-    },
+    solana_streamer::{quic::SkipClientVerification, tls_certificates::new_dummy_x509_certificate},
     std::{
         cmp::Reverse,
         collections::{hash_map::Entry, HashMap},
         io::{Cursor, Error as IoError},
-        net::{IpAddr, SocketAddr, UdpSocket},
+        net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, RwLock,
@@ -88,8 +85,6 @@ pub struct RemoteRequest {
 #[derive(Error, Debug)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Error {
-    #[error(transparent)]
-    CertificateError(#[from] RcgenError),
     #[error("Channel Send Error")]
     ChannelSendError,
     #[error(transparent)]
@@ -123,11 +118,10 @@ pub(crate) fn new_quic_endpoint(
     runtime: &tokio::runtime::Handle,
     keypair: &Keypair,
     socket: UdpSocket,
-    address: IpAddr,
     remote_request_sender: Sender<RemoteRequest>,
     bank_forks: Arc<RwLock<BankForks>>,
 ) -> Result<(Endpoint, AsyncSender<LocalRequest>, AsyncTryJoinHandle), Error> {
-    let (cert, key) = new_self_signed_tls_certificate(keypair, address)?;
+    let (cert, key) = new_dummy_x509_certificate(keypair);
     let server_config = new_server_config(cert.clone(), key.clone())?;
     let client_config = new_client_config(cert, key)?;
     let mut endpoint = {
@@ -792,7 +786,6 @@ async fn report_metrics_task(name: &'static str, stats: Arc<RepairQuicStats>) {
 
 fn record_error(err: &Error, stats: &RepairQuicStats) {
     match err {
-        Error::CertificateError(_) => (),
         Error::ChannelSendError => (),
         Error::ConnectError(ConnectError::EndpointStopping) => {
             add_metric!(stats.connect_error_other)
@@ -1048,7 +1041,6 @@ mod tests {
                         runtime.handle(),
                         keypair,
                         socket,
-                        IpAddr::V4(Ipv4Addr::LOCALHOST),
                         remote_request_sender,
                         bank_forks.clone(),
                     )

--- a/core/src/tpu.rs
+++ b/core/src/tpu.rs
@@ -19,7 +19,7 @@ use {
     },
     bytes::Bytes,
     crossbeam_channel::{unbounded, Receiver},
-    solana_client::connection_cache::{ConnectionCache, Protocol},
+    solana_client::connection_cache::ConnectionCache,
     solana_gossip::cluster_info::ClusterInfo,
     solana_ledger::{
         blockstore::Blockstore, blockstore_processor::TransactionStatusSender,
@@ -152,11 +152,6 @@ impl Tpu {
             "quic_streamer_tpu",
             transactions_quic_sockets,
             keypair,
-            cluster_info
-                .my_contact_info()
-                .tpu(Protocol::QUIC)
-                .expect("Operator must spin up node with valid (QUIC) TPU address")
-                .ip(),
             packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,
@@ -172,11 +167,6 @@ impl Tpu {
             "quic_streamer_tpu_forwards",
             transactions_forwards_quic_sockets,
             keypair,
-            cluster_info
-                .my_contact_info()
-                .tpu_forwards(Protocol::QUIC)
-                .expect("Operator must spin up node with valid (QUIC) TPU-forwards address")
-                .ip(),
             forwarded_packet_sender,
             exit.clone(),
             MAX_QUIC_CONNECTIONS_PER_PEER,

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1176,10 +1176,6 @@ impl Validator {
                 .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap()),
             &identity_keypair,
             node.sockets.tvu_quic,
-            node.info
-                .tvu(Protocol::QUIC)
-                .map_err(|err| format!("Invalid QUIC TVU address: {err:?}"))?
-                .ip(),
             turbine_quic_endpoint_sender,
             bank_forks.clone(),
         )
@@ -1201,10 +1197,6 @@ impl Validator {
                     .unwrap_or_else(|| current_runtime_handle.as_ref().unwrap()),
                 &identity_keypair,
                 node.sockets.serve_repair_quic,
-                node.info
-                    .serve_repair(Protocol::QUIC)
-                    .map_err(|err| format!("Invalid QUIC serve-repair address: {err:?}"))?
-                    .ip(),
                 repair_quic_endpoint_sender,
                 bank_forks.clone(),
             )

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -547,12 +547,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
-name = "base64ct"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71acf5509fc522cce1b100ac0121c635129bfd4d91cdf036bcc9b9935f97ccf5"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,12 +1039,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,15 +1242,6 @@ name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid",
-]
 
 [[package]]
 name = "der-parser"
@@ -3487,17 +3466,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der",
- "spki",
- "zeroize",
-]
 
 [[package]]
 name = "pkg-config"
@@ -6342,7 +6310,6 @@ dependencies = [
  "nix",
  "pem",
  "percentage",
- "pkcs8",
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
@@ -6705,16 +6672,6 @@ name = "spin"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
-
-[[package]]
-name = "spki"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
-dependencies = [
- "base64ct",
- "der",
-]
 
 [[package]]
 name = "spl-associated-token-account"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3858,18 +3858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
-dependencies = [
- "pem",
- "ring 0.16.20",
- "time",
- "yasna",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4901,7 +4889,6 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rayon",
- "rcgen",
  "solana-measure",
  "solana-metrics",
  "solana-sdk",
@@ -4935,7 +4922,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rcgen",
  "rolling-file",
  "rustc_version",
  "rustls",
@@ -5510,7 +5496,6 @@ dependencies = [
  "log",
  "quinn",
  "quinn-proto",
- "rcgen",
  "rustls",
  "solana-connection-cache",
  "solana-measure",
@@ -6313,7 +6298,6 @@ dependencies = [
  "quinn",
  "quinn-proto",
  "rand 0.8.5",
- "rcgen",
  "rustls",
  "solana-metrics",
  "solana-perf",
@@ -6438,7 +6422,6 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
- "rcgen",
  "rustls",
  "solana-entry",
  "solana-gossip",
@@ -8050,15 +8033,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "yasna"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
-dependencies = [
- "time",
 ]
 
 [[package]]

--- a/quic-client/Cargo.toml
+++ b/quic-client/Cargo.toml
@@ -18,7 +18,6 @@ lazy_static = { workspace = true }
 log = { workspace = true }
 quinn = { workspace = true }
 quinn-proto = { workspace = true }
-rcgen = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration"] }
 solana-connection-cache = { workspace = true }
 solana-measure = { workspace = true }

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -27,7 +27,7 @@ use {
         transport::Result as TransportResult,
     },
     solana_streamer::{
-        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, tls_certificates::new_self_signed_tls_certificate,
+        nonblocking::quic::ALPN_TPU_PROTOCOL_ID, tls_certificates::new_dummy_x509_certificate,
     },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
@@ -148,9 +148,7 @@ impl QuicLazyInitializedEndpoint {
 
 impl Default for QuicLazyInitializedEndpoint {
     fn default() -> Self {
-        let (cert, priv_key) =
-            new_self_signed_tls_certificate(&Keypair::new(), IpAddr::V4(Ipv4Addr::UNSPECIFIED))
-                .expect("Failed to create QUIC client certificate");
+        let (cert, priv_key) = new_dummy_x509_certificate(&Keypair::new());
         Self::new(
             Arc::new(QuicClientCertificate {
                 certificate: cert,

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -25,7 +25,6 @@ percentage = { workspace = true }
 quinn = { workspace = true }
 quinn-proto = { workspace = true }
 rand = { workspace = true }
-rcgen = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration"] }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -22,7 +22,6 @@ log = { workspace = true }
 nix = { workspace = true }
 pem = { workspace = true }
 percentage = { workspace = true }
-pkcs8 = { workspace = true, features = ["alloc"] }
 quinn = { workspace = true }
 quinn-proto = { workspace = true }
 rand = { workspace = true }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -85,7 +85,6 @@ pub fn spawn_server(
     name: &'static str,
     sock: UdpSocket,
     keypair: &Keypair,
-    gossip_host: IpAddr,
     packet_sender: Sender<PacketBatch>,
     exit: Arc<AtomicBool>,
     max_connections_per_peer: usize,
@@ -96,7 +95,7 @@ pub fn spawn_server(
     coalesce: Duration,
 ) -> Result<(Endpoint, Arc<StreamStats>, JoinHandle<()>), QuicServerError> {
     info!("Start {name} quic server on {sock:?}");
-    let (config, _cert) = configure_server(keypair, gossip_host)?;
+    let (config, _cert) = configure_server(keypair)?;
 
     let endpoint = Endpoint::new(
         EndpointConfig::default(),
@@ -1094,7 +1093,7 @@ pub mod test {
         crate::{
             nonblocking::quic::compute_max_allowed_uni_streams,
             quic::{MAX_STAKED_CONNECTIONS, MAX_UNSTAKED_CONNECTIONS},
-            tls_certificates::new_self_signed_tls_certificate,
+            tls_certificates::new_dummy_x509_certificate,
         },
         assert_matches::assert_matches,
         async_channel::unbounded as async_unbounded,
@@ -1106,7 +1105,7 @@ pub mod test {
             signature::Keypair,
             signer::Signer,
         },
-        std::{collections::HashMap, net::Ipv4Addr},
+        std::collections::HashMap,
         tokio::time::sleep,
     };
 
@@ -1133,9 +1132,7 @@ pub mod test {
     }
 
     pub fn get_client_config(keypair: &Keypair) -> ClientConfig {
-        let ipaddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
-        let (cert, key) = new_self_signed_tls_certificate(keypair, ipaddr)
-            .expect("Failed to generate client certificate");
+        let (cert, key) = new_dummy_x509_certificate(keypair);
 
         let mut crypto = rustls::ClientConfig::builder()
             .with_safe_defaults()
@@ -1171,14 +1168,12 @@ pub mod test {
         let exit = Arc::new(AtomicBool::new(false));
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
-        let ip = "127.0.0.1".parse().unwrap();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(option_staked_nodes.unwrap_or_default()));
         let (_, stats, t) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,
-            ip,
             sender,
             exit.clone(),
             max_connections_per_peer,
@@ -1607,14 +1602,12 @@ pub mod test {
         let exit = Arc::new(AtomicBool::new(false));
         let (sender, _) = unbounded();
         let keypair = Keypair::new();
-        let ip = "127.0.0.1".parse().unwrap();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (_, _, t) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,
-            ip,
             sender,
             exit.clone(),
             1,
@@ -1638,14 +1631,12 @@ pub mod test {
         let exit = Arc::new(AtomicBool::new(false));
         let (sender, receiver) = unbounded();
         let keypair = Keypair::new();
-        let ip = "127.0.0.1".parse().unwrap();
         let server_address = s.local_addr().unwrap();
         let staked_nodes = Arc::new(RwLock::new(StakedNodes::default()));
         let (_, stats, t) = spawn_server(
             "quic_streamer_test",
             s,
             &keypair,
-            ip,
             sender,
             exit.clone(),
             2,

--- a/streamer/src/tls_certificates.rs
+++ b/streamer/src/tls_certificates.rs
@@ -1,31 +1,10 @@
 use {
-    rcgen::{CertificateParams, DistinguishedName, DnType, RcgenError, SanType},
-    solana_sdk::{pubkey::Pubkey, signature::Keypair},
-    std::net::IpAddr,
+    solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer},
     x509_parser::{prelude::*, public_key::PublicKey},
 };
 
-pub fn new_self_signed_tls_certificate(
-    keypair: &Keypair,
-    san: IpAddr,
-) -> Result<(rustls::Certificate, rustls::PrivateKey), RcgenError> {
-    // Note: This function signs an X.509 certificate with the node
-    // identity key, which is theoretically redundant. (Peer validation
-    // is done at a later step in the TLS CertificateVerify) We are
-    // currently forced to use X.509 certificates regardless because the
-    // Rust ecosystem's poor support for RFC 7250 (raw public keys).
-    //
-    // This form of key reuse introduces risk of type confusion attacks
-    // against the signing payload. It was proven using a CBMC model
-    // that no such type confusion attack exists as of 2023-Nov:
-    //
-    // https://github.com/firedancer-io/firedancer/blob/7e91d9bda93dee2a43065e30f65ef6422bd93019/src/disco/keyguard/fd_keyguard_match.c
-
-    // TODO: Consider (1) signing with a dummy cert authority instead of
-    //       using a self-signed certificate, or (2) forcing use of
-    //       RFC 7250 RawPublicKeys.
-
-    // Unfortunately, rcgen does not accept a "raw" Ed25519 key.
+pub fn new_dummy_x509_certificate(keypair: &Keypair) -> (rustls::Certificate, rustls::PrivateKey) {
+    // Unfortunately, rustls does not accept a "raw" Ed25519 key.
     // We have to convert it to DER and pass it to the library.
 
     // Convert private key into PKCS#8 v1 object.
@@ -47,22 +26,73 @@ pub fn new_self_signed_tls_certificate(
     key_pkcs8_der.extend_from_slice(&PKCS8_PREFIX);
     key_pkcs8_der.extend_from_slice(keypair.secret().as_bytes());
 
-    let rcgen_keypair = rcgen::KeyPair::from_der(&key_pkcs8_der)?;
+    // Create a dummy certificate. Only the SubjectPublicKeyInfo field
+    // is relevant to the peer-to-peer protocols. The signature of the
+    // X.509 certificate is deliberately invalid. (Peer authenticity is
+    // checked in the TLS 1.3 CertificateVerify)
 
-    let mut cert_params = CertificateParams::default();
-    cert_params.subject_alt_names = vec![SanType::IpAddress(san)];
-    cert_params.alg = &rcgen::PKCS_ED25519;
-    cert_params.key_pair = Some(rcgen_keypair);
-    cert_params.distinguished_name = DistinguishedName::new();
-    cert_params
-        .distinguished_name
-        .push(DnType::CommonName, "Solana node");
+    let mut cert_der = Vec::<u8>::with_capacity(0xf4);
+    //    Certificate SEQUENCE (3 elem)
+    //      tbsCertificate TBSCertificate SEQUENCE (8 elem)
+    //        version [0] (1 elem)
+    //          INTEGER  2
+    //        serialNumber CertificateSerialNumber INTEGER (62 bit)
+    //        signature AlgorithmIdentifier SEQUENCE (1 elem)
+    //          algorithm OBJECT IDENTIFIER 1.3.101.112 curveEd25519 (EdDSA 25519 signature algorithm)
+    //        issuer Name SEQUENCE (1 elem)
+    //          RelativeDistinguishedName SET (1 elem)
+    //            AttributeTypeAndValue SEQUENCE (2 elem)
+    //              type AttributeType OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
+    //              value AttributeValue [?] UTF8String Solana
+    //        validity Validity SEQUENCE (2 elem)
+    //          notBefore Time UTCTime 1970-01-01 00:00:00 UTC
+    //          notAfter Time GeneralizedTime 4096-01-01 00:00:00 UTC
+    //        subject Name SEQUENCE (0 elem)
+    //        subjectPublicKeyInfo SubjectPublicKeyInfo SEQUENCE (2 elem)
+    //          algorithm AlgorithmIdentifier SEQUENCE (1 elem)
+    //            algorithm OBJECT IDENTIFIER 1.3.101.112 curveEd25519 (EdDSA 25519 signature algorithm)
+    //          subjectPublicKey BIT STRING (256 bit)
+    cert_der.extend_from_slice(&[
+        0x30, 0x81, 0xf1, 0x30, 0x81, 0xa4, 0xa0, 0x03, 0x02, 0x01, 0x02, 0x02, 0x08, 0x01, 0x01,
+        0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x30, 0x11,
+        0x31, 0x0f, 0x30, 0x0d, 0x06, 0x03, 0x55, 0x04, 0x03, 0x0c, 0x06, 0x53, 0x6f, 0x6c, 0x61,
+        0x6e, 0x61, 0x30, 0x20, 0x17, 0x0d, 0x37, 0x30, 0x30, 0x31, 0x30, 0x31, 0x30, 0x30, 0x30,
+        0x30, 0x30, 0x30, 0x5a, 0x18, 0x0f, 0x34, 0x30, 0x39, 0x36, 0x30, 0x31, 0x30, 0x31, 0x30,
+        0x30, 0x30, 0x30, 0x30, 0x30, 0x5a, 0x30, 0x00, 0x30, 0x2a, 0x30, 0x05, 0x06, 0x03, 0x2b,
+        0x65, 0x70, 0x03, 0x21, 0x00,
+    ]);
+    cert_der.extend_from_slice(&keypair.pubkey().to_bytes());
+    //        extensions [3] (1 elem)
+    //          Extensions SEQUENCE (2 elem)
+    //            Extension SEQUENCE (3 elem)
+    //              extnID OBJECT IDENTIFIER 2.5.29.17 subjectAltName (X.509 extension)
+    //              critical BOOLEAN true
+    //              extnValue OCTET STRING (13 byte) encapsulating
+    //                SEQUENCE (1 elem)
+    //                [2] (9 byte) localhost
+    //            Extension SEQUENCE (3 elem)
+    //              extnID OBJECT IDENTIFIER 2.5.29.19 basicConstraints (X.509 extension)
+    //              critical BOOLEAN true
+    //              extnValue OCTET STRING (2 byte) encapsulating
+    //                SEQUENCE (0 elem)
+    //      signatureAlgorithm AlgorithmIdentifier SEQUENCE (1 elem)
+    //        algorithm OBJECT IDENTIFIER 1.3.101.112 curveEd25519 (EdDSA 25519 signature algorithm)
+    //        signature BIT STRING (512 bit)
+    cert_der.extend_from_slice(&[
+        0xa3, 0x29, 0x30, 0x27, 0x30, 0x17, 0x06, 0x03, 0x55, 0x1d, 0x11, 0x01, 0x01, 0xff, 0x04,
+        0x0d, 0x30, 0x0b, 0x82, 0x09, 0x6c, 0x6f, 0x63, 0x61, 0x6c, 0x68, 0x6f, 0x73, 0x74, 0x30,
+        0x0c, 0x06, 0x03, 0x55, 0x1d, 0x13, 0x01, 0x01, 0xff, 0x04, 0x02, 0x30, 0x00, 0x30, 0x05,
+        0x06, 0x03, 0x2b, 0x65, 0x70, 0x03, 0x41, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    ]);
 
-    let cert = rcgen::Certificate::from_params(cert_params)?;
-    let cert_der = cert.serialize_der().unwrap();
-    let priv_key = cert.serialize_private_key_der();
-    let priv_key = rustls::PrivateKey(priv_key);
-    Ok((rustls::Certificate(cert_der), priv_key))
+    (
+        rustls::Certificate(cert_der),
+        rustls::PrivateKey(key_pkcs8_der),
+    )
 }
 
 pub fn get_pubkey_from_tls_certificate(der_cert: &rustls::Certificate) -> Option<Pubkey> {
@@ -75,22 +105,16 @@ pub fn get_pubkey_from_tls_certificate(der_cert: &rustls::Certificate) -> Option
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_sdk::signer::Signer, std::net::Ipv4Addr};
+    use {super::*, solana_sdk::signer::Signer};
 
     #[test]
     fn test_generate_tls_certificate() {
         let keypair = Keypair::new();
-
-        if let Ok((cert, _)) =
-            new_self_signed_tls_certificate(&keypair, IpAddr::V4(Ipv4Addr::LOCALHOST))
-        {
-            if let Some(pubkey) = get_pubkey_from_tls_certificate(&cert) {
-                assert_eq!(pubkey, keypair.pubkey());
-            } else {
-                panic!("Failed to get certificate pubkey");
-            }
+        let (cert, _) = new_dummy_x509_certificate(&keypair);
+        if let Some(pubkey) = get_pubkey_from_tls_certificate(&cert) {
+            assert_eq!(pubkey, keypair.pubkey());
         } else {
-            panic!("Failed to generate certificates");
+            panic!("Failed to get certificate pubkey");
         }
     }
 }

--- a/turbine/Cargo.toml
+++ b/turbine/Cargo.toml
@@ -21,7 +21,6 @@ quinn = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 rayon = { workspace = true }
-rcgen = { workspace = true }
 rustls = { workspace = true }
 solana-entry = { workspace = true }
 solana-gossip = { workspace = true }

--- a/turbine/src/quic_endpoint.rs
+++ b/turbine/src/quic_endpoint.rs
@@ -8,19 +8,16 @@ use {
         EndpointConfig, IdleTimeout, SendDatagramError, ServerConfig, TokioRuntime,
         TransportConfig, VarInt,
     },
-    rcgen::RcgenError,
     rustls::{Certificate, PrivateKey},
     solana_quic_client::nonblocking::quic_client::SkipServerVerification,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{pubkey::Pubkey, signature::Keypair},
-    solana_streamer::{
-        quic::SkipClientVerification, tls_certificates::new_self_signed_tls_certificate,
-    },
+    solana_streamer::{quic::SkipClientVerification, tls_certificates::new_dummy_x509_certificate},
     std::{
         cmp::Reverse,
         collections::{hash_map::Entry, HashMap},
         io::Error as IoError,
-        net::{IpAddr, SocketAddr, UdpSocket},
+        net::{SocketAddr, UdpSocket},
         sync::{
             atomic::{AtomicBool, AtomicU64, Ordering},
             Arc, RwLock,
@@ -67,8 +64,6 @@ pub type AsyncTryJoinHandle = TryJoin<JoinHandle<()>, JoinHandle<()>>;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error(transparent)]
-    CertificateError(#[from] RcgenError),
     #[error("Channel Send Error")]
     ChannelSendError,
     #[error(transparent)]
@@ -96,7 +91,6 @@ pub fn new_quic_endpoint(
     runtime: &tokio::runtime::Handle,
     keypair: &Keypair,
     socket: UdpSocket,
-    address: IpAddr,
     sender: Sender<(Pubkey, SocketAddr, Bytes)>,
     bank_forks: Arc<RwLock<BankForks>>,
 ) -> Result<
@@ -107,7 +101,7 @@ pub fn new_quic_endpoint(
     ),
     Error,
 > {
-    let (cert, key) = new_self_signed_tls_certificate(keypair, address)?;
+    let (cert, key) = new_dummy_x509_certificate(keypair);
     let server_config = new_server_config(cert.clone(), key.clone())?;
     let client_config = new_client_config(cert, key)?;
     let mut endpoint = {
@@ -639,7 +633,6 @@ async fn report_metrics_task(name: &'static str, stats: Arc<TurbineQuicStats>) {
 
 fn record_error(err: &Error, stats: &TurbineQuicStats) {
     match err {
-        Error::CertificateError(_) => (),
         Error::ChannelSendError => (),
         Error::ConnectError(ConnectError::EndpointStopping) => {
             add_metric!(stats.connect_error_other)
@@ -827,7 +820,6 @@ mod tests {
                         runtime.handle(),
                         keypair,
                         socket,
-                        IpAddr::V4(Ipv4Addr::LOCALHOST),
                         sender,
                         bank_forks.clone(),
                     )


### PR DESCRIPTION
#### Problem

- Addresses a TODO comment regarding a vulnerability 
- Removes the pkcs8 dependency 
- Removes logic to create X.509 signatures (X.509 signatures are ignored)
- Hardcodes the SAN (SAN is ignored)
- Removes the rcgen dependency

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
