### PR TITLE
Tag InterestingLimit enum with target_os

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -393,6 +393,7 @@ pub struct SystemMonitorStatsReportConfig {
     pub report_os_disk_stats: bool,
 }
 
+#[cfg(target_os = "linux")]
 enum InterestingLimit {
     Recommend(i64),
     QueryOnly,


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/34149 added some `target_os = "linux"` handling, but the accompanying enum is not tagged, leading to clippy complaints on other OSes, like mac:

```
warning: variants `Recommend` and `QueryOnly` are never constructed
   --> core/src/system_monitor_service.rs:397:5
    |
396 | enum InterestingLimit {
    |      ---------------- variants in this enum
397 |     Recommend(i64),
    |     ^^^^^^^^^
398 |     QueryOnly,
    |     ^^^^^^^^^
    |
    = note: `#[warn(dead_code)]` on by default

warning: `solana-core` (lib) generated 1 warning
```

#### Summary of Changes
Tag the enum
