### PR TITLE
blockstore: use u32 for fec_set_index in erasure set index store key

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -465,7 +465,7 @@ impl Blockstore {
 
     fn erasure_meta(&self, erasure_set: ErasureSetId) -> Result<Option<ErasureMeta>> {
         let (slot, fec_set_index) = erasure_set.store_key();
-        self.erasure_meta_cf.get((slot, fec_set_index as u64))
+        self.erasure_meta_cf.get((slot, u64::from(fec_set_index)))
     }
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
@@ -1020,7 +1020,7 @@ impl Blockstore {
 
         for (erasure_set, erasure_meta) in erasure_metas {
             let (slot, fec_set_index) = erasure_set.store_key();
-            write_batch.put::<cf::ErasureMeta>((slot, fec_set_index as u64), &erasure_meta)?;
+            write_batch.put::<cf::ErasureMeta>((slot, u64::from(fec_set_index)), &erasure_meta)?;
         }
 
         for (erasure_set, merkle_root_meta) in merkle_root_metas {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -464,11 +464,12 @@ impl Blockstore {
     }
 
     fn erasure_meta(&self, erasure_set: ErasureSetId) -> Result<Option<ErasureMeta>> {
-        self.erasure_meta_cf.get(erasure_set.store_key())
+        let (slot, fec_set_index) = erasure_set.store_key();
+        self.erasure_meta_cf.get((slot, fec_set_index as u64))
     }
 
     fn merkle_root_meta(&self, erasure_set: ErasureSetId) -> Result<Option<MerkleRootMeta>> {
-        self.merkle_root_meta_cf.get(erasure_set.key())
+        self.merkle_root_meta_cf.get(erasure_set.store_key())
     }
 
     /// Check whether the specified slot is an orphan slot which does not
@@ -1018,11 +1019,12 @@ impl Blockstore {
         )?;
 
         for (erasure_set, erasure_meta) in erasure_metas {
-            write_batch.put::<cf::ErasureMeta>(erasure_set.store_key(), &erasure_meta)?;
+            let (slot, fec_set_index) = erasure_set.store_key();
+            write_batch.put::<cf::ErasureMeta>((slot, fec_set_index as u64), &erasure_meta)?;
         }
 
         for (erasure_set, merkle_root_meta) in merkle_root_metas {
-            write_batch.put::<cf::MerkleRootMeta>(erasure_set.key(), &merkle_root_meta)?;
+            write_batch.put::<cf::MerkleRootMeta>(erasure_set.store_key(), &merkle_root_meta)?;
         }
 
         for (&slot, index_working_set_entry) in index_working_set.iter() {
@@ -6828,7 +6830,7 @@ pub mod tests {
 
         for (erasure_set, merkle_root_meta) in merkle_root_metas {
             write_batch
-                .put::<cf::MerkleRootMeta>(erasure_set.key(), &merkle_root_meta)
+                .put::<cf::MerkleRootMeta>(erasure_set.store_key(), &merkle_root_meta)
                 .unwrap();
         }
         blockstore.db.write(write_batch).unwrap();
@@ -7008,7 +7010,7 @@ pub mod tests {
 
         for (erasure_set, merkle_root_meta) in merkle_root_metas {
             write_batch
-                .put::<cf::MerkleRootMeta>(erasure_set.key(), &merkle_root_meta)
+                .put::<cf::MerkleRootMeta>(erasure_set.store_key(), &merkle_root_meta)
                 .unwrap();
         }
         blockstore.db.write(write_batch).unwrap();

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -283,12 +283,8 @@ impl ErasureSetId {
         self.0
     }
 
-    // Storage key for ErasureMeta in blockstore db.
-    pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u64) {
-        (self.0, u64::from(self.1))
-    }
-
-    pub(crate) fn key(&self) -> (Slot, /*fec_set_index:*/ u32) {
+    // Storage key for ErasureMeta and MerkleRootMeta in blockstore db.
+    pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u32) {
         (self.0, self.1)
     }
 }

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -284,6 +284,7 @@ impl ErasureSetId {
     }
 
     // Storage key for ErasureMeta and MerkleRootMeta in blockstore db.
+    // Note: ErasureMeta column uses u64 so this will need to be typecast
     pub(crate) fn store_key(&self) -> (Slot, /*fec_set_index:*/ u32) {
         (self.0, self.1)
     }


### PR DESCRIPTION
#### Problem
`fec_set_index` is `u32` but in some places we use `u64` which makes the code confusing.

#### Summary of Changes
Unify the type of `store_key` in `ErasureSetId` to `u32` and perform the type conversion at the call site.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
Contributes to #33644 
