### PR TITLE
Uses Display for error in VerifyAccountsHashInBackground's panic message

### DIFF
--- a/accounts-db/src/verify_accounts_hash_in_background.rs
+++ b/accounts-db/src/verify_accounts_hash_in_background.rs
@@ -67,7 +67,7 @@ impl VerifyAccountsHashInBackground {
         }
         let result = lock.take().unwrap().join().unwrap();
         if !result {
-            panic!("initial hash verification failed: {result:?}");
+            panic!("initial background accounts hash verification failed: {result}");
         }
         // we never have to check again
         self.verification_complete();
@@ -139,7 +139,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "initial hash verification failed")]
+    #[should_panic(expected = "initial background accounts hash verification failed")]
     fn test_panic() {
         let verify = Arc::new(VerifyAccountsHashInBackground::default());
         start_thread_and_return(&verify, false, || {});


### PR DESCRIPTION
#### Problem

If the initial accounts hash verification fails, the panic message prints out the error, but with `Debug`. This may not include useful information that `Display` would. Since this message is user/dev-facing, `Display` is more helpful.


#### Summary of Changes

Change the error to be printed with `Display` instead of `Debug`.

Also, change the panic text to match the logs when the bg process starts/stops:
https://github.com/solana-labs/solana/blob/c6451e9441cd8a18a160c14fa2a5b2531611ab09/runtime/src/bank.rs#L7165


#### Backports

I'd also like to backport this to v1.17, to aid in debugging any issues sooner.