### PR TITLE
Increase pull request clusterinfo probability

### DIFF
--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2085,8 +2085,7 @@ impl ClusterInfo {
                     score
                 };
                 let score = match response.data {
-                    CrdsData::LegacyContactInfo(_) => 2 * score,
-                    CrdsData::ContactInfo(_) => 2 * score,
+                    CrdsData::LegacyContactInfo(_) | CrdsData::ContactInfo(_) => 2 * score,
                     _ => score,
                 };
                 ((addr, response), score)

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -2086,6 +2086,7 @@ impl ClusterInfo {
                 };
                 let score = match response.data {
                     CrdsData::LegacyContactInfo(_) => 2 * score,
+                    CrdsData::ContactInfo(_) => 2 * score,
                     _ => score,
                 };
                 ((addr, response), score)


### PR DESCRIPTION
#### Problem
we upgraded to a new `ContactInfo`, but we haven't increased the new `ContactInfo`'s propagation probability through pull requests as it is for `LegacyContactInfo`

#### Summary of Changes
Added in score increase for `ContactInfo`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
