### PR TITLE
blockstore: populate duplicate shred proofs for merkle root conflicts

### DIFF
--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -173,6 +173,7 @@ fn run_check_duplicate(
                     return Ok(());
                 }
             }
+            PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => (shred, conflict),
             PossibleDuplicateShred::Exists(shred) => {
                 // Unlike the other cases we have to wait until here to decide to handle the duplicate and store
                 // in blockstore. This is because the duplicate could have been part of the same insert batch,

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -164,7 +164,7 @@ fn run_check_duplicate(
             shred_slot,
             &root_bank,
         );
-        let send_merkle_root_conflicts = cluster_nodes::check_feature_activation(
+        let merkle_conflict_duplicate_proofs = cluster_nodes::check_feature_activation(
             &feature_set::merkle_conflict_duplicate_proofs::id(),
             shred_slot,
             &root_bank,
@@ -179,7 +179,7 @@ fn run_check_duplicate(
                 }
             }
             PossibleDuplicateShred::MerkleRootConflict(shred, conflict) => {
-                if send_merkle_root_conflicts {
+                if merkle_conflict_duplicate_proofs {
                     // Although this proof can be immediately stored on detection, we wait until
                     // here in order to check the feature flag, as storage in blockstore can
                     // preclude the detection of other duplicate proofs in this slot

--- a/core/src/window_service.rs
+++ b/core/src/window_service.rs
@@ -183,6 +183,9 @@ fn run_check_duplicate(
                     // Although this proof can be immediately stored on detection, we wait until
                     // here in order to check the feature flag, as storage in blockstore can
                     // preclude the detection of other duplicate proofs in this slot
+                    if blockstore.has_duplicate_shreds_in_slot(shred_slot) {
+                        return Ok(());
+                    }
                     blockstore.store_duplicate_slot(
                         shred_slot,
                         conflict.clone(),

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1597,7 +1597,7 @@ impl Blockstore {
     /// the existing `merkle_root_meta` and `shred`
     ///
     /// Otherwise return false and if not already present, add duplicate proof to
-    /// blockstore and `duplicate_shreds`.
+    /// `duplicate_shreds`.
     fn perform_merkle_check(
         &self,
         just_inserted_shreds: &HashMap<ShredId, Shred>,
@@ -1636,12 +1636,6 @@ impl Blockstore {
             let conflicting_shred = self
                 .get_shred_from_just_inserted_or_db(just_inserted_shreds, shred_id)
                 .into_owned();
-            if self
-                .store_duplicate_slot(slot, conflicting_shred.clone(), shred.payload().clone())
-                .is_err()
-            {
-                warn!("store duplicate error");
-            }
             duplicate_shreds.push(PossibleDuplicateShred::MerkleRootConflict(
                 shred.clone(),
                 conflicting_shred,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -7003,10 +7003,10 @@ pub mod tests {
 
         // No insert, notify duplicate
         assert_eq!(duplicates.len(), 1);
-        assert_matches!(
-            duplicates[0],
-            PossibleDuplicateShred::MerkleRootConflict(_, _)
-        );
+        match &duplicates[0] {
+            PossibleDuplicateShred::MerkleRootConflict(shred, _) if shred.slot() == slot => (),
+            _ => panic!("No merkle root conflict"),
+        }
 
         // Verify that we still have the merkle root meta from the original shred
         assert_eq!(merkle_root_metas.len(), 1);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -144,6 +144,7 @@ pub enum PossibleDuplicateShred {
     Exists(Shred), // Blockstore has another shred in its spot
     LastIndexConflict(/* original */ Shred, /* conflict */ Vec<u8>), // The index of this shred conflicts with `slot_meta.last_index`
     ErasureConflict(/* original */ Shred, /* conflict */ Vec<u8>), // The coding shred has a conflict in the erasure_meta
+    MerkleRootConflict(/* original */ Shred, /* conflict */ Vec<u8>), // Merkle root conflict in the same fec set
 }
 
 impl PossibleDuplicateShred {
@@ -152,6 +153,7 @@ impl PossibleDuplicateShred {
             Self::Exists(shred) => shred.slot(),
             Self::LastIndexConflict(shred, _) => shred.slot(),
             Self::ErasureConflict(shred, _) => shred.slot(),
+            Self::MerkleRootConflict(shred, _) => shred.slot(),
         }
     }
 }
@@ -1257,6 +1259,18 @@ impl Blockstore {
                 metrics.num_coding_shreds_invalid += 1;
                 return false;
             }
+
+            if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
+                if !self.perform_merkle_check(
+                    just_received_shreds,
+                    slot,
+                    merkle_root_meta.as_ref(),
+                    &shred,
+                    duplicate_shreds,
+                ) {
+                    return false;
+                }
+            }
         }
 
         let erasure_meta_entry = erasure_metas.entry(erasure_set).or_insert_with(|| {
@@ -1476,6 +1490,18 @@ impl Blockstore {
             ) {
                 return Err(InsertDataShredError::InvalidShred);
             }
+
+            if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
+                if !self.perform_merkle_check(
+                    just_inserted_shreds,
+                    slot,
+                    merkle_root_meta.as_ref(),
+                    &shred,
+                    duplicate_shreds,
+                ) {
+                    return Err(InsertDataShredError::InvalidShred);
+                }
+            }
         }
 
         let newly_completed_data_sets = self.insert_data_shred(
@@ -1532,20 +1558,92 @@ impl Blockstore {
         shred_index < slot_meta.consumed || data_index.contains(shred_index)
     }
 
-    fn get_data_shred_from_just_inserted_or_db<'a>(
+    fn get_shred_from_just_inserted_or_db<'a>(
         &'a self,
         just_inserted_shreds: &'a HashMap<ShredId, Shred>,
         slot: Slot,
-        index: u64,
+        index: u32,
+        shred_type: ShredType,
     ) -> Cow<'a, Vec<u8>> {
-        let key = ShredId::new(slot, u32::try_from(index).unwrap(), ShredType::Data);
+        let key = ShredId::new(slot, index, shred_type);
         if let Some(shred) = just_inserted_shreds.get(&key) {
             Cow::Borrowed(shred.payload())
-        } else {
+        } else if shred_type == ShredType::Data {
             // If it doesn't exist in the just inserted set, it must exist in
             // the backing store
-            Cow::Owned(self.get_data_shred(slot, index).unwrap().unwrap())
+            Cow::Owned(
+                self.get_data_shred(slot, u64::from(index))
+                    .unwrap()
+                    .unwrap_or_else(|| {
+                        panic!("{} {} {:?} must be present!", slot, index, shred_type)
+                    }),
+            )
+        } else {
+            Cow::Owned(
+                self.get_coding_shred(slot, u64::from(index))
+                    .unwrap()
+                    .unwrap_or_else(|| {
+                        panic!("{} {} {:?} must be present!", slot, index, shred_type)
+                    }),
+            )
         }
+    }
+
+    /// Returns true if there is no merkle root conflict between
+    /// the existing `merkle_root_meta` and `shred`
+    ///
+    /// Otherwise return false and if not already present, add duplicate proof to
+    /// blockstore and `duplicate_shreds`.
+    fn perform_merkle_check(
+        &self,
+        just_inserted_shreds: &HashMap<ShredId, Shred>,
+        slot: Slot,
+        merkle_root_meta: &MerkleRootMeta,
+        shred: &Shred,
+        duplicate_shreds: &mut Vec<PossibleDuplicateShred>,
+    ) -> bool {
+        let new_merkle_root = shred.merkle_root().ok();
+        if merkle_root_meta.merkle_root() == new_merkle_root {
+            // No conflict, either both merkle shreds with same merkle root
+            // or both legacy shreds with merkle_root `None`
+            return true;
+        }
+
+        warn!(
+            "Received conflicting merkle roots for slot: {}, erasure_set: {:?}
+                original merkle root {:?} shred index {} type {:?} vs
+                conflicting merkle root {:?} shred index {} type {:?}. Reporting as duplicate",
+            slot,
+            shred.erasure_set(),
+            merkle_root_meta.merkle_root(),
+            merkle_root_meta.first_received_shred_index(),
+            merkle_root_meta.first_received_shred_type(),
+            new_merkle_root,
+            shred.index(),
+            shred.shred_type(),
+        );
+
+        if !self.has_duplicate_shreds_in_slot(slot) {
+            let conflicting_shred = self
+                .get_shred_from_just_inserted_or_db(
+                    just_inserted_shreds,
+                    slot,
+                    merkle_root_meta.first_received_shred_index(),
+                    merkle_root_meta.first_received_shred_type(),
+                )
+                .into_owned();
+            if self
+                .store_duplicate_slot(slot, conflicting_shred.clone(), shred.payload().clone())
+                .is_err()
+            {
+                warn!("store duplicate error");
+            }
+            duplicate_shreds.push(PossibleDuplicateShred::MerkleRootConflict(
+                shred.clone(),
+                conflicting_shred,
+            ));
+        }
+        false
     }
 
     fn should_insert_data_shred(
@@ -1576,10 +1674,11 @@ impl Blockstore {
 
             if !self.has_duplicate_shreds_in_slot(slot) {
                 let ending_shred: Vec<u8> = self
-                    .get_data_shred_from_just_inserted_or_db(
+                    .get_shred_from_just_inserted_or_db(
                         just_inserted_shreds,
                         slot,
-                        last_index.unwrap(),
+                        u32::try_from(last_index.unwrap()).unwrap(),
+                        ShredType::Data,
                     )
                     .into_owned();
 
@@ -1615,10 +1714,11 @@ impl Blockstore {
 
             if !self.has_duplicate_shreds_in_slot(slot) {
                 let ending_shred: Vec<u8> = self
-                    .get_data_shred_from_just_inserted_or_db(
+                    .get_shred_from_just_inserted_or_db(
                         just_inserted_shreds,
                         slot,
-                        slot_meta.received - 1,
+                        u32::try_from(slot_meta.received - 1).unwrap(),
+                        ShredType::Data,
                     )
                     .into_owned();
 
@@ -6887,7 +6987,7 @@ pub mod tests {
         let mut write_batch = blockstore.db.batch().unwrap();
         let mut duplicates = vec![];
 
-        assert!(blockstore.check_insert_coding_shred(
+        assert!(!blockstore.check_insert_coding_shred(
             new_coding_shred.clone(),
             &mut erasure_metas,
             &mut merkle_root_metas,
@@ -6900,6 +7000,13 @@ pub mod tests {
             ShredSource::Turbine,
             &mut BlockstoreInsertionMetrics::default(),
         ));
+
+        // No insert, notify duplicate
+        assert_eq!(duplicates.len(), 1);
+        assert_matches!(
+            duplicates[0],
+            PossibleDuplicateShred::MerkleRootConflict(_, _)
+        );
 
         // Verify that we still have the merkle root meta from the original shred
         assert_eq!(merkle_root_metas.len(), 1);
@@ -7095,7 +7202,14 @@ pub mod tests {
                 None,
                 ShredSource::Turbine,
             )
-            .is_ok());
+            .is_err());
+
+        // No insert, notify duplicate
+        assert_eq!(duplicates.len(), 1);
+        assert_matches!(
+            duplicates[0],
+            PossibleDuplicateShred::MerkleRootConflict(_, _)
+        );
 
         // Verify that we still have the merkle root meta from the original shred
         assert_eq!(merkle_root_metas.len(), 1);

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1261,6 +1261,9 @@ impl Blockstore {
             }
 
             if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
+                // A previous shred has been inserted in this batch or in blockstore
+                // Compare our current shred against the previous shred for potential
+                // conflicts
                 if !self.perform_merkle_check(
                     just_received_shreds,
                     slot,
@@ -1492,6 +1495,9 @@ impl Blockstore {
             }
 
             if let Some(merkle_root_meta) = merkle_root_metas.get(&erasure_set) {
+                // A previous shred has been inserted in this batch or in blockstore
+                // Compare our current shred against the previous shred for potential
+                // conflicts
                 if !self.perform_merkle_check(
                     just_inserted_shreds,
                     slot,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1264,7 +1264,7 @@ impl Blockstore {
                 // A previous shred has been inserted in this batch or in blockstore
                 // Compare our current shred against the previous shred for potential
                 // conflicts
-                if !self.perform_merkle_check(
+                if !self.check_merkle_root_consistency(
                     just_received_shreds,
                     slot,
                     merkle_root_meta.as_ref(),
@@ -1498,7 +1498,7 @@ impl Blockstore {
                 // A previous shred has been inserted in this batch or in blockstore
                 // Compare our current shred against the previous shred for potential
                 // conflicts
-                if !self.perform_merkle_check(
+                if !self.check_merkle_root_consistency(
                     just_inserted_shreds,
                     slot,
                     merkle_root_meta.as_ref(),
@@ -1598,7 +1598,7 @@ impl Blockstore {
     ///
     /// Otherwise return false and if not already present, add duplicate proof to
     /// `duplicate_shreds`.
-    fn perform_merkle_check(
+    fn check_merkle_root_consistency(
         &self,
         just_inserted_shreds: &HashMap<ShredId, Shred>,
         slot: Slot,
@@ -1615,13 +1615,11 @@ impl Blockstore {
 
         warn!(
             "Received conflicting merkle roots for slot: {}, erasure_set: {:?}
-                original merkle root {:?} shred index {} type {:?} vs
+                original merkle root meta {:?} vs
                 conflicting merkle root {:?} shred index {} type {:?}. Reporting as duplicate",
             slot,
             shred.erasure_set(),
-            merkle_root_meta.merkle_root(),
-            merkle_root_meta.first_received_shred_index(),
-            merkle_root_meta.first_received_shred_type(),
+            merkle_root_meta,
             new_merkle_root,
             shred.index(),
             shred.shred_type(),

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -406,7 +406,6 @@ impl ErasureMeta {
     }
 }
 
-#[allow(dead_code)]
 impl MerkleRootMeta {
     pub(crate) fn from_shred(shred: &Shred) -> Self {
         Self {

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -748,6 +748,10 @@ pub mod index_erasure_conflict_duplicate_proofs {
     solana_sdk::declare_id!("dupPajaLy2SSn8ko42aZz4mHANDNrLe8Nw8VQgFecLa");
 }
 
+pub mod merkle_conflict_duplicate_proofs {
+    solana_sdk::declare_id!("mrkPjRg79B2oK2ZLgd7S3AfEJaX9B6gAF3H9aEykRUS");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -930,6 +934,7 @@ lazy_static! {
         (allow_commission_decrease_at_any_time::id(), "Allow commission decrease at any time in epoch #33843"),
         (consume_blockstore_duplicate_proofs::id(), "consume duplicate proofs from blockstore in consensus #34372"),
         (index_erasure_conflict_duplicate_proofs::id(), "generate duplicate proofs for index and erasure conflicts #34360"),
+        (merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for merkle root conflicts #34270"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
We only construct duplicate proofs for conflicting shreds, LAST_SHRED_IN_SLOT, and erasure meta conflicts.

#### Summary of Changes
When receiving a new shred check to see if there is a merkle root conflict from an existing merkle root meta. If there is such a conflict, construct a duplicate proof and notify gossip and the duplicate block state machine. 

Split from https://github.com/solana-labs/solana/pull/33889
Fixes #33644 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
