### PR TITLE
clear_signatures, clear_slot_signatures dev-context-only-utils gated

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4160,10 +4160,12 @@ impl Bank {
     }
 
     /// Forget all signatures. Useful for benchmarking.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn clear_signatures(&self) {
         self.status_cache.write().unwrap().clear();
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn clear_slot_signatures(&self, slot: Slot) {
         self.status_cache.write().unwrap().clear_slot_entries(slot);
     }


### PR DESCRIPTION
#### Problem
- These functions have comments describing they should only be used in tests/benches

#### Summary of Changes
- These should be dev-context only, since we don't want them called by an actual production bank

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
