### PR TITLE
Bump prio-graph to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd2fa9ca0901b4d0dbf51d9862d7e3fb004605e4f4b4132472c3d08e7d901b"
+checksum = "952091df80157ff6f267c9bcb6ad68e42405e217bd83268f2aedee0aa4f03b5c"
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,7 +263,7 @@ pickledb = { version = "0.5.1", default-features = false }
 pkcs8 = "0.8.0"
 predicates = "2.1"
 pretty-hex = "0.3.0"
-prio-graph = "0.1.0"
+prio-graph = "0.2.0"
 proc-macro2 = "1.0.70"
 proptest = "1.4"
 prost = "0.11.9"

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -184,7 +184,7 @@ impl PrioGraphScheduler {
         }
 
         // Push remaining transactions back into the container
-        while let Some(id) = prio_graph.pop_and_unblock() {
+        while let Some((id, _)) = prio_graph.pop_and_unblock() {
             container.push_id_into_queue(id);
         }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3593,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd2fa9ca0901b4d0dbf51d9862d7e3fb004605e4f4b4132472c3d08e7d901b"
+checksum = "952091df80157ff6f267c9bcb6ad68e42405e217bd83268f2aedee0aa4f03b5c"
 
 [[package]]
 name = "proc-macro-crate"


### PR DESCRIPTION
#### Problem
Following up on https://github.com/solana-labs/solana/issues/34221#issuecomment-1828269609.
prio-graph 0.2.0 supports conflicting transactions so if the checks added in #34229 fail, it will not crash like it did previously.

#### Summary of Changes
- Update Cargo.toml prio-graph to 0.2.0
- Return value of `PrioGraph::pop_and_unblock` changed, update the call-site in `PrioGraphScheduler::schedule`
  - immediately drop blocked ids returned, only use the popped id

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
