### PR TITLE
check vote costs against block limits in would_fit

### DIFF
--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -186,7 +186,9 @@ impl CostTracker {
             if self.vote_cost.saturating_add(cost) > self.vote_cost_limit {
                 return Err(CostTrackerError::WouldExceedVoteMaxLimit);
             }
-        } else if self.block_cost.saturating_add(cost) > self.block_cost_limit {
+        }
+
+        if self.block_cost.saturating_add(cost) > self.block_cost_limit {
             // check against the total package cost
             return Err(CostTrackerError::WouldExceedBlockMaxLimit);
         }


### PR DESCRIPTION
#### Problem
`CostTracker::would_fit` incorrectly not checking votes against block limits.
Introduced in #33230

#### Summary of Changes
Remove the `else` so we check against block limits regardless of `is_simple_vote`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
