### PR TITLE
Fix mac build

### DIFF
--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -393,7 +393,7 @@ pub struct SystemMonitorStatsReportConfig {
     pub report_os_disk_stats: bool,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 enum InterestingLimit {
     Recommend(i64),
     QueryOnly,


### PR DESCRIPTION
#### Problem
I broke the mac build because it turns out macos does have interesting limits, kind of. Imho, clippy should therefore be able to tell that the variants of the enum get used. But it doesn't.

#### Summary of Changes
Fix max build by allowing dead_code on InterestingLimit when os is not linux
