### PR TITLE
bigtable: fix AccessToken issues

### DIFF
--- a/storage-bigtable/src/access_token.rs
+++ b/storage-bigtable/src/access_token.rs
@@ -34,12 +34,24 @@ fn load_stringified_credentials(credential: String) -> Result<Credentials, Strin
     Credentials::from_str(&credential).map_err(|err| format!("{err}"))
 }
 
-#[derive(Clone)]
-pub struct AccessToken {
+pub struct AccessTokenInner {
     credentials: Credentials,
     scope: Scope,
-    refresh_active: Arc<AtomicBool>,
-    token: Arc<RwLock<(Token, Instant)>>,
+    token: RwLock<(Token, Instant)>,
+    refresh_active: AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct AccessToken {
+    inner: Arc<AccessTokenInner>,
+}
+
+impl std::ops::Deref for AccessToken {
+    type Target = AccessTokenInner;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
 }
 
 impl AccessToken {
@@ -52,12 +64,14 @@ impl AccessToken {
         if let Err(err) = credentials.rsa_key() {
             Err(format!("Invalid rsa key: {err}"))
         } else {
-            let token = Arc::new(RwLock::new(Self::get_token(&credentials, &scope).await?));
+            let token = RwLock::new(Self::get_token(&credentials, &scope).await?);
             let access_token = Self {
-                credentials,
-                scope,
-                token,
-                refresh_active: Arc::new(AtomicBool::new(false)),
+                inner: Arc::new(AccessTokenInner {
+                    credentials,
+                    scope,
+                    token,
+                    refresh_active: AtomicBool::new(false),
+                }),
             };
             Ok(access_token)
         }
@@ -91,41 +105,55 @@ impl AccessToken {
     }
 
     /// Call this function regularly to ensure the access token does not expire
-    pub async fn refresh(&self) {
+    pub fn try_refresh(&self) {
         // Check if it's time to try a token refresh
-        {
-            let token_r = self.token.read().unwrap();
-            if token_r.1.elapsed().as_secs() < token_r.0.expires_in() as u64 / 2 {
+        match self.token.read() {
+            Ok(token_r) => {
+                if token_r.1.elapsed().as_secs() < token_r.0.expires_in() as u64 / 2 {
+                    debug!("token is not expired yet");
+                    return;
+                }
+                drop(token_r);
+            }
+            Err(_poisoned) => {
+                error!("token is poisoned (read op)");
                 return;
             }
+        }
 
-            #[allow(deprecated)]
-            if self
-                .refresh_active
-                .compare_and_swap(false, true, Ordering::Relaxed)
+        // Refresh already is progress
+        let refresh_progress =
+            self.refresh_active
+                .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed);
+        if refresh_progress.is_err() {
+            debug!("token update is already in progress");
+            return;
+        }
+
+        let this = self.clone();
+        tokio::spawn(async move {
+            match time::timeout(
+                time::Duration::from_secs(5),
+                Self::get_token(&this.credentials, &this.scope),
+            )
+            .await
             {
-                // Refresh already pending
-                return;
+                Ok(new_token) => match (new_token, this.token.write()) {
+                    (Ok(new_token), Ok(mut token_w)) => {
+                        *token_w = new_token;
+                    }
+                    (Ok(_new_token), Err(_poisoned)) => {
+                        error!("token is poisoned (write op)")
+                    }
+                    (Err(err), _) => error!("failed to fetch new token: {}", err),
+                },
+                Err(_timeout) => {
+                    warn!("token refresh timeout")
+                }
             }
-        }
-
-        info!("Refreshing token");
-        match time::timeout(
-            time::Duration::from_secs(5),
-            Self::get_token(&self.credentials, &self.scope),
-        )
-        .await
-        {
-            Ok(new_token) => match (new_token, self.token.write()) {
-                (Ok(new_token), Ok(mut token_w)) => *token_w = new_token,
-                (Ok(_new_token), Err(err)) => warn!("{}", err),
-                (Err(err), _) => warn!("{}", err),
-            },
-            Err(_) => {
-                warn!("Token refresh timeout")
-            }
-        }
-        self.refresh_active.store(false, Ordering::Relaxed);
+            this.refresh_active.store(false, Ordering::Relaxed);
+            info!("token refreshed");
+        });
     }
 
     /// Return an access token suitable for use in an HTTP authorization header

--- a/storage-bigtable/src/bigtable.rs
+++ b/storage-bigtable/src/bigtable.rs
@@ -410,9 +410,9 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         Ok(rows)
     }
 
-    async fn refresh_access_token(&self) {
+    fn refresh_access_token(&self) {
         if let Some(ref access_token) = self.access_token {
-            access_token.refresh().await;
+            access_token.try_refresh();
         }
     }
 
@@ -434,7 +434,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         if rows_limit == 0 {
             return Ok(vec![]);
         }
-        self.refresh_access_token().await;
+        self.refresh_access_token();
         let response = self
             .client
             .read_rows(ReadRowsRequest {
@@ -479,7 +479,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
 
     /// Check whether a row key exists in a `table`
     pub async fn row_key_exists(&mut self, table_name: &str, row_key: RowKey) -> Result<bool> {
-        self.refresh_access_token().await;
+        self.refresh_access_token();
 
         let response = self
             .client
@@ -524,7 +524,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         if rows_limit == 0 {
             return Ok(vec![]);
         }
-        self.refresh_access_token().await;
+        self.refresh_access_token();
         let response = self
             .client
             .read_rows(ReadRowsRequest {
@@ -558,7 +558,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         table_name: &str,
         row_keys: &[RowKey],
     ) -> Result<Vec<(RowKey, RowData)>> {
-        self.refresh_access_token().await;
+        self.refresh_access_token();
 
         let response = self
             .client
@@ -594,7 +594,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         table_name: &str,
         row_key: RowKey,
     ) -> Result<RowData> {
-        self.refresh_access_token().await;
+        self.refresh_access_token();
 
         let response = self
             .client
@@ -623,7 +623,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
 
     /// Delete one or more `table` rows
     async fn delete_rows(&mut self, table_name: &str, row_keys: &[RowKey]) -> Result<()> {
-        self.refresh_access_token().await;
+        self.refresh_access_token();
 
         let mut entries = vec![];
         for row_key in row_keys {
@@ -669,7 +669,7 @@ impl<F: FnMut(Request<()>) -> InterceptedRequestResult> BigTable<F> {
         family_name: &str,
         row_data: &[(&RowKey, RowData)],
     ) -> Result<()> {
-        self.refresh_access_token().await;
+        self.refresh_access_token();
 
         let mut entries = vec![];
         for (row_key, row_data) in row_data {


### PR DESCRIPTION
#### Problem

The problem is widely known that sometimes nodes lose BigTable connection (Access Token expired actually).

Previously described in different issues and pull requests, like #20336 #26217 #28728 #29692

The code itself looks completely OK, we test if the token is expired and if so set the flag to disable updates from other calls, have a timeout, and correctly handle an error, in the end we set the flag back to 'non-update status'. Everything is correct, except for one thing.... we miss that function is `async` and if `Future` would dropped during update we never finish the token update and never set the flag back to 'non-update status'. As a result, we will lose connection to BigTable. *If* `Mutex` were used instead `AtomicFlag` we would never had that problem because `MutexGuard` would be dropped anyway :grin: use `AtomicFlag` is ok too, but you need to be careful :wink: 

We currently test this patch on Triton nodes but everything looks great so far.

#### Summary of Changes

The obvious fix was to use `Mutex` instead `AtomicFlag` but instead I prefer to change `try_refresh` to 'non-async' function and use `tokio::spawn` for the token refresh. This is slightly more complicated but I think it's OK.