### PR TITLE
Use Vec::with_capacity() to avoid reallocations with repeated push()'s

### DIFF
--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -885,7 +885,7 @@ impl LedgerStorage {
         );
         let mut by_addr: HashMap<&Pubkey, Vec<TransactionByAddrInfo>> = HashMap::new();
 
-        let mut tx_cells = vec![];
+        let mut tx_cells = Vec::with_capacity(confirmed_block.transactions.len());
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
             let VersionedTransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
             let err = meta.status.clone().err();


### PR DESCRIPTION
#### Problem
The length of tx_cells is known at the start, so we can size the Vec appropriately off the bat to avoid the reallocations.

#### Summary of Changes
`vec![] ==> Vec::with_capacity()`
