### PR TITLE
TransactionScheduler: Schedule Filter

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -115,7 +115,7 @@ impl SchedulerController {
         match decision {
             BufferedPacketsDecision::Consume(_bank_start) => {
                 let (scheduling_summary, schedule_time_us) =
-                    measure_us!(self.scheduler.schedule(&mut self.container)?);
+                    measure_us!(self.scheduler.schedule(&mut self.container, |_| true)?);
                 saturating_add_assign!(
                     self.count_metrics.num_scheduled,
                     scheduling_summary.num_scheduled


### PR DESCRIPTION
#### Problem
#34233 will filter transactions out before we become leader, but we still may receive filterable transactions during or very close to our leader slot.
We should be filtering these out before prio-graph insertion, so they do not block other transactions.

#### Summary of Changes
- Add a generic filter to `PrioGraph::schedule`
- Call `Bank::check_transactions` inside filter
- Add filter count and time metrics
- For efficiency in filter, do batched pops from the container to prio-graph

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
