### PR TITLE
v1.16 Add ability to output components that go into Bank hash (backport of #32632)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6557,6 +6557,7 @@ version = "1.16.21"
 dependencies = [
  "arrayref",
  "assert_matches",
+ "base64 0.21.2",
  "bincode",
  "blake3",
  "bv",
@@ -6594,6 +6595,7 @@ dependencies = [
  "rustc_version 0.4.0",
  "serde",
  "serde_derive",
+ "serde_json",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-bucket-map",
@@ -6611,6 +6613,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",
+ "solana-version",
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -59,7 +59,7 @@ use {
     solana_rpc_client_api::response::SlotUpdate,
     solana_runtime::{
         accounts_background_service::AbsRequestSender,
-        bank::{Bank, NewBankOptions},
+        bank::{bank_hash_details, Bank, NewBankOptions},
         bank_forks::{BankForks, MAX_ROOT_DISTANCE_FOR_VOTE_ONLY},
         commitment::BlockCommitmentCache,
         prioritization_fee_cache::PrioritizationFeeCache,
@@ -1502,6 +1502,7 @@ impl ReplayStage {
                     let bank = w_bank_forks
                         .remove(*slot)
                         .expect("BankForks should not have been purged yet");
+                    let _ = bank_hash_details::write_bank_hash_details_file(&bank);
                     ((*slot, bank.bank_id()), bank)
                 })
                 .unzip()

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -60,6 +60,7 @@ pub fn get_accounts_db_config(
         accounts_hash_cache_path: Some(
             ledger_path.join(AccountsDb::DEFAULT_ACCOUNTS_HASH_CACHE_DIR),
         ),
+        base_working_path: Some(ledger_path.to_path_buf()),
         filler_accounts_config,
         ancient_append_vec_offset: value_t!(arg_matches, "accounts_db_ancient_append_vecs", i64)
             .ok(),

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -47,7 +47,7 @@ use {
         accounts::Accounts,
         accounts_db::CalcAccountsHashDataSource,
         accounts_index::ScanConfig,
-        bank::{Bank, RewardCalculationEvent, TotalAccountsStats},
+        bank::{bank_hash_details, Bank, RewardCalculationEvent, TotalAccountsStats},
         bank_forks::BankForks,
         cost_model::CostModel,
         cost_tracker::CostTracker,
@@ -1629,6 +1629,14 @@ fn main() {
                     .takes_value(false)
                     .help("After verifying the ledger, print some information about the account stores"),
             )
+            .arg(
+                Arg::with_name("write_bank_file")
+                    .long("write-bank-file")
+                    .takes_value(false)
+                    .help("After verifying the ledger, write a file that contains the information \
+                        that went into computing the completed bank's bank hash. The file will be \
+                        written within <LEDGER_DIR>/bank_hash_details/"),
+            )
         ).subcommand(
             SubCommand::with_name("graph")
             .about("Create a Graphviz rendering of the ledger")
@@ -2592,6 +2600,7 @@ fn main() {
                     ..ProcessOptions::default()
                 };
                 let print_accounts_stats = arg_matches.is_present("print_accounts_stats");
+                let write_bank_file = arg_matches.is_present("write_bank_file");
                 let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
                 info!("genesis hash: {}", genesis_config.hash());
 
@@ -2616,6 +2625,10 @@ fn main() {
                 if print_accounts_stats {
                     let working_bank = bank_forks.read().unwrap().working_bank();
                     working_bank.print_accounts_stats();
+                }
+                if write_bank_file {
+                    let working_bank = bank_forks.read().unwrap().working_bank();
+                    let _ = bank_hash_details::write_bank_hash_details_file(&working_bank);
                 }
                 exit_signal.store(true, Ordering::Relaxed);
                 system_monitor_service.join().unwrap();

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5416,6 +5416,7 @@ name = "solana-runtime"
 version = "1.16.21"
 dependencies = [
  "arrayref",
+ "base64 0.21.2",
  "bincode",
  "blake3",
  "bv",
@@ -5449,6 +5450,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_derive",
+ "serde_json",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",
  "solana-bucket-map",
@@ -5465,6 +5467,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-system-program",
+ "solana-version",
  "solana-vote-program",
  "solana-zk-token-proof-program",
  "solana-zk-token-sdk",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 arrayref = { workspace = true }
+base64 = { workspace = true }
 bincode = { workspace = true }
 blake3 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
@@ -43,6 +44,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
+serde_json = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-bucket-map = { workspace = true }
@@ -59,6 +61,7 @@ solana-rayon-threadlimit = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-system-program = { workspace = true }
+solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 solana-zk-token-proof-program = { workspace = true }
 solana-zk-token-sdk = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -200,6 +200,7 @@ struct VerifyAccountsHashConfig {
 }
 
 mod address_lookup_table;
+pub mod bank_hash_details;
 mod builtin_programs;
 mod metrics;
 mod sysvar_cache;

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -1,0 +1,277 @@
+//! Container to capture information relevant to computing a bank hash
+
+use {
+    super::Bank,
+    crate::{accounts_db::PubkeyHashAccount, accounts_hash::AccountsDeltaHash},
+    base64::{prelude::BASE64_STANDARD, Engine},
+    log::*,
+    serde::{
+        de::{self, Deserialize, Deserializer},
+        ser::{Serialize, SerializeSeq, Serializer},
+    },
+    solana_sdk::{
+        account::{Account, AccountSharedData, ReadableAccount},
+        clock::{Epoch, Slot},
+        hash::Hash,
+        pubkey::Pubkey,
+    },
+    std::str::FromStr,
+};
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct BankHashDetails {
+    /// client version
+    pub version: String,
+    pub account_data_encoding: String,
+    pub slot: Slot,
+    pub bank_hash: String,
+    pub parent_bank_hash: String,
+    pub accounts_delta_hash: String,
+    pub signature_count: u64,
+    pub last_blockhash: String,
+    pub accounts: BankHashAccounts,
+}
+
+impl BankHashDetails {
+    pub fn new(
+        slot: Slot,
+        bank_hash: Hash,
+        parent_bank_hash: Hash,
+        accounts_delta_hash: Hash,
+        signature_count: u64,
+        last_blockhash: Hash,
+        accounts: BankHashAccounts,
+    ) -> Self {
+        Self {
+            version: solana_version::version!().to_string(),
+            account_data_encoding: "base64".to_string(),
+            slot,
+            bank_hash: bank_hash.to_string(),
+            parent_bank_hash: parent_bank_hash.to_string(),
+            accounts_delta_hash: accounts_delta_hash.to_string(),
+            signature_count,
+            last_blockhash: last_blockhash.to_string(),
+            accounts,
+        }
+    }
+}
+
+impl TryFrom<&Bank> for BankHashDetails {
+    type Error = String;
+
+    fn try_from(bank: &Bank) -> Result<Self, Self::Error> {
+        let slot = bank.slot();
+        if !bank.is_frozen() {
+            return Err(format!(
+                "Bank {slot} must be frozen in order to get bank hash details"
+            ));
+        }
+
+        // This bank is frozen; as a result, we know that the state has been
+        // hashed which means the delta hash is Some(). So, .unwrap() is safe
+        let AccountsDeltaHash(accounts_delta_hash) = bank
+            .rc
+            .accounts
+            .accounts_db
+            .get_accounts_delta_hash(slot)
+            .unwrap();
+        let mut accounts = bank
+            .rc
+            .accounts
+            .accounts_db
+            .get_pubkey_hash_account_for_slot(slot);
+        // get_pubkey_hash_account_for_slot() returns an arbitrary ordering;
+        // sort by pubkey to match the ordering used for accounts delta hash
+        accounts.sort_by_key(|account| account.pubkey);
+
+        Ok(Self::new(
+            slot,
+            bank.hash(),
+            bank.parent_hash(),
+            accounts_delta_hash,
+            bank.signature_count(),
+            bank.last_blockhash(),
+            BankHashAccounts { accounts },
+        ))
+    }
+}
+
+// Wrap the Vec<...> so we can implement custom Serialize/Deserialize traits on the wrapper type
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BankHashAccounts {
+    pub accounts: Vec<PubkeyHashAccount>,
+}
+
+#[derive(Deserialize, Serialize)]
+/// Used as an intermediate for serializing and deserializing account fields
+/// into a human readable format.
+struct SerdeAccount {
+    pubkey: String,
+    hash: String,
+    owner: String,
+    lamports: u64,
+    rent_epoch: Epoch,
+    executable: bool,
+    data: String,
+}
+
+impl From<&PubkeyHashAccount> for SerdeAccount {
+    fn from(pubkey_hash_account: &PubkeyHashAccount) -> Self {
+        let PubkeyHashAccount {
+            pubkey,
+            hash,
+            account,
+        } = pubkey_hash_account;
+        Self {
+            pubkey: pubkey.to_string(),
+            hash: hash.to_string(),
+            owner: account.owner().to_string(),
+            lamports: account.lamports(),
+            rent_epoch: account.rent_epoch(),
+            executable: account.executable(),
+            data: BASE64_STANDARD.encode(account.data()),
+        }
+    }
+}
+
+impl TryFrom<SerdeAccount> for PubkeyHashAccount {
+    type Error = String;
+
+    fn try_from(temp_account: SerdeAccount) -> Result<Self, Self::Error> {
+        let pubkey = Pubkey::from_str(&temp_account.pubkey).map_err(|err| err.to_string())?;
+        let hash = Hash::from_str(&temp_account.hash).map_err(|err| err.to_string())?;
+
+        let account = AccountSharedData::from(Account {
+            lamports: temp_account.lamports,
+            data: BASE64_STANDARD
+                .decode(temp_account.data)
+                .map_err(|err| err.to_string())?,
+            owner: Pubkey::from_str(&temp_account.owner).map_err(|err| err.to_string())?,
+            executable: temp_account.executable,
+            rent_epoch: temp_account.rent_epoch,
+        });
+
+        Ok(Self {
+            pubkey,
+            hash,
+            account,
+        })
+    }
+}
+
+impl Serialize for BankHashAccounts {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.accounts.len()))?;
+        for account in self.accounts.iter() {
+            let temp_account = SerdeAccount::from(account);
+            seq.serialize_element(&temp_account)?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for BankHashAccounts {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let temp_accounts: Vec<SerdeAccount> = Deserialize::deserialize(deserializer)?;
+        let pubkey_hash_accounts: Result<Vec<_>, _> = temp_accounts
+            .into_iter()
+            .map(PubkeyHashAccount::try_from)
+            .collect();
+        let pubkey_hash_accounts = pubkey_hash_accounts.map_err(de::Error::custom)?;
+        Ok(BankHashAccounts {
+            accounts: pubkey_hash_accounts,
+        })
+    }
+}
+
+/// Output the components that comprise bank hash
+pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), String> {
+    let details = BankHashDetails::try_from(bank)?;
+
+    let slot = details.slot;
+    let hash = &details.bank_hash;
+    let file_name = format!("{slot}-{hash}.json");
+    let parent_dir = bank
+        .rc
+        .accounts
+        .accounts_db
+        .get_base_working_path()
+        .join("bank_hash_details");
+    let path = parent_dir.join(file_name);
+    // A file with the same name implies the same hash for this slot. Skip
+    // rewriting a duplicate file in this scenario
+    if !path.exists() {
+        info!("writing details of bank {} to {}", slot, path.display());
+
+        // std::fs::write may fail (depending on platform) if the full directory
+        // path does not exist. So, call std::fs_create_dir_all first.
+        // https://doc.rust-lang.org/std/fs/fn.write.html
+        _ = std::fs::create_dir_all(parent_dir);
+        let file = std::fs::File::create(&path).map_err(|err| {
+            format!(
+                "Unable to create bank hash file at {}: {err}",
+                path.display()
+            )
+        })?;
+        serde_json::to_writer_pretty(file, &details)
+            .map_err(|err| format!("Unable to write bank hash file contents: {err}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serde_bank_hash_details() {
+        use solana_sdk::hash::hash;
+
+        let slot = 123_456_789;
+        let signature_count = 314;
+
+        let account = AccountSharedData::from(Account {
+            lamports: 123_456_789,
+            data: vec![0, 9, 1, 8, 2, 7, 3, 6, 4, 5],
+            owner: Pubkey::new_unique(),
+            executable: true,
+            rent_epoch: 123,
+        });
+        let account_pubkey = Pubkey::new_unique();
+        let account_hash = hash("account".as_bytes());
+        let accounts = BankHashAccounts {
+            accounts: vec![PubkeyHashAccount {
+                pubkey: account_pubkey,
+                hash: account_hash,
+                account,
+            }],
+        };
+
+        let bank_hash = hash("bank".as_bytes());
+        let parent_bank_hash = hash("parent_bank".as_bytes());
+        let accounts_delta_hash = hash("accounts_delta".as_bytes());
+        let last_blockhash = hash("last_blockhash".as_bytes());
+
+        let bank_hash_details = BankHashDetails::new(
+            slot,
+            bank_hash,
+            parent_bank_hash,
+            accounts_delta_hash,
+            signature_count,
+            last_blockhash,
+            accounts,
+        );
+
+        let serialized_bytes = serde_json::to_vec(&bank_hash_details).unwrap();
+        let deserialized_bank_hash_details: BankHashDetails =
+            serde_json::from_slice(&serialized_bytes).unwrap();
+
+        assert_eq!(bank_hash_details, deserialized_bank_hash_details);
+    }
+}

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1182,6 +1182,7 @@ pub fn main() {
     let accounts_db_config = AccountsDbConfig {
         index: Some(accounts_index_config),
         accounts_hash_cache_path: Some(accounts_hash_cache_path),
+        base_working_path: Some(ledger_path.clone()),
         filler_accounts_config,
         write_cache_limit_bytes: value_t!(matches, "accounts_db_cache_limit_mb", u64)
             .ok()


### PR DESCRIPTION
This is a backport of https://github.com/solana-labs/solana/pull/32632; I did it manually since
- Some files moved around AND
- I had previously done the BP as a one-off thing before I intended to push it into the v1.16

#### Problem
When a consensus divergance occurs, the current workflow involves a handful of manual steps to hone in on the offending slot and transaction. This process isn't overly difficult to execute; however, it is tedious and currently involves creating and parsing logs.

#### Summary of Changes
This change introduces functionality to output a debug file that contains the components go into the bank hash. The file can be generated in two ways:
- Via solana-validator when the node realizes it has diverged
- Via solana-ledger-tool verify by passing a flag

When a divergance occurs now, the steps to debug would be:
- Grab the file from the node that diverged
- Generate a file for the same slot with ledger-tool with a known good version
- Diff the files, they are pretty-printed json