### PR TITLE
Patch tokio to vendored version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8393,8 +8393,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+source = "git+https://github.com/solana-labs/solana-tokio.git?rev=7cf47705faacf7bf0e43e4131a5377b3291fce21#7cf47705faacf7bf0e43e4131a5377b3291fce21"
 dependencies = [
  "autocfg",
  "backtrace",
@@ -8423,8 +8422,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+source = "git+https://github.com/solana-labs/solana-tokio.git?rev=7cf47705faacf7bf0e43e4131a5377b3291fce21#7cf47705faacf7bf0e43e4131a5377b3291fce21"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -408,6 +408,7 @@ tempfile = "3.8.1"
 test-case = "3.3.1"
 thiserror = "1.0.50"
 tiny-bip39 = "0.8.2"
+# Update solana-tokio patch below when updating this version
 tokio = "1.29.1"
 tokio-serde = "0.8"
 tokio-stream = "0.1.14"
@@ -537,3 +538,21 @@ rev = "6105d7a5591aefa646a95d12b5e8d3f55a9214ef"
 [patch.crates-io.curve25519-dalek]
 git = "https://github.com/solana-labs/curve25519-dalek.git"
 rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
+
+# Solana RPC nodes experience stalls when running with `tokio` containing this
+# commit:
+# https://github.com/tokio-rs/tokio/commit/4eed411519783ef6f58cbf74f886f91142b5cfa6
+#
+# Tokio maintainers believe performance degradation is due to application bugs:
+# https://github.com/tokio-rs/tokio/issues/4873#issuecomment-1198277677
+#
+# This may indeed be true of the code in this monorepo, but we haven't yet
+# identified the big or a way to fix. As a stopgap, this patches `tokio` to the
+# tagged version specified above with commit `4eed411` reverted.
+#
+# Comparison:
+# https://github.com/tokio-rs/tokio/compare/tokio-1.29.1...solana-labs:solana-tokio:tokio-1.29.1-revert-4eed411
+#
+[patch.crates-io.tokio]
+git = "https://github.com/solana-labs/solana-tokio.git"
+rev = "7cf47705faacf7bf0e43e4131a5377b3291fce21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -547,7 +547,7 @@ rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464"
 # https://github.com/tokio-rs/tokio/issues/4873#issuecomment-1198277677
 #
 # This may indeed be true of the code in this monorepo, but we haven't yet
-# identified the big or a way to fix. As a stopgap, this patches `tokio` to the
+# identified the bug or a way to fix. As a stopgap, this patches `tokio` to the
 # tagged version specified above with commit `4eed411` reverted.
 #
 # Comparison:


### PR DESCRIPTION
#### Problem
This issue still exists for RPC operators: https://github.com/solana-labs/solana/issues/24644

#### Summary of Changes
Patch tokio to `solana-tokio` at v1.29.1 with 4eed411 manually reverted
