### PR TITLE
Use `BankForks` on tests - Part 1

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -966,7 +966,7 @@ pub(super) enum RewardInterval {
 }
 
 impl Bank {
-    fn with_mocked_fork(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
+    fn wrap_with_bank_forks_for_tests(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
         let bank_fork = BankForks::new_rw_arc(self);
         let bank_arc = bank_fork.read().unwrap().root_bank();
         bank_arc
@@ -989,21 +989,21 @@ impl Bank {
         Self::new_for_tests_with_config(genesis_config, BankTestConfig::default())
     }
 
-    pub fn new_with_fork_for_tests(
+    pub fn new_with_bank_forks_for_tests(
         genesis_config: &GenesisConfig,
     ) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
         let bank = Self::new_for_tests(genesis_config);
-        bank.with_mocked_fork()
+        bank.wrap_with_bank_forks_for_tests()
     }
 
-    pub fn new_with_mockup_builtin(
+    pub fn new_with_mockup_builtin_for_tests(
         genesis_config: &GenesisConfig,
         program_id: Pubkey,
         builtin_function: BuiltinFunctionWithContext,
     ) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
         let mut bank = Self::new_for_tests(genesis_config);
         bank.add_mockup_builtin(program_id, builtin_function);
-        bank.with_mocked_fork()
+        bank.wrap_with_bank_forks_for_tests()
     }
 
     pub fn new_for_tests_with_config(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -966,6 +966,17 @@ pub(super) enum RewardInterval {
 }
 
 impl Bank {
+    fn with_mocked_fork(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
+        let bank_fork = BankForks::new_rw_arc(self);
+        let bank_arc = bank_fork.read().unwrap().root_bank();
+        bank_arc
+            .loaded_programs_cache
+            .write()
+            .unwrap()
+            .set_fork_graph(bank_fork.clone());
+        (bank_arc, bank_fork)
+    }
+
     pub fn default_for_tests() -> Self {
         Self::default_with_accounts(Accounts::default_for_tests())
     }
@@ -976,6 +987,23 @@ impl Bank {
 
     pub fn new_for_tests(genesis_config: &GenesisConfig) -> Self {
         Self::new_for_tests_with_config(genesis_config, BankTestConfig::default())
+    }
+
+    pub fn new_with_fork_for_tests(
+        genesis_config: &GenesisConfig,
+    ) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
+        let bank = Self::new_for_tests(genesis_config);
+        bank.with_mocked_fork()
+    }
+
+    pub fn new_with_mockup_builtin(
+        genesis_config: &GenesisConfig,
+        program_id: Pubkey,
+        builtin_function: BuiltinFunctionWithContext,
+    ) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
+        let mut bank = Self::new_for_tests(genesis_config);
+        bank.add_mockup_builtin(program_id, builtin_function);
+        bank.with_mocked_fork()
     }
 
     pub fn new_for_tests_with_config(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -277,7 +277,9 @@ pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {
 }
 
 fn create_simple_test_arc_bank(lamports: u64) -> Arc<Bank> {
-    Arc::new(create_simple_test_bank(lamports))
+    let bank = create_simple_test_bank(lamports);
+    let (bank, _) = bank.with_mocked_fork();
+    bank
 }
 
 #[test]
@@ -2291,7 +2293,7 @@ fn test_detect_failed_duplicate_transactions() {
 fn test_account_not_found() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(0);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
     let keypair = Keypair::new();
     assert_eq!(
         bank.transfer(
@@ -2492,7 +2494,7 @@ fn test_bank_tx_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
 
     let capitalization = bank.capitalization();
 
@@ -2541,7 +2543,10 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
+    let bank = bank_forks
+        .write()
+        .unwrap()
+        .new_bank_from_parent_for_tests(bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2605,7 +2610,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
 
     let capitalization = bank.capitalization();
 
@@ -2653,7 +2658,10 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
+    let bank = bank_forks
+        .write()
+        .unwrap()
+        .new_bank_from_parent_for_tests(bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2703,7 +2711,7 @@ fn test_bank_blockhash_fee_structure() {
         .target_lamports_per_signature = 5000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
 
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank, _) = Bank::new_with_fork_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
@@ -2755,19 +2763,25 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
         .target_lamports_per_signature = 1000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
 
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = Arc::new(Bank::new_from_parent(bank, &leader, 1));
+    let bank = bank_forks
+        .write()
+        .unwrap()
+        .new_bank_from_parent_for_tests(bank, &leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = Bank::new_from_parent(bank, &leader, 2);
+    let bank = bank_forks
+        .write()
+        .unwrap()
+        .new_bank_from_parent_for_tests(bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -3162,7 +3176,7 @@ fn test_bank_invalid_account_index() {
 fn test_bank_pay_to_self() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let key1 = Keypair::new();
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
     let amount = genesis_config.rent.minimum_balance(0);
 
     bank.transfer(amount, &mint_keypair, &key1.pubkey())
@@ -3181,6 +3195,13 @@ fn new_from_parent(parent: Arc<Bank>) -> Bank {
     let slot = parent.slot() + 1;
     let collector_id = Pubkey::default();
     Bank::new_from_parent(parent, &collector_id, slot)
+}
+
+fn new_from_parent_with_fork(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
+    let slot = parent.slot() + 1;
+    fork.write()
+        .unwrap()
+        .new_bank_from_parent_for_tests(parent, &Pubkey::default(), slot)
 }
 
 /// Verify that the parent's vector is computed correctly
@@ -3232,13 +3253,13 @@ fn test_tx_already_processed() {
 fn test_bank_parent_already_processed() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let key1 = Keypair::new();
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent(parent);
+    let bank = new_from_parent_with_fork(parent, bank_forks.as_ref());
     assert_eq!(
         bank.process_transaction(&tx),
         Err(TransactionError::AlreadyProcessed)
@@ -3251,13 +3272,13 @@ fn test_bank_parent_account_spend() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.0));
     let key1 = Keypair::new();
     let key2 = Keypair::new();
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent(parent.clone());
+    let bank = new_from_parent_with_fork(parent.clone(), bank_forks.as_ref());
     let tx = system_transaction::transfer(&key1, &key2.pubkey(), amount, genesis_config.hash());
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(parent.get_signature_status(&tx.signatures[0]), None);
@@ -3266,8 +3287,8 @@ fn test_bank_parent_account_spend() {
 #[test]
 fn test_bank_hash_internal_state() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let bank0 = Bank::new_for_tests(&genesis_config);
-    let bank1 = Bank::new_for_tests(&genesis_config);
+    let (bank0, _) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank1, bank_forks_1) = Bank::new_with_fork_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
     let initial_state = bank0.hash_internal_state();
     assert_eq!(bank1.hash_internal_state(), initial_state);
@@ -3279,8 +3300,7 @@ fn test_bank_hash_internal_state() {
     assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
 
     // Checkpointing should always result in a new state
-    let bank1 = Arc::new(bank1);
-    let bank2 = new_from_parent(bank1.clone());
+    let bank2 = new_from_parent_with_fork(bank1.clone(), bank_forks_1.as_ref());
     assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
     let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -3298,7 +3318,7 @@ fn test_bank_hash_internal_state_verify() {
     for pass in 0..3 {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-        let bank0 = Bank::new_for_tests(&genesis_config);
+        let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
         let amount = genesis_config.rent.minimum_balance(0);
 
         let pubkey = solana_sdk::pubkey::new_rand();
@@ -3306,9 +3326,12 @@ fn test_bank_hash_internal_state_verify() {
         bank0.transfer(amount, &mint_keypair, &pubkey).unwrap();
 
         let bank0_state = bank0.hash_internal_state();
-        let bank0 = Arc::new(bank0);
         // Checkpointing should result in a new state while freezing the parent
-        let bank2 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 1);
+        let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+            bank0.clone(),
+            &solana_sdk::pubkey::new_rand(),
+            1,
+        );
         assert_ne!(bank0_state, bank2.hash_internal_state());
         // Checkpointing should modify the checkpoint's state when freezed
         assert_ne!(bank0_state, bank0.hash_internal_state());
@@ -3322,7 +3345,11 @@ fn test_bank_hash_internal_state_verify() {
             bank2.update_accounts_hash_for_tests();
             assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
         }
-        let bank3 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 2);
+        let bank3 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+            bank0.clone(),
+            &solana_sdk::pubkey::new_rand(),
+            2,
+        );
         assert_eq!(bank0_state, bank0.hash_internal_state());
         if pass == 0 {
             // this relies on us having set the bank hash in the pass==0 if above
@@ -3386,9 +3413,13 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let initial_state = bank0.hash_internal_state();
-    let bank1 = Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1);
+    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank0.clone(),
+        &Pubkey::default(),
+        1,
+    );
     assert_ne!(bank1.hash_internal_state(), initial_state);
 
     info!("transfer bank1");
@@ -3398,7 +3429,11 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
 
     info!("transfer bank2");
     // bank2 should not hash the same as bank1
-    let bank2 = Bank::new_from_parent(bank0, &Pubkey::default(), 2);
+    let bank2 =
+        bank_forks
+            .write()
+            .unwrap()
+            .new_bank_from_parent_for_tests(bank0, &Pubkey::default(), 2);
     bank2.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_ne!(bank2.hash_internal_state(), initial_state);
     assert_ne!(bank1.hash_internal_state(), bank2.hash_internal_state());
@@ -3478,7 +3513,7 @@ fn test_bank_squash() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(2.));
     let key1 = Keypair::new();
     let key2 = Keypair::new();
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx_transfer_mint_to_1 =
@@ -3494,7 +3529,7 @@ fn test_bank_squash() {
     );
 
     trace!("new from parent");
-    let bank = new_from_parent(parent.clone());
+    let bank = new_from_parent_with_fork(parent.clone(), bank_forks.as_ref());
     trace!("done new from parent");
     assert_eq!(
         bank.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
@@ -3547,7 +3582,7 @@ fn test_bank_squash() {
 #[test]
 fn test_bank_get_account_in_parent_after_squash() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let parent = Arc::new(Bank::new_for_tests(&genesis_config));
+    let parent = Bank::new_with_fork_for_tests(&genesis_config).0;
     let amount = genesis_config.rent.minimum_balance(0);
 
     let key1 = Keypair::new();
@@ -3565,7 +3600,7 @@ fn test_bank_get_account_in_parent_after_squash() {
 fn test_bank_get_account_in_parent_after_squash2() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let key1 = Keypair::new();
@@ -3575,15 +3610,28 @@ fn test_bank_get_account_in_parent_after_squash2() {
         .unwrap();
     assert_eq!(bank0.get_balance(&key1.pubkey()), amount);
 
-    let bank1 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 1));
+    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank0.clone(),
+        &Pubkey::default(),
+        1,
+    );
     bank1
         .transfer(3 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank2 = Arc::new(Bank::new_from_parent(bank0.clone(), &Pubkey::default(), 2));
+    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank0.clone(),
+        &Pubkey::default(),
+        2,
+    );
     bank2
         .transfer(2 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank3 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 3));
+
+    let bank3 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank1.clone(),
+        &Pubkey::default(),
+        3,
+    );
     bank1.squash();
 
     // This picks up the values from 1 which is the highest root:
@@ -3595,16 +3643,28 @@ fn test_bank_get_account_in_parent_after_squash2() {
     bank3.squash();
     assert_eq!(bank1.get_balance(&key1.pubkey()), 4 * amount);
 
-    let bank4 = Arc::new(Bank::new_from_parent(bank3.clone(), &Pubkey::default(), 4));
+    let bank4 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank3.clone(),
+        &Pubkey::default(),
+        4,
+    );
     bank4
         .transfer(4 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
     assert_eq!(bank4.get_balance(&key1.pubkey()), 8 * amount);
     assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
     bank4.squash();
-    let bank5 = Arc::new(Bank::new_from_parent(bank4.clone(), &Pubkey::default(), 5));
+    let bank5 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank4.clone(),
+        &Pubkey::default(),
+        5,
+    );
     bank5.squash();
-    let bank6 = Arc::new(Bank::new_from_parent(bank5, &Pubkey::default(), 6));
+    let bank6 =
+        bank_forks
+            .write()
+            .unwrap()
+            .new_bank_from_parent_for_tests(bank5, &Pubkey::default(), 6);
     bank6.squash();
 
     // This picks up the values from 4 which is the highest root:
@@ -3622,7 +3682,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
-    let bank1 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank1, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
     let result = bank1.get_account_modified_since_parent_with_fixed_root(&pubkey);
     assert!(result.is_some());
@@ -3630,7 +3690,11 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     assert_eq!(account.lamports(), amount);
     assert_eq!(slot, 0);
 
-    let bank2 = Arc::new(Bank::new_from_parent(bank1.clone(), &Pubkey::default(), 1));
+    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank1.clone(),
+        &Pubkey::default(),
+        1,
+    );
     assert!(bank2
         .get_account_modified_since_parent_with_fixed_root(&pubkey)
         .is_none());
@@ -3648,7 +3712,11 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
     bank1.squash();
 
-    let bank3 = Bank::new_from_parent(bank2, &Pubkey::default(), 3);
+    let bank3 =
+        bank_forks
+            .write()
+            .unwrap()
+            .new_bank_from_parent_for_tests(bank2, &Pubkey::default(), 3);
     assert_eq!(
         None,
         bank3.get_account_modified_since_parent_with_fixed_root(&pubkey)
@@ -3999,16 +4067,20 @@ fn test_is_empty() {
 #[test]
 fn test_bank_inherit_tx_count() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.0));
-    let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
 
     // Bank 1
-    let bank1 = Arc::new(Bank::new_from_parent(
+    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
         bank0.clone(),
         &solana_sdk::pubkey::new_rand(),
         1,
-    ));
+    );
     // Bank 2
-    let bank2 = Bank::new_from_parent(bank0.clone(), &solana_sdk::pubkey::new_rand(), 2);
+    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank0.clone(),
+        &solana_sdk::pubkey::new_rand(),
+        2,
+    );
 
     // transfer a token
     assert_eq!(
@@ -4037,7 +4109,11 @@ fn test_bank_inherit_tx_count() {
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
-    let bank6 = Bank::new_from_parent(bank1.clone(), &solana_sdk::pubkey::new_rand(), 3);
+    let bank6 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        bank1.clone(),
+        &solana_sdk::pubkey::new_rand(),
+        3,
+    );
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
     assert_eq!(bank6.transaction_count(), 1);
@@ -4073,7 +4149,7 @@ fn test_bank_vote_accounts() {
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     let vote_accounts = bank.vote_accounts();
     assert_eq!(vote_accounts.len(), 1); // bootstrap validator has
@@ -4130,7 +4206,7 @@ fn test_bank_cloned_stake_delegations() {
         123_000_000_000,
     );
     genesis_config.rent = Rent::default();
-    let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
     assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
@@ -4484,6 +4560,7 @@ fn test_add_builtin() {
         bank.last_blockhash(),
     );
 
+    let bank = bank.with_mocked_fork().0;
     assert_eq!(
         bank.process_transaction(&transaction),
         Err(TransactionError::InstructionError(
@@ -4500,7 +4577,7 @@ fn test_add_duplicate_static_program() {
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     declare_process_instruction!(MockBuiltin, 1, |_invoke_context| {
         Err(InstructionError::Custom(42))
@@ -4530,7 +4607,7 @@ fn test_add_duplicate_static_program() {
     );
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
 
     let vote_loader_account = bank.get_account(&solana_vote_program::id()).unwrap();
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::vm);
@@ -4722,7 +4799,7 @@ fn test_banks_leak() {
     solana_logger::setup();
     let (mut genesis_config, _) = create_genesis_config(100_000_000_000_000);
     add_lotsa_stake_accounts(&mut genesis_config);
-    let mut bank = std::sync::Arc::new(Bank::new_for_tests(&genesis_config));
+    let (mut bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
     let mut num_banks = 0;
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
@@ -4731,7 +4808,7 @@ fn test_banks_leak() {
     );
     loop {
         num_banks += 1;
-        bank = std::sync::Arc::new(new_from_parent(bank));
+        bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
         if num_banks % 100 == 0 {
             #[cfg(target_os = "linux")]
             {
@@ -4815,13 +4892,13 @@ where
     genesis_cfg_fn(&mut genesis_config);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(feature_set);
-    let mut bank = Arc::new(bank);
+    let (mut bank, bank_forks) = bank.with_mocked_fork();
 
     // Banks 0 and 1 have no fees, wait two blocks before
     // initializing our nonce accounts
     for _ in 0..2 {
         goto_end_of_slot(bank.clone());
-        bank = Arc::new(new_from_parent(bank));
+        bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
     }
 
     let (custodian_keypair, nonce_keypair) = nonce_setup(
@@ -4835,7 +4912,7 @@ where
     // The setup nonce is not valid to be used until the next bank
     // so wait one more block
     goto_end_of_slot(bank.clone());
-    bank = Arc::new(new_from_parent(bank));
+    bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
 
     Ok((bank, mint_keypair, custodian_keypair, nonce_keypair))
 }
@@ -5937,7 +6014,7 @@ fn test_transaction_with_program_ids_passed_to_programs() {
 fn test_account_ids_after_program_ids() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     let from_pubkey = solana_sdk::pubkey::new_rand();
     let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -5958,7 +6035,7 @@ fn test_account_ids_after_program_ids() {
     tx.message.account_keys.push(solana_sdk::pubkey::new_rand());
 
     let slot = bank.slot().saturating_add(1);
-    let mut bank = Bank::new_from_parent(Arc::new(bank), &Pubkey::default(), slot);
+    let mut bank = Bank::new_from_parent(bank, &Pubkey::default(), slot);
 
     bank.add_mockup_builtin(solana_vote_program::id(), MockBuiltin::vm);
     let result = bank.process_transaction(&tx);
@@ -7010,7 +7087,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
-    let bank = Arc::new(bank);
+    let bank = bank.with_mocked_fork().0;
     let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Setup keypairs and addresses
@@ -9306,7 +9383,9 @@ fn test_transfer_sysvar() {
         &Pubkey::new_unique(),
         bootstrap_validator_stake_lamports(),
     );
-    let mut bank = Bank::new_for_tests(&genesis_config);
+    let program_id = solana_sdk::pubkey::new_rand();
+
+    let bank = Bank::new_with_mockup_builtin(&genesis_config, program_id, MockBuiltin::vm).0;
 
     declare_process_instruction!(MockBuiltin, 1, |invoke_context| {
         let transaction_context = &invoke_context.transaction_context;
@@ -9316,9 +9395,6 @@ fn test_transfer_sysvar() {
             .set_data(vec![0; 40])?;
         Ok(())
     });
-
-    let program_id = solana_sdk::pubkey::new_rand();
-    bank.add_mockup_builtin(program_id, MockBuiltin::vm);
 
     let blockhash = bank.last_blockhash();
     #[allow(deprecated)]
@@ -9779,7 +9855,7 @@ fn test_call_precomiled_program() {
         ..
     } = create_genesis_config_with_leader(42, &Pubkey::new_unique(), 42);
     activate_all_features(&mut genesis_config);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     // libsecp256k1
     // Since libsecp256k1 is still using the old version of rand, this test
@@ -10129,7 +10205,7 @@ fn test_an_empty_instruction_without_program() {
     let message = Message::new(&[ix], Some(&mint_keypair.pubkey()));
     let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
 
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
     assert_eq!(
         bank.process_transaction(&tx).unwrap_err(),
         TransactionError::InstructionError(0, InstructionError::UnsupportedProgramId),
@@ -10158,6 +10234,7 @@ fn test_accounts_data_size_with_good_transaction() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1_000.));
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.activate_feature(&feature_set::cap_accounts_data_len::id());
+    let bank = bank.with_mocked_fork().0;
     let transaction = system_transaction::create_account(
         &mint_keypair,
         &Keypair::new(),
@@ -10206,6 +10283,8 @@ fn test_accounts_data_size_with_bad_transaction() {
         ACCOUNT_SIZE,
         &solana_sdk::system_program::id(),
     );
+
+    let bank = bank.with_mocked_fork().0;
 
     let accounts_data_size_before = bank.load_accounts_data_size();
     let accounts_data_size_delta_before = bank.load_accounts_data_size_delta();
@@ -11338,9 +11417,9 @@ fn test_accounts_data_size_and_resize_transactions() {
         mint_keypair,
         ..
     } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
-    let mut bank = Bank::new_for_tests(&genesis_config);
     let mock_program_id = Pubkey::new_unique();
-    bank.add_mockup_builtin(mock_program_id, MockReallocBuiltin::vm);
+    let bank =
+        Bank::new_with_mockup_builtin(&genesis_config, mock_program_id, MockReallocBuiltin::vm).0;
 
     let recent_blockhash = bank.last_blockhash();
 
@@ -11548,7 +11627,7 @@ fn test_accounts_data_size_from_genesis() {
     genesis_config.rent = Rent::default();
     genesis_config.ticks_per_slot = 3;
 
-    let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let mut bank = Bank::new_with_fork_for_tests(&genesis_config).0;
     assert_eq!(
         bank.load_accounts_data_size() as usize,
         bank.get_total_accounts_stats().unwrap().data_len
@@ -11589,7 +11668,7 @@ fn test_cap_accounts_data_allocations_per_transaction() {
             / MAX_PERMITTED_DATA_LENGTH as usize;
 
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-    let bank = Bank::new_for_tests(&genesis_config);
+    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
 
     let mut instructions = Vec::new();
     let mut keypairs = vec![mint_keypair.insecure_clone()];
@@ -12030,12 +12109,16 @@ fn test_bank_verify_accounts_hash_with_base() {
         bank.fill_bank_with_ticks_for_tests();
     };
 
-    let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+    let (mut bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
 
     // make some banks, do some transactions, ensure there's some zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
+        bank = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+            bank,
+            &Pubkey::new_unique(),
+            slot,
+        );
         do_transfers(&bank);
     }
 
@@ -12049,7 +12132,11 @@ fn test_bank_verify_accounts_hash_with_base() {
     // make more banks, do more transactions, ensure there's more zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::new_unique(), slot));
+        bank = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+            bank,
+            &Pubkey::new_unique(),
+            slot,
+        );
         do_transfers(&bank);
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -154,6 +154,20 @@ impl VoteReward {
     }
 }
 
+pub fn new_bank_from_parent_for_tests(
+    bank_forks: &RwLock<BankForks>,
+    parent: Arc<Bank>,
+    collector_id: &Pubkey,
+    slot: Slot,
+) -> Arc<Bank> {
+    let bank = Bank::new_from_parent(parent, collector_id, slot);
+    bank_forks
+        .write()
+        .unwrap()
+        .insert(bank)
+        .clone_without_scheduler()
+}
+
 #[test]
 fn test_race_register_tick_freeze() {
     solana_logger::setup();
@@ -278,7 +292,7 @@ pub(crate) fn create_simple_test_bank(lamports: u64) -> Bank {
 
 fn create_simple_test_arc_bank(lamports: u64) -> Arc<Bank> {
     let bank = create_simple_test_bank(lamports);
-    let (bank, _) = bank.with_mocked_fork();
+    let (bank, _) = bank.wrap_with_bank_forks_for_tests();
     bank
 }
 
@@ -1817,6 +1831,7 @@ fn test_bank_update_vote_stake_rewards() {
         bank._load_vote_and_stake_accounts(&thread_pool, null_tracer())
     });
 }
+
 #[cfg(test)]
 fn check_bank_update_vote_stake_rewards<F>(load_vote_and_stake_accounts: F)
 where
@@ -2293,7 +2308,7 @@ fn test_detect_failed_duplicate_transactions() {
 fn test_account_not_found() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(0);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
     let keypair = Keypair::new();
     assert_eq!(
         bank.transfer(
@@ -2494,7 +2509,7 @@ fn test_bank_tx_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let capitalization = bank.capitalization();
 
@@ -2543,10 +2558,7 @@ fn test_bank_tx_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = bank_forks
-        .write()
-        .unwrap()
-        .new_bank_from_parent_for_tests(bank, &leader, 1);
+    let bank = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2610,7 +2622,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (expected_fee_collected, expected_fee_burned) =
         genesis_config.fee_rate_governor.burn(expected_fee_paid);
 
-    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let capitalization = bank.capitalization();
 
@@ -2658,10 +2670,7 @@ fn test_bank_tx_compute_unit_fee() {
     );
 
     // Verify that an InstructionError collects fees, too
-    let bank = bank_forks
-        .write()
-        .unwrap()
-        .new_bank_from_parent_for_tests(bank, &leader, 1);
+    let bank = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &leader, 1);
     let mut tx = system_transaction::transfer(&mint_keypair, &key, 1, bank.last_blockhash());
     // Create a bogus instruction to system_program to cause an instruction error
     tx.message.instructions[0].data[0] = 40;
@@ -2711,7 +2720,7 @@ fn test_bank_blockhash_fee_structure() {
         .target_lamports_per_signature = 5000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 0;
 
-    let (bank, _) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank, _) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
@@ -2763,25 +2772,19 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
         .target_lamports_per_signature = 1000;
     genesis_config.fee_rate_governor.target_signatures_per_slot = 1;
 
-    let (bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     goto_end_of_slot(bank.clone());
     let cheap_blockhash = bank.last_blockhash();
     let cheap_lamports_per_signature = bank.get_lamports_per_signature();
     assert_eq!(cheap_lamports_per_signature, 0);
 
-    let bank = bank_forks
-        .write()
-        .unwrap()
-        .new_bank_from_parent_for_tests(bank, &leader, 1);
+    let bank = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &leader, 1);
     goto_end_of_slot(bank.clone());
     let expensive_blockhash = bank.last_blockhash();
     let expensive_lamports_per_signature = bank.get_lamports_per_signature();
     assert!(cheap_lamports_per_signature < expensive_lamports_per_signature);
 
-    let bank = bank_forks
-        .write()
-        .unwrap()
-        .new_bank_from_parent_for_tests(bank, &leader, 2);
+    let bank = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &leader, 2);
 
     // Send a transfer using cheap_blockhash
     let key = solana_sdk::pubkey::new_rand();
@@ -3176,7 +3179,7 @@ fn test_bank_invalid_account_index() {
 fn test_bank_pay_to_self() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let key1 = Keypair::new();
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
     let amount = genesis_config.rent.minimum_balance(0);
 
     bank.transfer(amount, &mint_keypair, &key1.pubkey())
@@ -3197,11 +3200,9 @@ fn new_from_parent(parent: Arc<Bank>) -> Bank {
     Bank::new_from_parent(parent, &collector_id, slot)
 }
 
-fn new_from_parent_with_fork(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
+fn new_from_parent_with_fork_next_slot(parent: Arc<Bank>, fork: &RwLock<BankForks>) -> Arc<Bank> {
     let slot = parent.slot() + 1;
-    fork.write()
-        .unwrap()
-        .new_bank_from_parent_for_tests(parent, &Pubkey::default(), slot)
+    new_bank_from_parent_for_tests(fork, parent, &Pubkey::default(), slot)
 }
 
 /// Verify that the parent's vector is computed correctly
@@ -3253,13 +3254,13 @@ fn test_tx_already_processed() {
 fn test_bank_parent_already_processed() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let key1 = Keypair::new();
-    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent_with_fork(parent, bank_forks.as_ref());
+    let bank = new_from_parent_with_fork_next_slot(parent, bank_forks.as_ref());
     assert_eq!(
         bank.process_transaction(&tx),
         Err(TransactionError::AlreadyProcessed)
@@ -3272,13 +3273,13 @@ fn test_bank_parent_account_spend() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.0));
     let key1 = Keypair::new();
     let key2 = Keypair::new();
-    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());
     assert_eq!(parent.process_transaction(&tx), Ok(()));
-    let bank = new_from_parent_with_fork(parent.clone(), bank_forks.as_ref());
+    let bank = new_from_parent_with_fork_next_slot(parent.clone(), bank_forks.as_ref());
     let tx = system_transaction::transfer(&key1, &key2.pubkey(), amount, genesis_config.hash());
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(parent.get_signature_status(&tx.signatures[0]), None);
@@ -3287,8 +3288,8 @@ fn test_bank_parent_account_spend() {
 #[test]
 fn test_bank_hash_internal_state() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let (bank0, _) = Bank::new_with_fork_for_tests(&genesis_config);
-    let (bank1, bank_forks_1) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank0, _) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let (bank1, bank_forks_1) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
     let initial_state = bank0.hash_internal_state();
     assert_eq!(bank1.hash_internal_state(), initial_state);
@@ -3300,7 +3301,7 @@ fn test_bank_hash_internal_state() {
     assert_eq!(bank0.hash_internal_state(), bank1.hash_internal_state());
 
     // Checkpointing should always result in a new state
-    let bank2 = new_from_parent_with_fork(bank1.clone(), bank_forks_1.as_ref());
+    let bank2 = new_from_parent_with_fork_next_slot(bank1.clone(), bank_forks_1.as_ref());
     assert_ne!(bank0.hash_internal_state(), bank2.hash_internal_state());
 
     let pubkey2 = solana_sdk::pubkey::new_rand();
@@ -3318,7 +3319,7 @@ fn test_bank_hash_internal_state_verify() {
     for pass in 0..3 {
         solana_logger::setup();
         let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-        let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+        let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
         let amount = genesis_config.rent.minimum_balance(0);
 
         let pubkey = solana_sdk::pubkey::new_rand();
@@ -3327,7 +3328,8 @@ fn test_bank_hash_internal_state_verify() {
 
         let bank0_state = bank0.hash_internal_state();
         // Checkpointing should result in a new state while freezing the parent
-        let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        let bank2 = new_bank_from_parent_for_tests(
+            bank_forks.as_ref(),
             bank0.clone(),
             &solana_sdk::pubkey::new_rand(),
             1,
@@ -3345,7 +3347,8 @@ fn test_bank_hash_internal_state_verify() {
             bank2.update_accounts_hash_for_tests();
             assert!(bank2.verify_accounts_hash(None, VerifyAccountsHashConfig::default_for_test()));
         }
-        let bank3 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+        let bank3 = new_bank_from_parent_for_tests(
+            bank_forks.as_ref(),
             bank0.clone(),
             &solana_sdk::pubkey::new_rand(),
             2,
@@ -3413,13 +3416,10 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
-    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let initial_state = bank0.hash_internal_state();
-    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank0.clone(),
-        &Pubkey::default(),
-        1,
-    );
+    let bank1 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank0.clone(), &Pubkey::default(), 1);
     assert_ne!(bank1.hash_internal_state(), initial_state);
 
     info!("transfer bank1");
@@ -3429,11 +3429,7 @@ fn test_bank_hash_internal_state_same_account_different_fork() {
 
     info!("transfer bank2");
     // bank2 should not hash the same as bank1
-    let bank2 =
-        bank_forks
-            .write()
-            .unwrap()
-            .new_bank_from_parent_for_tests(bank0, &Pubkey::default(), 2);
+    let bank2 = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank0, &Pubkey::default(), 2);
     bank2.transfer(amount, &mint_keypair, &pubkey).unwrap();
     assert_ne!(bank2.hash_internal_state(), initial_state);
     assert_ne!(bank1.hash_internal_state(), bank2.hash_internal_state());
@@ -3513,7 +3509,7 @@ fn test_bank_squash() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(2.));
     let key1 = Keypair::new();
     let key2 = Keypair::new();
-    let (parent, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let tx_transfer_mint_to_1 =
@@ -3529,7 +3525,7 @@ fn test_bank_squash() {
     );
 
     trace!("new from parent");
-    let bank = new_from_parent_with_fork(parent.clone(), bank_forks.as_ref());
+    let bank = new_from_parent_with_fork_next_slot(parent.clone(), bank_forks.as_ref());
     trace!("done new from parent");
     assert_eq!(
         bank.get_signature_status(&tx_transfer_mint_to_1.signatures[0]),
@@ -3582,7 +3578,7 @@ fn test_bank_squash() {
 #[test]
 fn test_bank_get_account_in_parent_after_squash() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let parent = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let parent = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
     let amount = genesis_config.rent.minimum_balance(0);
 
     let key1 = Keypair::new();
@@ -3600,7 +3596,7 @@ fn test_bank_get_account_in_parent_after_squash() {
 fn test_bank_get_account_in_parent_after_squash2() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
-    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
 
     let key1 = Keypair::new();
@@ -3610,28 +3606,19 @@ fn test_bank_get_account_in_parent_after_squash2() {
         .unwrap();
     assert_eq!(bank0.get_balance(&key1.pubkey()), amount);
 
-    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank0.clone(),
-        &Pubkey::default(),
-        1,
-    );
+    let bank1 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank0.clone(), &Pubkey::default(), 1);
     bank1
         .transfer(3 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
-    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank0.clone(),
-        &Pubkey::default(),
-        2,
-    );
+    let bank2 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank0.clone(), &Pubkey::default(), 2);
     bank2
         .transfer(2 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
 
-    let bank3 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank1.clone(),
-        &Pubkey::default(),
-        3,
-    );
+    let bank3 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank1.clone(), &Pubkey::default(), 3);
     bank1.squash();
 
     // This picks up the values from 1 which is the highest root:
@@ -3643,28 +3630,18 @@ fn test_bank_get_account_in_parent_after_squash2() {
     bank3.squash();
     assert_eq!(bank1.get_balance(&key1.pubkey()), 4 * amount);
 
-    let bank4 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank3.clone(),
-        &Pubkey::default(),
-        4,
-    );
+    let bank4 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank3.clone(), &Pubkey::default(), 4);
     bank4
         .transfer(4 * amount, &mint_keypair, &key1.pubkey())
         .unwrap();
     assert_eq!(bank4.get_balance(&key1.pubkey()), 8 * amount);
     assert_eq!(bank3.get_balance(&key1.pubkey()), 4 * amount);
     bank4.squash();
-    let bank5 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank4.clone(),
-        &Pubkey::default(),
-        5,
-    );
+    let bank5 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank4.clone(), &Pubkey::default(), 5);
     bank5.squash();
-    let bank6 =
-        bank_forks
-            .write()
-            .unwrap()
-            .new_bank_from_parent_for_tests(bank5, &Pubkey::default(), 6);
+    let bank6 = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank5, &Pubkey::default(), 6);
     bank6.squash();
 
     // This picks up the values from 4 which is the highest root:
@@ -3682,7 +3659,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.));
     let amount = genesis_config.rent.minimum_balance(0);
-    let (bank1, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank1, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     bank1.transfer(amount, &mint_keypair, &pubkey).unwrap();
     let result = bank1.get_account_modified_since_parent_with_fixed_root(&pubkey);
     assert!(result.is_some());
@@ -3690,11 +3667,8 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
     assert_eq!(account.lamports(), amount);
     assert_eq!(slot, 0);
 
-    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-        bank1.clone(),
-        &Pubkey::default(),
-        1,
-    );
+    let bank2 =
+        new_bank_from_parent_for_tests(bank_forks.as_ref(), bank1.clone(), &Pubkey::default(), 1);
     assert!(bank2
         .get_account_modified_since_parent_with_fixed_root(&pubkey)
         .is_none());
@@ -3712,11 +3686,7 @@ fn test_bank_get_account_modified_since_parent_with_fixed_root() {
 
     bank1.squash();
 
-    let bank3 =
-        bank_forks
-            .write()
-            .unwrap()
-            .new_bank_from_parent_for_tests(bank2, &Pubkey::default(), 3);
+    let bank3 = new_bank_from_parent_for_tests(bank_forks.as_ref(), bank2, &Pubkey::default(), 3);
     assert_eq!(
         None,
         bank3.get_account_modified_since_parent_with_fixed_root(&pubkey)
@@ -4067,16 +4037,18 @@ fn test_is_empty() {
 #[test]
 fn test_bank_inherit_tx_count() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1.0));
-    let (bank0, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (bank0, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // Bank 1
-    let bank1 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+    let bank1 = new_bank_from_parent_for_tests(
+        bank_forks.as_ref(),
         bank0.clone(),
         &solana_sdk::pubkey::new_rand(),
         1,
     );
     // Bank 2
-    let bank2 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+    let bank2 = new_bank_from_parent_for_tests(
+        bank_forks.as_ref(),
         bank0.clone(),
         &solana_sdk::pubkey::new_rand(),
         2,
@@ -4109,7 +4081,8 @@ fn test_bank_inherit_tx_count() {
     assert_eq!(bank1.transaction_count(), 1);
     assert_eq!(bank1.non_vote_transaction_count_since_restart(), 1);
 
-    let bank6 = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
+    let bank6 = new_bank_from_parent_for_tests(
+        bank_forks.as_ref(),
         bank1.clone(),
         &solana_sdk::pubkey::new_rand(),
         3,
@@ -4149,7 +4122,7 @@ fn test_bank_vote_accounts() {
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 1);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     let vote_accounts = bank.vote_accounts();
     assert_eq!(vote_accounts.len(), 1); // bootstrap validator has
@@ -4206,7 +4179,7 @@ fn test_bank_cloned_stake_delegations() {
         123_000_000_000,
     );
     genesis_config.rent = Rent::default();
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     let stake_delegations = bank.stakes_cache.stakes().stake_delegations().clone();
     assert_eq!(stake_delegations.len(), 1); // bootstrap validator has
@@ -4560,7 +4533,7 @@ fn test_add_builtin() {
         bank.last_blockhash(),
     );
 
-    let bank = bank.with_mocked_fork().0;
+    let bank = bank.wrap_with_bank_forks_for_tests().0;
     assert_eq!(
         bank.process_transaction(&transaction),
         Err(TransactionError::InstructionError(
@@ -4577,7 +4550,7 @@ fn test_add_duplicate_static_program() {
         mint_keypair,
         ..
     } = create_genesis_config_with_leader(500, &solana_sdk::pubkey::new_rand(), 0);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     declare_process_instruction!(MockBuiltin, 1, |_invoke_context| {
         Err(InstructionError::Custom(42))
@@ -4799,7 +4772,7 @@ fn test_banks_leak() {
     solana_logger::setup();
     let (mut genesis_config, _) = create_genesis_config(100_000_000_000_000);
     add_lotsa_stake_accounts(&mut genesis_config);
-    let (mut bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let mut num_banks = 0;
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
@@ -4808,7 +4781,7 @@ fn test_banks_leak() {
     );
     loop {
         num_banks += 1;
-        bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
+        bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
         if num_banks % 100 == 0 {
             #[cfg(target_os = "linux")]
             {
@@ -4892,13 +4865,13 @@ where
     genesis_cfg_fn(&mut genesis_config);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(feature_set);
-    let (mut bank, bank_forks) = bank.with_mocked_fork();
+    let (mut bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
 
     // Banks 0 and 1 have no fees, wait two blocks before
     // initializing our nonce accounts
     for _ in 0..2 {
         goto_end_of_slot(bank.clone());
-        bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
+        bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
     }
 
     let (custodian_keypair, nonce_keypair) = nonce_setup(
@@ -4912,7 +4885,7 @@ where
     // The setup nonce is not valid to be used until the next bank
     // so wait one more block
     goto_end_of_slot(bank.clone());
-    bank = new_from_parent_with_fork(bank, bank_forks.as_ref());
+    bank = new_from_parent_with_fork_next_slot(bank, bank_forks.as_ref());
 
     Ok((bank, mint_keypair, custodian_keypair, nonce_keypair))
 }
@@ -6014,7 +5987,7 @@ fn test_transaction_with_program_ids_passed_to_programs() {
 fn test_account_ids_after_program_ids() {
     solana_logger::setup();
     let (genesis_config, mint_keypair) = create_genesis_config(500);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     let from_pubkey = solana_sdk::pubkey::new_rand();
     let to_pubkey = solana_sdk::pubkey::new_rand();
@@ -7087,7 +7060,7 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000_000);
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.feature_set = Arc::new(FeatureSet::all_enabled());
-    let bank = bank.with_mocked_fork().0;
+    let bank = bank.wrap_with_bank_forks_for_tests().0;
     let mut bank_client = BankClient::new_shared(bank.clone());
 
     // Setup keypairs and addresses
@@ -9385,7 +9358,8 @@ fn test_transfer_sysvar() {
     );
     let program_id = solana_sdk::pubkey::new_rand();
 
-    let bank = Bank::new_with_mockup_builtin(&genesis_config, program_id, MockBuiltin::vm).0;
+    let bank =
+        Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm).0;
 
     declare_process_instruction!(MockBuiltin, 1, |invoke_context| {
         let transaction_context = &invoke_context.transaction_context;
@@ -9855,7 +9829,7 @@ fn test_call_precomiled_program() {
         ..
     } = create_genesis_config_with_leader(42, &Pubkey::new_unique(), 42);
     activate_all_features(&mut genesis_config);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     // libsecp256k1
     // Since libsecp256k1 is still using the old version of rand, this test
@@ -10205,7 +10179,7 @@ fn test_an_empty_instruction_without_program() {
     let message = Message::new(&[ix], Some(&mint_keypair.pubkey()));
     let tx = Transaction::new(&[&mint_keypair], message, genesis_config.hash());
 
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
     assert_eq!(
         bank.process_transaction(&tx).unwrap_err(),
         TransactionError::InstructionError(0, InstructionError::UnsupportedProgramId),
@@ -10234,7 +10208,7 @@ fn test_accounts_data_size_with_good_transaction() {
     let (genesis_config, mint_keypair) = create_genesis_config(sol_to_lamports(1_000.));
     let mut bank = Bank::new_for_tests(&genesis_config);
     bank.activate_feature(&feature_set::cap_accounts_data_len::id());
-    let bank = bank.with_mocked_fork().0;
+    let bank = bank.wrap_with_bank_forks_for_tests().0;
     let transaction = system_transaction::create_account(
         &mint_keypair,
         &Keypair::new(),
@@ -10284,7 +10258,7 @@ fn test_accounts_data_size_with_bad_transaction() {
         &solana_sdk::system_program::id(),
     );
 
-    let bank = bank.with_mocked_fork().0;
+    let bank = bank.wrap_with_bank_forks_for_tests().0;
 
     let accounts_data_size_before = bank.load_accounts_data_size();
     let accounts_data_size_delta_before = bank.load_accounts_data_size_delta();
@@ -11418,8 +11392,12 @@ fn test_accounts_data_size_and_resize_transactions() {
         ..
     } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
     let mock_program_id = Pubkey::new_unique();
-    let bank =
-        Bank::new_with_mockup_builtin(&genesis_config, mock_program_id, MockReallocBuiltin::vm).0;
+    let bank = Bank::new_with_mockup_builtin_for_tests(
+        &genesis_config,
+        mock_program_id,
+        MockReallocBuiltin::vm,
+    )
+    .0;
 
     let recent_blockhash = bank.last_blockhash();
 
@@ -11627,7 +11605,7 @@ fn test_accounts_data_size_from_genesis() {
     genesis_config.rent = Rent::default();
     genesis_config.ticks_per_slot = 3;
 
-    let mut bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let mut bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
     assert_eq!(
         bank.load_accounts_data_size() as usize,
         bank.get_total_accounts_stats().unwrap().data_len
@@ -11668,7 +11646,7 @@ fn test_cap_accounts_data_allocations_per_transaction() {
             / MAX_PERMITTED_DATA_LENGTH as usize;
 
     let (genesis_config, mint_keypair) = create_genesis_config(1_000_000 * LAMPORTS_PER_SOL);
-    let bank = Bank::new_with_fork_for_tests(&genesis_config).0;
+    let bank = Bank::new_with_bank_forks_for_tests(&genesis_config).0;
 
     let mut instructions = Vec::new();
     let mut keypairs = vec![mint_keypair.insecure_clone()];
@@ -12109,16 +12087,13 @@ fn test_bank_verify_accounts_hash_with_base() {
         bank.fill_bank_with_ticks_for_tests();
     };
 
-    let (mut bank, bank_forks) = Bank::new_with_fork_for_tests(&genesis_config);
+    let (mut bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     // make some banks, do some transactions, ensure there's some zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-            bank,
-            &Pubkey::new_unique(),
-            slot,
-        );
+        bank =
+            new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &Pubkey::new_unique(), slot);
         do_transfers(&bank);
     }
 
@@ -12132,11 +12107,8 @@ fn test_bank_verify_accounts_hash_with_base() {
     // make more banks, do more transactions, ensure there's more zero-lamport accounts
     for _ in 0..2 {
         let slot = bank.slot() + 1;
-        bank = bank_forks.write().unwrap().new_bank_from_parent_for_tests(
-            bank,
-            &Pubkey::new_unique(),
-            slot,
-        );
+        bank =
+            new_bank_from_parent_for_tests(bank_forks.as_ref(), bank, &Pubkey::new_unique(), slot);
         do_transfers(&bank);
     }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -16,6 +16,7 @@ use {
         clock::{Epoch, Slot},
         feature_set,
         hash::Hash,
+        pubkey::Pubkey,
         timing,
     },
     std::{
@@ -693,6 +694,16 @@ impl BankForks {
         bank.slot() > self.last_accounts_hash_slot
             && bank.parent_slot() < start_slot
             && bank.slot() >= start_slot
+    }
+
+    pub fn new_bank_from_parent_for_tests(
+        &mut self,
+        parent: Arc<Bank>,
+        collector_id: &Pubkey,
+        slot: Slot,
+    ) -> Arc<Bank> {
+        let bank = Bank::new_from_parent(parent, collector_id, slot);
+        self.insert(bank).clone_without_scheduler()
     }
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -16,7 +16,6 @@ use {
         clock::{Epoch, Slot},
         feature_set,
         hash::Hash,
-        pubkey::Pubkey,
         timing,
     },
     std::{
@@ -694,16 +693,6 @@ impl BankForks {
         bank.slot() > self.last_accounts_hash_slot
             && bank.parent_slot() < start_slot
             && bank.slot() >= start_slot
-    }
-
-    pub fn new_bank_from_parent_for_tests(
-        &mut self,
-        parent: Arc<Bank>,
-        collector_id: &Pubkey,
-        slot: Slot,
-    ) -> Arc<Bank> {
-        let bank = Bank::new_from_parent(parent, collector_id, slot);
-        self.insert(bank).clone_without_scheduler()
     }
 }
 


### PR DESCRIPTION
#### Problem

In order for us to implement #34169 (remove `WorkSlot` from `LoadedPrograms::extract`), we need to make sure all tests create a `BankFork` and use a `Bank` instance that has been added to the fork.

#### Summary of Changes

This PR adds a few auxiliary functions to deal with `BankForks` and fixes some tests. Another PR that fixes more tests is waiting for this one to be merged.

