### PR TITLE
Output BankHashDetails file when leader drops its' own block

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1349,9 +1349,13 @@ impl ReplayStage {
                         );
                     }
 
-
                     // Should not dump slots for which we were the leader
                     if Some(*my_pubkey) == leader_schedule_cache.slot_leader_at(*duplicate_slot, None) {
+                        if let Some(duplicate_bank) = bank_forks.read().unwrap().get(*duplicate_slot) {
+                            let _ = bank_hash_details::write_bank_hash_details_file(&duplicate_bank);
+                        } else {
+                            warn!("Unable to get bank for slot {duplicate_slot} from bank forks");
+                        };
                         panic!("We are attempting to dump a block that we produced. \
                             This indicates that we are producing duplicate blocks, \
                             or that there is a bug in our runtime/replay code which \

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1352,11 +1352,11 @@ impl ReplayStage {
 
                     // Should not dump slots for which we were the leader
                     if Some(*my_pubkey) == leader_schedule_cache.slot_leader_at(*duplicate_slot, None) {
-                            panic!("We are attempting to dump a block that we produced. \
-                                This indicates that we are producing duplicate blocks, \
-                                or that there is a bug in our runtime/replay code which \
-                                causes us to compute different bank hashes than the rest of the cluster. \
-                                We froze slot {duplicate_slot} with hash {frozen_hash:?} while the cluster hash is {correct_hash}");
+                        panic!("We are attempting to dump a block that we produced. \
+                            This indicates that we are producing duplicate blocks, \
+                            or that there is a bug in our runtime/replay code which \
+                            causes us to compute different bank hashes than the rest of the cluster. \
+                            We froze slot {duplicate_slot} with hash {frozen_hash:?} while the cluster hash is {correct_hash}");
                     }
 
                     let attempt_no = purge_repair_slot_counter

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2695,7 +2695,11 @@ fn main() {
                 }
                 if write_bank_file {
                     let working_bank = bank_forks.read().unwrap().working_bank();
-                    let _ = bank_hash_details::write_bank_hash_details_file(&working_bank);
+                    bank_hash_details::write_bank_hash_details_file(&working_bank)
+                        .map_err(|err| {
+                            warn!("Unable to write bank hash_details file: {err}");
+                        })
+                        .ok();
                 }
                 exit_signal.store(true, Ordering::Relaxed);
                 system_monitor_service.join().unwrap();

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -216,14 +216,10 @@ pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), Stri
         // path does not exist. So, call std::fs_create_dir_all first.
         // https://doc.rust-lang.org/std/fs/fn.write.html
         _ = std::fs::create_dir_all(parent_dir);
-        let file = std::fs::File::create(&path).map_err(|err| {
-            format!(
-                "Unable to create bank hash file at {}: {err}",
-                path.display()
-            )
-        })?;
+        let file = std::fs::File::create(&path)
+            .map_err(|err| format!("Unable to create file at {}: {err}", path.display()))?;
         serde_json::to_writer_pretty(file, &details)
-            .map_err(|err| format!("Unable to write bank hash file contents: {err}"))?;
+            .map_err(|err| format!("Unable to write file at {}: {err}", path.display()))?;
     }
     Ok(())
 }


### PR DESCRIPTION
#### Problem
    Currently, the file is generated when a node drops a block that was
    produced by another node. However, it would also be beneficial to see
    the account state when a node drops its' own block.

#### Summary of Changes
    Output the file in this additional failure codepath
    
Note that the debug file gets generated when we are not the leader via `ReplayStage::purge_unconfirmed_duplicate_slot()`:
https://github.com/solana-labs/solana/blob/e425c1acaadf6ac22aec3afa09750616443349f1/core/src/replay_stage.rs#L1510