### PR TITLE
ledger-tool does *not* fastboot by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Release channels have their own copy of this changelog:
 * Changes
   * Added a github check to support `changelog` label
   * The default for `--use-snapshot-archives-at-startup` is now `when-newest` (#33883)
+    * The default for `solana-ledger-tool`, however, remains `always` (#34228)
 * Upgrade Notes
 
 ## [1.17.0]

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1246,7 +1246,7 @@ fn main() {
             .long(use_snapshot_archives_at_startup::cli::LONG_ARG)
             .takes_value(true)
             .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
-            .default_value(use_snapshot_archives_at_startup::cli::default_value())
+            .default_value(use_snapshot_archives_at_startup::cli::default_value_for_ledger_tool())
             .help(use_snapshot_archives_at_startup::cli::HELP)
             .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP);
 

--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -48,4 +48,8 @@ pub mod cli {
     pub fn default_value() -> &'static str {
         UseSnapshotArchivesAtStartup::default().into()
     }
+
+    pub fn default_value_for_ledger_tool() -> &'static str {
+        UseSnapshotArchivesAtStartup::Always.into()
+    }
 }


### PR DESCRIPTION
#### Problem

Fastboot is great for the validator, but can expose some sharp edges for ledger-tool. If a validator is already running, then calling ledger-tool will fail (on the subcommand that use accounts) due to the default fastboot value (since it tries to get primary access to the ledger). The error message does not make it obvious what the problem is, nor how to fix it.


#### Summary of Changes

Do not fastboot by default for ledger-tool.

This is safe, and retains the expectation that ledger-tool should *not* modify anything by default. Users can still opt into fastboot with ledger-tool.