### PR TITLE
Set format_strings to true in rustfmt.toml file

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -394,7 +394,8 @@ fn run_accounts_bench(
         count += 1;
         if last_log.elapsed().as_millis() > 3000 || (count >= iterations && iterations != 0) {
             info!(
-                "total_accounts_created: {} total_accounts_closed: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
+                "total_accounts_created: {} total_accounts_closed: {} tx_sent_count: {} \
+                 loop_count: {} balance(s): {:?}",
                 total_accounts_created, total_accounts_closed, tx_sent_count, count, balances
             );
             last_log = Instant::now();
@@ -512,8 +513,8 @@ fn main() {
                 .validator(is_url_or_moniker)
                 .conflicts_with("entrypoint")
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -569,9 +570,8 @@ fn main() {
                 .help(
                     "Every `n` batches, create a batch of close transactions for
                     the earliest remaining batch of accounts created.
-                    Note: Should be > 1 to avoid situations where the close \
-                    transactions will be submitted before the corresponding \
-                    create transactions have been confirmed",
+                    Note: Should be > 1 to avoid situations where the close transactions will be \
+                     submitted before the corresponding create transactions have been confirmed",
                 ),
         )
         .arg(

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1694,51 +1694,197 @@ mod tests {
             .collect();
 
         type ExpectedType = (String, bool, u64, String);
-        let expected:Vec<ExpectedType> = vec![
+        let expected: Vec<ExpectedType> = vec![
             // ("key/lamports key2/lamports ...",
             // is_last_slice
             // result lamports
             // result hashes)
             // "a5" = key_a, 5 lamports
             ("a1", false, 1, "[11111111111111111111111111111111]"),
-            ("a1b2", false, 3, "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("a1b2b3", false, 4, "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("a1b2b3b4", false, 5, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("a1b2b3b4c5", false, 10, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b2", false, 2, "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("b2b3", false, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b2b3b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b2b3b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b3", false, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b3b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b3b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b4", false, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b4c5", false, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("c5", false, 5, "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
+            (
+                "a1b2",
+                false,
+                3,
+                "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "a1b2b3",
+                false,
+                4,
+                "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "a1b2b3b4",
+                false,
+                5,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "a1b2b3b4c5",
+                false,
+                10,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b2",
+                false,
+                2,
+                "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "b2b3",
+                false,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b2b3b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b2b3b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b3",
+                false,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b3b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b3b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b4",
+                false,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b4c5",
+                false,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "c5",
+                false,
+                5,
+                "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
             ("a1", true, 1, "[11111111111111111111111111111111]"),
-            ("a1b2", true, 3, "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("a1b2b3", true, 4, "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("a1b2b3b4", true, 5, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("a1b2b3b4c5", true, 10, "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b2", true, 2, "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]"),
-            ("b2b3", true, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b2b3b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b2b3b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b3", true, 3, "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]"),
-            ("b3b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b3b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("b4", true, 4, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]"),
-            ("b4c5", true, 9, "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ("c5", true, 5, "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]"),
-            ].into_iter().map(|item| {
-                let result: ExpectedType = (
-                    item.0.to_string(),
-                    item.1,
-                    item.2,
-                    item.3.to_string(),
-                );
-                result
-            }).collect();
+            (
+                "a1b2",
+                true,
+                3,
+                "[11111111111111111111111111111111, 4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "a1b2b3",
+                true,
+                4,
+                "[11111111111111111111111111111111, 8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "a1b2b3b4",
+                true,
+                5,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "a1b2b3b4c5",
+                true,
+                10,
+                "[11111111111111111111111111111111, CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b2",
+                true,
+                2,
+                "[4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi]",
+            ),
+            (
+                "b2b3",
+                true,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b2b3b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b2b3b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b3",
+                true,
+                3,
+                "[8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR]",
+            ),
+            (
+                "b3b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b3b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "b4",
+                true,
+                4,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8]",
+            ),
+            (
+                "b4c5",
+                true,
+                9,
+                "[CktRuQ2mttgRGkXJtyksdKHjUdc2C4TgDzyB98oEzy8, \
+                 GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+            (
+                "c5",
+                true,
+                5,
+                "[GgBaCs3NCBuZN12kCJgAW63ydqohFkHEdfdEXBPzLHq]",
+            ),
+        ]
+        .into_iter()
+        .map(|item| {
+            let result: ExpectedType = (item.0.to_string(), item.1, item.2, item.3.to_string());
+            result
+        })
+        .collect();
 
         let dir_for_temp_cache_files = tempdir().unwrap();
         let hash = AccountsHasher::new(dir_for_temp_cache_files.path().to_path_buf());

--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -150,7 +150,10 @@ pub trait DiskIndexValue:
 
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum ScanError {
-    #[error("Node detected it replayed bad version of slot {slot:?} with id {bank_id:?}, thus the scan on said slot was aborted")]
+    #[error(
+        "Node detected it replayed bad version of slot {slot:?} with id {bank_id:?}, thus the \
+         scan on said slot was aborted"
+    )]
     SlotRemoved { slot: Slot, bank_id: BankId },
     #[error("scan aborted: {0}")]
     Aborted(String),

--- a/accounts-db/src/accounts_partition.rs
+++ b/accounts-db/src/accounts_partition.rs
@@ -293,7 +293,8 @@ pub fn pubkey_range_from_partition(
                 start_index + 1
             },
             partition_from_pubkey(&start_pubkey_final, partition_count),
-            "{start_index}, {end_index}, start_key_prefix: {start_key_prefix}, {start_pubkey_final}, {partition_count}"
+            "{start_index}, {end_index}, start_key_prefix: {start_key_prefix}, \
+             {start_pubkey_final}, {partition_count}"
         );
         assert_eq!(
             end_index,
@@ -322,7 +323,8 @@ pub fn pubkey_range_from_partition(
             assert_eq!(
                 end_index.saturating_add(1),
                 partition_from_pubkey(&pubkey_test, partition_count),
-                "start: {}, end: {}, pubkey: {}, partition_count: {}, prefix_before_addition: {}, prefix after: {}",
+                "start: {}, end: {}, pubkey: {}, partition_count: {}, prefix_before_addition: {}, \
+                 prefix after: {}",
                 start_index,
                 end_index,
                 pubkey_test,

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1179,7 +1179,11 @@ pub mod tests {
                     NonZeroU64::new(ideal_size).unwrap(),
                 );
                 let storages_needed = result.len();
-                assert_eq!(storages_needed, expected_storages, "num_slots: {num_slots}, expected_storages: {expected_storages}, storages_needed: {storages_needed}, ideal_size: {ideal_size}");
+                assert_eq!(
+                    storages_needed, expected_storages,
+                    "num_slots: {num_slots}, expected_storages: {expected_storages}, \
+                     storages_needed: {storages_needed}, ideal_size: {ideal_size}"
+                );
                 compare_all_accounts(
                     &packed_to_compare(&result)[..],
                     &unique_to_compare(&original_results)[..],
@@ -1301,13 +1305,17 @@ pub mod tests {
                             largest_account_size
                         );
                     }
+                    assert!(packed.bytes > 0, "packed size of zero");
                     assert!(
-                        packed.bytes > 0,
-                        "packed size of zero"
-                    );
-                    assert!(
-                        packed.bytes <= ideal_size || packed.accounts.iter().map(|(_slot, accounts)| accounts.len()).sum::<usize>() == 1,
-                        "packed size too large: bytes: {}, ideal_size: {}, data_size: {}, num_slots: {}, # accounts: {}",
+                        packed.bytes <= ideal_size
+                            || packed
+                                .accounts
+                                .iter()
+                                .map(|(_slot, accounts)| accounts.len())
+                                .sum::<usize>()
+                                == 1,
+                        "packed size too large: bytes: {}, ideal_size: {}, data_size: {}, \
+                         num_slots: {}, # accounts: {}",
                         packed.bytes,
                         ideal_size,
                         data_size,
@@ -2847,8 +2855,13 @@ pub mod tests {
                     assert_eq!(
                         expected_infos,
                         count,
-                        "percent_of_alive_shrunk_data: {percent_of_alive_shrunk_data}, infos: {expected_infos}, method: {method:?}, swap: {swap}, data: {:?}",
-                        infos.all_infos.iter().map(|info| (info.slot, info.capacity, info.alive_bytes)).collect::<Vec<_>>()
+                        "percent_of_alive_shrunk_data: {percent_of_alive_shrunk_data}, infos: \
+                         {expected_infos}, method: {method:?}, swap: {swap}, data: {:?}",
+                        infos
+                            .all_infos
+                            .iter()
+                            .map(|info| (info.slot, info.capacity, info.alive_bytes))
+                            .collect::<Vec<_>>()
                     );
                 }
             }

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -369,7 +369,11 @@ impl AppendVec {
             let result = MmapMut::map_mut(&data);
             if result.is_err() {
                 // for vm.max_map_count, error is: {code: 12, kind: Other, message: "Cannot allocate memory"}
-                info!("memory map error: {:?}. This may be because vm.max_map_count is not set correctly.", result);
+                info!(
+                    "memory map error: {:?}. This may be because vm.max_map_count is not set \
+                     correctly.",
+                    result
+                );
             }
             result?
         };

--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -84,8 +84,11 @@ impl CacheHashDataFileReference {
         }
         cache_file.capacity = capacity;
         assert_eq!(
-            capacity, file_len,
-            "expected: {capacity}, len on disk: {file_len} {}, entries: {entries}, cell_size: {cell_size}", self.path.display(),
+            capacity,
+            file_len,
+            "expected: {capacity}, len on disk: {file_len} {}, entries: {entries}, cell_size: \
+             {cell_size}",
+            self.path.display(),
         );
 
         self.stats
@@ -454,7 +457,8 @@ mod tests {
                         }
                         assert_eq!(
                             accum, data_this_pass,
-                            "bins: {bins}, start_bin_this_pass: {start_bin_this_pass}, pass: {pass}, flatten: {flatten_data}, passes: {passes}"
+                            "bins: {bins}, start_bin_this_pass: {start_bin_this_pass}, pass: \
+                             {pass}, flatten: {flatten_data}, passes: {passes}"
                         );
                     }
                 }

--- a/accounts-db/src/epoch_accounts_hash/manager.rs
+++ b/accounts-db/src/epoch_accounts_hash/manager.rs
@@ -51,9 +51,9 @@ impl Manager {
         let mut state = self.state.lock().unwrap();
         if let State::Valid(old_epoch_accounts_hash, old_slot) = &*state {
             panic!(
-                "The epoch accounts hash is already valid! \
-                \nold slot: {old_slot}, epoch accounts hash: {old_epoch_accounts_hash:?} \
-                \nnew slot: {slot}, epoch accounts hash: {epoch_accounts_hash:?}"
+                "The epoch accounts hash is already valid! \nold slot: {old_slot}, epoch accounts \
+                 hash: {old_epoch_accounts_hash:?} \nnew slot: {slot}, epoch accounts hash: \
+                 {epoch_accounts_hash:?}"
             );
         }
         *state = State::Valid(epoch_accounts_hash, slot);

--- a/accounts-db/src/in_mem_accounts_index.rs
+++ b/accounts-db/src/in_mem_accounts_index.rs
@@ -2025,21 +2025,24 @@ mod tests {
                     }
                     assert_eq!(
                         expected_result, result,
-                        "return value different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "return value different. other: {other_slot:?}, {expected:?}, \
+                         {slot_list:?}, original: {original:?}"
                     );
                     // sort for easy comparison
                     expected_reclaims.sort_unstable();
                     reclaims.sort_unstable();
                     assert_eq!(
                         expected_reclaims, reclaims,
-                        "reclaims different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "reclaims different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
                     );
                     // sort for easy comparison
                     slot_list.sort_unstable();
                     expected.sort_unstable();
                     assert_eq!(
                         slot_list, expected,
-                        "slot_list different. other: {other_slot:?}, {expected:?}, {slot_list:?}, original: {original:?}"
+                        "slot_list different. other: {other_slot:?}, {expected:?}, {slot_list:?}, \
+                         original: {original:?}"
                     );
                 }
             }

--- a/accounts-db/src/shared_buffer_reader.rs
+++ b/accounts-db/src/shared_buffer_reader.rs
@@ -269,7 +269,8 @@ impl SharedBufferBgReader {
         }
 
         info!(
-            "reading entire decompressed file took: {} us, bytes: {}, read_us: {}, waiting_for_buffer_us: {}, largest fetch: {}, error: {:?}",
+            "reading entire decompressed file took: {} us, bytes: {}, read_us: {}, \
+             waiting_for_buffer_us: {}, largest fetch: {}, error: {:?}",
             now.elapsed().as_micros(),
             total_bytes,
             read_us,

--- a/banking-bench/src/main.rs
+++ b/banking-bench/src/main.rs
@@ -590,8 +590,16 @@ fn main() {
         .transaction_count();
     debug!("processed: {} base: {}", txs_processed, base_tx_count);
 
-    eprintln!("[total_sent: {}, base_tx_count: {}, txs_processed: {}, txs_landed: {}, total_us: {}, tx_total_us: {}]",
-            total_sent, base_tx_count, txs_processed, (txs_processed - base_tx_count), total_us, tx_total_us);
+    eprintln!(
+        "[total_sent: {}, base_tx_count: {}, txs_processed: {}, txs_landed: {}, total_us: {}, \
+         tx_total_us: {}]",
+        total_sent,
+        base_tx_count,
+        txs_processed,
+        (txs_processed - base_tx_count),
+        total_us,
+        tx_total_us
+    );
 
     eprintln!(
         "{{'name': 'banking_bench_total', 'median': '{:.2}'}}",

--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -214,7 +214,8 @@ where
         let bsps = (tx_count) as f64 / ns as f64;
         let nsps = ns as f64 / (tx_count) as f64;
         info!(
-            "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total time, {:?}",
+            "Done. {:.2} thousand signatures per second, {:.2} us per signature, {} ms total \
+             time, {:?}",
             bsps * 1_000_000_f64,
             nsps / 1_000_f64,
             duration_as_ms(&duration),
@@ -1028,7 +1029,8 @@ fn compute_and_report_stats(
         0.0
     };
     info!(
-        "\nHighest TPS: {:.2} sampling period {}s max transactions: {} clients: {} drop rate: {:.2}",
+        "\nHighest TPS: {:.2} sampling period {}s max transactions: {} clients: {} drop rate: \
+         {:.2}",
         max_of_maxes,
         sample_period,
         max_tx_count,

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -121,7 +121,8 @@ impl Default for Config {
 
 /// Defines and builds the CLI args for a run of the benchmark
 pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
-    App::new(crate_name!()).about(crate_description!())
+    App::new(crate_name!())
+        .about(crate_description!())
         .version(version)
         .arg({
             let arg = Arg::with_name("config_file")
@@ -146,8 +147,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -185,7 +186,9 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("entrypoint")
                 .value_name("HOST:PORT")
                 .takes_value(true)
-                .help("Rendezvous with the cluster at this entry point; defaults to 127.0.0.1:8001"),
+                .help(
+                    "Rendezvous with the cluster at this entry point; defaults to 127.0.0.1:8001",
+                ),
         )
         .arg(
             Arg::with_name("faucet")
@@ -227,11 +230,10 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .help("Seconds to run benchmark, then exit; default is forever"),
         )
-        .arg(
-            Arg::with_name("sustained")
-                .long("sustained")
-                .help("Use sustained performance mode vs. peak mode. This overlaps the tx generation with transfers."),
-        )
+        .arg(Arg::with_name("sustained").long("sustained").help(
+            "Use sustained performance mode vs. peak mode. This overlaps the tx generation with \
+             transfers.",
+        ))
         .arg(
             Arg::with_name("no-multi-client")
                 .long("no-multi-client")
@@ -251,14 +253,14 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .alias("tx_count")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Number of transactions to send per batch")
+                .help("Number of transactions to send per batch"),
         )
         .arg(
             Arg::with_name("keypair_multiplier")
                 .long("keypair-multiplier")
                 .value_name("NUM")
                 .takes_value(true)
-                .help("Multiply by transaction count to determine number of keypairs to create")
+                .help("Multiply by transaction count to determine number of keypairs to create"),
         )
         .arg(
             Arg::with_name("thread-batch-sleep-ms")
@@ -288,8 +290,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .value_name("LAMPORTS")
                 .takes_value(true)
                 .help(
-                    "The cost in lamports that the cluster will charge for signature \
-                     verification when the cluster is operating at target-signatures-per-slot",
+                    "The cost in lamports that the cluster will charge for signature verification \
+                     when the cluster is operating at target-signatures-per-slot",
                 ),
         )
         .arg(
@@ -297,53 +299,53 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("num-lamports-per-account")
                 .value_name("LAMPORTS")
                 .takes_value(true)
-                .help(
-                    "Number of lamports per account.",
-                ),
+                .help("Number of lamports per account."),
         )
         .arg(
             Arg::with_name("target_slots_per_epoch")
                 .long("target-slots-per-epoch")
                 .value_name("SLOTS")
                 .takes_value(true)
-                .help(
-                    "Wait until epochs are this many slots long.",
-                ),
+                .help("Wait until epochs are this many slots long."),
         )
         .arg(
             Arg::with_name("rpc_client")
                 .long("use-rpc-client")
                 .conflicts_with("tpu_client")
                 .takes_value(false)
-                .help("Submit transactions with a RpcClient")
+                .help("Submit transactions with a RpcClient"),
         )
         .arg(
             Arg::with_name("tpu_client")
                 .long("use-tpu-client")
                 .conflicts_with("rpc_client")
                 .takes_value(false)
-                .help("Submit transactions with a TpuClient")
+                .help("Submit transactions with a TpuClient"),
         )
         .arg(
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Do not submit transactions via QUIC; only affects ThinClient (default) \
-                    or TpuClient sends"),
+                .help(
+                    "Do not submit transactions via QUIC; only affects ThinClient (default) or \
+                     TpuClient sends",
+                ),
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)
-                .help("Controls the connection pool size per remote address; only affects ThinClient (default) \
-                    or TpuClient sends"),
+                .help(
+                    "Controls the connection pool size per remote address; only affects \
+                     ThinClient (default) or TpuClient sends",
+                ),
         )
         .arg(
             Arg::with_name("compute_unit_price")
-            .long("compute-unit-price")
-            .takes_value(true)
-            .validator(|s| is_within_range(s, 0..))
-            .help("Sets constant compute-unit-price to transfer transactions"),
+                .long("compute-unit-price")
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 0..))
+                .help("Sets constant compute-unit-price to transfer transactions"),
         )
         .arg(
             Arg::with_name("use_randomized_compute_unit_price")
@@ -363,20 +365,29 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .requires("instruction_padding_data_size")
                 .takes_value(true)
                 .value_name("PUBKEY")
-                .help("If instruction data is padded, optionally specify the padding program id to target"),
+                .help(
+                    "If instruction data is padded, optionally specify the padding program id to \
+                     target",
+                ),
         )
         .arg(
             Arg::with_name("instruction_padding_data_size")
                 .long("instruction-padding-data-size")
                 .takes_value(true)
-                .help("If set, wraps all instructions in the instruction padding program, with the given amount of padding bytes in instruction data."),
+                .help(
+                    "If set, wraps all instructions in the instruction padding program, with the \
+                     given amount of padding bytes in instruction data.",
+                ),
         )
         .arg(
             Arg::with_name("num_conflict_groups")
                 .long("num-conflict-groups")
                 .takes_value(true)
                 .validator(|arg| is_within_range(arg, 1..))
-                .help("The number of unique destination accounts per transactions 'chunk'. Lower values will result in more transaction conflicts.")
+                .help(
+                    "The number of unique destination accounts per transactions 'chunk'. Lower \
+                     values will result in more transaction conflicts.",
+                ),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -394,7 +405,10 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .takes_value(true)
                 .requires("json_rpc_url")
                 .validator(is_keypair)
-                .help("File containing the node identity (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
+                .help(
+                    "File containing the node identity (keypair) of a validator with active \
+                     stake. This allows communicating with network using staked connection",
+                ),
         )
 }
 

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -336,7 +336,12 @@ fn main() {
         );
         client
             .get_account(&instruction_padding_config.program_id)
-            .expect("Instruction padding program must be deployed to this cluster. Deploy the program using `solana program deploy ./bench-tps/tests/fixtures/spl_instruction_padding.so` and pass the resulting program id with `--instruction-padding-program-id`");
+            .expect(
+                "Instruction padding program must be deployed to this cluster. Deploy the program \
+                 using `solana program deploy \
+                 ./bench-tps/tests/fixtures/spl_instruction_padding.so` and pass the resulting \
+                 program id with `--instruction-padding-program-id`",
+            );
     }
     let keypairs = get_keypairs(
         client.clone(),

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -171,7 +171,15 @@ impl<O: BucketOccupied> BucketStorage<O> {
             let full_page_bytes = bytes / PAGE_SIZE * PAGE_SIZE / cell_size * cell_size;
             if full_page_bytes < bytes {
                 let bytes_new = ((bytes / PAGE_SIZE) + 1) * PAGE_SIZE / cell_size * cell_size;
-                assert!(bytes_new >= bytes, "allocating less than requested, capacity: {}, bytes: {}, bytes_new: {}, full_page_bytes: {}", capacity.capacity(), bytes, bytes_new, full_page_bytes);
+                assert!(
+                    bytes_new >= bytes,
+                    "allocating less than requested, capacity: {}, bytes: {}, bytes_new: {}, \
+                     full_page_bytes: {}",
+                    capacity.capacity(),
+                    bytes,
+                    bytes_new,
+                    full_page_bytes
+                );
                 assert_eq!(bytes_new % cell_size, 0);
                 bytes = bytes_new;
                 *capacity = Capacity::Actual(bytes / cell_size);

--- a/clap-utils/src/compute_unit_price.rs
+++ b/clap-utils/src/compute_unit_price.rs
@@ -3,7 +3,8 @@ use {crate::ArgConstant, clap::Arg};
 pub const COMPUTE_UNIT_PRICE_ARG: ArgConstant<'static> = ArgConstant {
     name: "compute_unit_price",
     long: "--with-compute-unit-price",
-    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute unit.",
+    help: "Set compute unit price for transaction, in increments of 0.000001 lamports per compute \
+           unit.",
 };
 
 pub fn compute_unit_price_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/clap-utils/src/fee_payer.rs
+++ b/clap-utils/src/fee_payer.rs
@@ -6,9 +6,9 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \n\
-           or the pubkey of an offline signer, provided an appropriate --signer argument \n\
-           is also passed. Defaults to the client keypair.",
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \nor the \
+           pubkey of an offline signer, provided an appropriate --signer argument \nis also \
+           passed. Defaults to the client keypair.",
 };
 
 pub fn fee_payer_arg<'a, 'b>() -> Arg<'a, 'b> {

--- a/clap-utils/src/keypair.rs
+++ b/clap-utils/src/keypair.rs
@@ -177,9 +177,10 @@ impl DefaultSigner {
                     std::io::Error::new(
                         std::io::ErrorKind::Other,
                         format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new one",
-                        self.path
-                    ),
+                            "No default signer found, run \"solana-keygen new -o {}\" to create a \
+                             new one",
+                            self.path
+                        ),
                     )
                 })?;
             *self.is_path_checked.borrow_mut() = true;
@@ -776,7 +777,10 @@ pub fn signer_from_path_with_config(
         SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a keypair file: {e}"),
+                format!(
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
+                ),
             )
             .into()),
             Ok(file) => Ok(Box::new(file)),
@@ -899,8 +903,8 @@ pub fn resolve_signer_from_path(
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
-                    "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
                 ),
             )
             .into()),
@@ -940,7 +944,8 @@ pub const ASK_KEYWORD: &str = "ASK";
 pub const SKIP_SEED_PHRASE_VALIDATION_ARG: ArgConstant<'static> = ArgConstant {
     long: "skip-seed-phrase-validation",
     name: "skip_seed_phrase_validation",
-    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 official English word list",
+    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 \
+           official English word list",
 };
 
 /// Prompts user for a passphrase and then asks for confirmirmation to check for mistakes
@@ -1021,8 +1026,8 @@ pub fn keypair_from_path(
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
-                    "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
                 ),
             )
             .into()),
@@ -1054,7 +1059,8 @@ pub fn keypair_from_seed_phrase(
     let seed_phrase = prompt_password(format!("[{keypair_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
-        "[{keypair_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
+        "[{keypair_name}] If this seed phrase has an associated passphrase, enter it now. \
+         Otherwise, press ENTER to continue: ",
     );
 
     let keypair = if skip_validation {

--- a/clap-v3-utils/src/fee_payer.rs
+++ b/clap-v3-utils/src/fee_payer.rs
@@ -6,9 +6,9 @@ use {
 pub const FEE_PAYER_ARG: ArgConstant<'static> = ArgConstant {
     name: "fee_payer",
     long: "fee-payer",
-    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \n\
-           or the pubkey of an offline signer, provided an appropriate --signer argument \n\
-           is also passed. Defaults to the client keypair.",
+    help: "Specify the fee-payer account. This may be a keypair file, the ASK keyword \nor the \
+           pubkey of an offline signer, provided an appropriate --signer argument \nis also \
+           passed. Defaults to the client keypair.",
 };
 
 pub fn fee_payer_arg<'a>() -> Arg<'a> {

--- a/clap-v3-utils/src/input_parsers/mod.rs
+++ b/clap-v3-utils/src/input_parsers/mod.rs
@@ -19,7 +19,8 @@ use {
 pub mod signer;
 #[deprecated(
     since = "1.17.0",
-    note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly instead"
+    note = "Please use the functions in `solana_clap_v3_utils::input_parsers::signer` directly \
+            instead"
 )]
 pub use signer::{
     pubkey_of_signer, pubkeys_of_multiple_signers, pubkeys_sigs_of, resolve_signer, signer_of,

--- a/clap-v3-utils/src/keygen/derivation_path.rs
+++ b/clap-v3-utils/src/keygen/derivation_path.rs
@@ -13,9 +13,10 @@ pub fn derivation_path_arg<'a>() -> Arg<'a> {
         .takes_value(true)
         .min_values(0)
         .max_values(1)
-        .help("Derivation path. All indexes will be promoted to hardened. \
-            If arg is not presented then derivation path will not be used. \
-            If arg is presented with empty DERIVATION_PATH value then m/44'/501'/0'/0' will be used."
+        .help(
+            "Derivation path. All indexes will be promoted to hardened. If arg is not presented \
+             then derivation path will not be used. If arg is presented with empty \
+             DERIVATION_PATH value then m/44'/501'/0'/0' will be used.",
         )
 }
 

--- a/clap-v3-utils/src/keygen/mnemonic.rs
+++ b/clap-v3-utils/src/keygen/mnemonic.rs
@@ -90,10 +90,9 @@ pub fn acquire_passphrase_and_message(
         Ok(no_passphrase_and_message())
     } else {
         match prompt_passphrase(
-            "\nFor added security, enter a BIP39 passphrase\n\
-             \nNOTE! This passphrase improves security of the recovery seed phrase NOT the\n\
-             keypair file itself, which is stored as insecure plain text\n\
-             \nBIP39 Passphrase (empty for none): ",
+            "\nFor added security, enter a BIP39 passphrase\n\nNOTE! This passphrase improves \
+             security of the recovery seed phrase NOT the\nkeypair file itself, which is stored \
+             as insecure plain text\n\nBIP39 Passphrase (empty for none): ",
         ) {
             Ok(passphrase) => {
                 println!();

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -178,9 +178,10 @@ impl DefaultSigner {
                     std::io::Error::new(
                         std::io::ErrorKind::Other,
                         format!(
-                        "No default signer found, run \"solana-keygen new -o {}\" to create a new one",
-                        self.path
-                    ),
+                            "No default signer found, run \"solana-keygen new -o {}\" to create a \
+                             new one",
+                            self.path
+                        ),
                     )
                 })?;
             *self.is_path_checked.borrow_mut() = true;
@@ -777,7 +778,10 @@ pub fn signer_from_path_with_config(
         SignerSourceKind::Filepath(path) => match read_keypair_file(&path) {
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
-                format!("could not read keypair file \"{path}\". Run \"solana-keygen new\" to create a keypair file: {e}"),
+                format!(
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
+                ),
             )
             .into()),
             Ok(file) => Ok(Box::new(file)),
@@ -901,8 +905,8 @@ pub fn resolve_signer_from_path(
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
-                    "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
                 ),
             )
             .into()),
@@ -943,7 +947,8 @@ pub const ASK_KEYWORD: &str = "ASK";
 pub const SKIP_SEED_PHRASE_VALIDATION_ARG: ArgConstant<'static> = ArgConstant {
     long: "skip-seed-phrase-validation",
     name: "skip_seed_phrase_validation",
-    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 official English word list",
+    help: "Skip validation of seed phrases. Use this if your phrase does not use the BIP39 \
+           official English word list",
 };
 
 /// Prompts user for a passphrase and then asks for confirmirmation to check for mistakes
@@ -1132,8 +1137,8 @@ fn encodable_key_from_path<K: EncodableKey + SeedDerivable>(
             Err(e) => Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 format!(
-                    "could not read keypair file \"{path}\". \
-                    Run \"solana-keygen new\" to create a keypair file: {e}"
+                    "could not read keypair file \"{path}\". Run \"solana-keygen new\" to create \
+                     a keypair file: {e}"
                 ),
             )
             .into()),
@@ -1213,7 +1218,8 @@ fn encodable_key_from_seed_phrase<K: EncodableKey + SeedDerivable>(
     let seed_phrase = prompt_password(format!("[{key_name}] seed phrase: "))?;
     let seed_phrase = seed_phrase.trim();
     let passphrase_prompt = format!(
-        "[{key_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, press ENTER to continue: ",
+        "[{key_name}] If this seed phrase has an associated passphrase, enter it now. Otherwise, \
+         press ENTER to continue: ",
     );
 
     let key = if skip_validation {

--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -3378,7 +3378,16 @@ mod tests {
 
         c.use_csv = true;
         let s = format!("{c}");
-        assert_eq!(s, "Account Balance: 0.00001 SOL\nValidator Identity: 11111111111111111111111111111111\nVote Authority: {}\nWithdraw Authority: \nCredits: 0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot 0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent Change,APR,Commission\n1,100,1970-01-01 00:00:00 UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 UTC,0.000000012,0.0000001,11%,13.00%,1%\n");
+        assert_eq!(
+            s,
+            "Account Balance: 0.00001 SOL\nValidator Identity: \
+             11111111111111111111111111111111\nVote Authority: {}\nWithdraw Authority: \nCredits: \
+             0\nCommission: 0%\nRoot Slot: ~\nRecent Timestamp: 1970-01-01T00:00:00Z from slot \
+             0\nEpoch Rewards:\nEpoch,Reward Slot,Time,Amount,New Balance,Percent \
+             Change,APR,Commission\n1,100,1970-01-01 00:00:00 \
+             UTC,0.00000001,0.0000001,11%,10.00%,1%\n2,200,1970-01-12 13:46:40 \
+             UTC,0.000000012,0.0000001,11%,13.00%,1%\n"
+        );
         println!("{s}");
     }
 }

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -80,10 +80,12 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_pubkey)
                                 .help(
-                                    "Lookup table authority address [default: the default configured keypair]. \
-                                    WARNING: Cannot be used for creating a lookup table for a cluster running v1.11
-                                    or earlier which requires the authority to sign for lookup table creation.",
-                                )
+                                    "Lookup table authority address [default: the default \
+                                     configured keypair]. WARNING: Cannot be used for creating a \
+                                     lookup table for a cluster running v1.11
+                                    or earlier which requires the authority to sign for lookup \
+                                     table creation.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority_signer")
@@ -92,7 +94,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .conflicts_with("authority")
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority keypair [default: the default configured keypair].")
+                                .help(
+                                    "Lookup table authority keypair [default: the default \
+                                     configured keypair].",
+                                ),
                         )
                         .arg(
                             Arg::with_name("payer")
@@ -100,8 +105,11 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("PAYER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Account that will pay rent fees for the created lookup table [default: the default configured keypair]")
-                        )
+                                .help(
+                                    "Account that will pay rent fees for the created lookup table \
+                                     [default: the default configured keypair]",
+                                ),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("freeze")
@@ -113,7 +121,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -121,7 +129,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("bypass_warning")
@@ -140,7 +151,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -148,7 +159,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("payer")
@@ -156,7 +170,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("PAYER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Account that will pay rent fees for the extended lookup table [default: the default configured keypair]")
+                                .help(
+                                    "Account that will pay rent fees for the extended lookup \
+                                     table [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("addresses")
@@ -166,8 +183,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .use_delimiter(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Comma separated list of addresses to append")
-                        )
+                                .help("Comma separated list of addresses to append"),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("deactivate")
@@ -178,7 +195,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -186,7 +203,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("bypass_warning")
@@ -204,7 +224,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("recipient")
@@ -212,7 +232,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("RECIPIENT_ADDRESS")
                                 .takes_value(true)
                                 .validator(is_pubkey)
-                                .help("Address of the recipient account to deposit the closed account's lamports [default: the default configured keypair]")
+                                .help(
+                                    "Address of the recipient account to deposit the closed \
+                                     account's lamports [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -220,8 +243,11 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
-                        )
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("get")
@@ -231,9 +257,9 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the lookup table to show")
-                        )
-                )
+                                .help("Address of the lookup table to show"),
+                        ),
+                ),
         )
     }
 }
@@ -593,9 +619,9 @@ fn process_create_lookup_table(
     }
 }
 
-pub const FREEZE_LOOKUP_TABLE_WARNING: &str = "WARNING! \
-Once a lookup table is frozen, it can never be modified or unfrozen again. \
-To proceed with freezing, rerun the `freeze` command with the `--bypass-warning` flag";
+pub const FREEZE_LOOKUP_TABLE_WARNING: &str =
+    "WARNING! Once a lookup table is frozen, it can never be modified or unfrozen again. To \
+     proceed with freezing, rerun the `freeze` command with the `--bypass-warning` flag";
 
 fn process_freeze_lookup_table(
     rpc_client: &RpcClient,
@@ -613,9 +639,10 @@ fn process_freeze_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     if !bypass_warning {
@@ -671,9 +698,10 @@ fn process_extend_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let authority_address = authority_signer.pubkey();
@@ -709,10 +737,10 @@ fn process_extend_lookup_table(
     }
 }
 
-pub const DEACTIVATE_LOOKUP_TABLE_WARNING: &str = "WARNING! \
-Once a lookup table is deactivated, it is no longer usable by transactions.
-Deactivated lookup tables may only be closed and cannot be recreated at the same address. \
-To proceed with deactivation, rerun the `deactivate` command with the `--bypass-warning` flag";
+pub const DEACTIVATE_LOOKUP_TABLE_WARNING: &str =
+    "WARNING! Once a lookup table is deactivated, it is no longer usable by transactions.
+Deactivated lookup tables may only be closed and cannot be recreated at the same address. To \
+     proceed with deactivation, rerun the `deactivate` command with the `--bypass-warning` flag";
 
 fn process_deactivate_lookup_table(
     rpc_client: &RpcClient,
@@ -730,9 +758,10 @@ fn process_deactivate_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     if !bypass_warning {
@@ -783,17 +812,19 @@ fn process_close_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let lookup_table_account = AddressLookupTable::deserialize(&lookup_table_account.data)?;
     if lookup_table_account.meta.deactivation_slot == u64::MAX {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not deactivated. Only deactivated lookup tables may be closed",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not deactivated. Only deactivated \
+             lookup tables may be closed",
+        )
+        .into());
     }
 
     let authority_address = authority_signer.pubkey();
@@ -836,9 +867,10 @@ fn process_show_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let lookup_table_account = AddressLookupTable::deserialize(&lookup_table_account.data)?;

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -37,8 +37,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -67,16 +67,19 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                     "processed",
                     "confirmed",
                     "finalized",
-                    "recent", // Deprecated as of v1.5.5
-                    "single", // Deprecated as of v1.5.5
+                    "recent",       // Deprecated as of v1.5.5
+                    "single",       // Deprecated as of v1.5.5
                     "singleGossip", // Deprecated as of v1.5.5
-                    "root", // Deprecated as of v1.5.5
-                    "max", // Deprecated as of v1.5.5
+                    "root",         // Deprecated as of v1.5.5
+                    "max",          // Deprecated as of v1.5.5
                 ])
                 .value_name("COMMITMENT_LEVEL")
                 .hide_possible_values(true)
                 .global(true)
-                .help("Return information at the selected commitment level [possible values: processed, confirmed, finalized]"),
+                .help(
+                    "Return information at the selected commitment level [possible values: \
+                     processed, confirmed, finalized]",
+                ),
         )
         .arg(
             Arg::with_name("verbose")
@@ -207,14 +210,14 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
         )
         .subcommand(
             SubCommand::with_name("completion")
-            .about("Generate completion scripts for various shells")
-            .arg(
-                Arg::with_name("shell")
-                .long("shell")
-                .short("s")
-                .takes_value(true)
-                .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
-                .default_value("bash")
-            )
+                .about("Generate completion scripts for various shells")
+                .arg(
+                    Arg::with_name("shell")
+                        .long("shell")
+                        .short("s")
+                        .takes_value(true)
+                        .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
+                        .default_value("bash"),
+                ),
         )
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -103,20 +103,23 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("catchup")
                 .about("Wait for a validator to catch up to the cluster")
-                .arg(
-                    pubkey!(Arg::with_name("node_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("node_pubkey")
                         .index(1)
                         .value_name("OUR_VALIDATOR_PUBKEY")
                         .required(false),
-                        "Identity pubkey of the validator"),
-                )
+                    "Identity pubkey of the validator"
+                ))
                 .arg(
                     Arg::with_name("node_json_rpc_url")
                         .index(2)
                         .value_name("OUR_URL")
                         .takes_value(true)
                         .validator(is_url)
-                        .help("JSON RPC URL for validator, which is useful for validators with a private RPC service")
+                        .help(
+                            "JSON RPC URL for validator, which is useful for validators with a \
+                             private RPC service",
+                        ),
                 )
                 .arg(
                     Arg::with_name("follow")
@@ -131,19 +134,19 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .value_name("PORT")
                         .default_value(DEFAULT_RPC_PORT_STR)
                         .validator(is_port)
-                        .help("Guess Identity pubkey and validator rpc node assuming local (possibly private) validator"),
+                        .help(
+                            "Guess Identity pubkey and validator rpc node assuming local \
+                             (possibly private) validator",
+                        ),
                 )
-                .arg(
-                    Arg::with_name("log")
-                        .long("log")
-                        .takes_value(false)
-                        .help("Don't update the progress inplace; instead show updates with its own new lines"),
-                ),
+                .arg(Arg::with_name("log").long("log").takes_value(false).help(
+                    "Don't update the progress inplace; instead show updates with its own new \
+                     lines",
+                )),
         )
-        .subcommand(
-            SubCommand::with_name("cluster-date")
-                .about("Get current cluster date, computed from genesis creation time and network time"),
-        )
+        .subcommand(SubCommand::with_name("cluster-date").about(
+            "Get current cluster date, computed from genesis creation time and network time",
+        ))
         .subcommand(
             SubCommand::with_name("cluster-version")
                 .about("Get the version of the cluster entrypoint"),
@@ -151,94 +154,97 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         // Deprecated in v1.8.0
         .subcommand(
             SubCommand::with_name("fees")
-            .about("Display current cluster fees (Deprecated in v1.8.0)")
-            .arg(
-                Arg::with_name("blockhash")
-                    .long("blockhash")
-                    .takes_value(true)
-                    .value_name("BLOCKHASH")
-                    .validator(is_hash)
-                    .help("Query fees for BLOCKHASH instead of the the most recent blockhash")
-            ),
+                .about("Display current cluster fees (Deprecated in v1.8.0)")
+                .arg(
+                    Arg::with_name("blockhash")
+                        .long("blockhash")
+                        .takes_value(true)
+                        .value_name("BLOCKHASH")
+                        .validator(is_hash)
+                        .help("Query fees for BLOCKHASH instead of the the most recent blockhash"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("first-available-block")
                 .about("Get the first available block in the storage"),
         )
-        .subcommand(SubCommand::with_name("block-time")
-            .about("Get estimated production time of a block")
-            .alias("get-block-time")
-            .arg(
-                Arg::with_name("slot")
-                    .index(1)
-                    .takes_value(true)
-                    .value_name("SLOT")
-                    .help("Slot number of the block to query")
-            )
+        .subcommand(
+            SubCommand::with_name("block-time")
+                .about("Get estimated production time of a block")
+                .alias("get-block-time")
+                .arg(
+                    Arg::with_name("slot")
+                        .index(1)
+                        .takes_value(true)
+                        .value_name("SLOT")
+                        .help("Slot number of the block to query"),
+                ),
         )
-        .subcommand(SubCommand::with_name("leader-schedule")
-            .about("Display leader schedule")
-            .arg(
-                Arg::with_name("epoch")
-                    .long("epoch")
-                    .takes_value(true)
-                    .value_name("EPOCH")
-                    .validator(is_epoch)
-                    .help("Epoch to show leader schedule for. [default: current]")
-            )
+        .subcommand(
+            SubCommand::with_name("leader-schedule")
+                .about("Display leader schedule")
+                .arg(
+                    Arg::with_name("epoch")
+                        .long("epoch")
+                        .takes_value(true)
+                        .value_name("EPOCH")
+                        .validator(is_epoch)
+                        .help("Epoch to show leader schedule for. [default: current]"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("epoch-info")
-            .about("Get information about the current epoch")
-            .alias("get-epoch-info"),
+                .about("Get information about the current epoch")
+                .alias("get-epoch-info"),
         )
         .subcommand(
             SubCommand::with_name("genesis-hash")
-            .about("Get the genesis hash")
-            .alias("get-genesis-hash")
+                .about("Get the genesis hash")
+                .alias("get-genesis-hash"),
         )
         .subcommand(
-            SubCommand::with_name("slot").about("Get current slot")
-            .alias("get-slot"),
+            SubCommand::with_name("slot")
+                .about("Get current slot")
+                .alias("get-slot"),
+        )
+        .subcommand(SubCommand::with_name("block-height").about("Get current block height"))
+        .subcommand(SubCommand::with_name("epoch").about("Get current epoch"))
+        .subcommand(
+            SubCommand::with_name("largest-accounts")
+                .about("Get addresses of largest cluster accounts")
+                .arg(
+                    Arg::with_name("circulating")
+                        .long("circulating")
+                        .takes_value(false)
+                        .help("Filter address list to only circulating accounts"),
+                )
+                .arg(
+                    Arg::with_name("non_circulating")
+                        .long("non-circulating")
+                        .takes_value(false)
+                        .conflicts_with("circulating")
+                        .help("Filter address list to only non-circulating accounts"),
+                ),
         )
         .subcommand(
-            SubCommand::with_name("block-height").about("Get current block height"),
+            SubCommand::with_name("supply")
+                .about("Get information about the cluster supply of SOL")
+                .arg(
+                    Arg::with_name("print_accounts")
+                        .long("print-accounts")
+                        .takes_value(false)
+                        .help("Print list of non-circualting account addresses"),
+                ),
         )
         .subcommand(
-            SubCommand::with_name("epoch").about("Get current epoch"),
+            SubCommand::with_name("total-supply")
+                .about("Get total number of SOL")
+                .setting(AppSettings::Hidden),
         )
         .subcommand(
-            SubCommand::with_name("largest-accounts").about("Get addresses of largest cluster accounts")
-            .arg(
-                Arg::with_name("circulating")
-                    .long("circulating")
-                    .takes_value(false)
-                    .help("Filter address list to only circulating accounts")
-            )
-            .arg(
-                Arg::with_name("non_circulating")
-                    .long("non-circulating")
-                    .takes_value(false)
-                    .conflicts_with("circulating")
-                    .help("Filter address list to only non-circulating accounts")
-            ),
-        )
-        .subcommand(
-            SubCommand::with_name("supply").about("Get information about the cluster supply of SOL")
-            .arg(
-                Arg::with_name("print_accounts")
-                    .long("print-accounts")
-                    .takes_value(false)
-                    .help("Print list of non-circualting account addresses")
-            ),
-        )
-        .subcommand(
-            SubCommand::with_name("total-supply").about("Get total number of SOL")
-            .setting(AppSettings::Hidden),
-        )
-        .subcommand(
-            SubCommand::with_name("transaction-count").about("Get current transaction count")
-            .alias("get-transaction-count"),
+            SubCommand::with_name("transaction-count")
+                .about("Get current transaction count")
+                .alias("get-transaction-count"),
         )
         .subcommand(
             SubCommand::with_name("ping")
@@ -265,7 +271,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .short("D")
                         .long("print-timestamp")
                         .takes_value(false)
-                        .help("Print timestamp (unix time + microseconds as in gettimeofday) before each line"),
+                        .help(
+                            "Print timestamp (unix time + microseconds as in gettimeofday) before \
+                             each line",
+                        ),
                 )
                 .arg(
                     Arg::with_name("timeout")
@@ -286,20 +295,17 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("logs")
                 .about("Stream transaction logs")
-                .arg(
-                    pubkey!(Arg::with_name("address")
-                        .index(1)
-                        .value_name("ADDRESS"),
-                        "Account address to monitor \
-                         [default: monitor all transactions except for votes] \
-                        ")
-                )
+                .arg(pubkey!(
+                    Arg::with_name("address").index(1).value_name("ADDRESS"),
+                    "Account address to monitor [default: monitor all transactions except for \
+                     votes] "
+                ))
                 .arg(
                     Arg::with_name("include_votes")
                         .long("include-votes")
                         .takes_value(false)
                         .conflicts_with("address")
-                        .help("Include vote transactions when monitoring all transactions")
+                        .help("Include vote transactions when monitoring all transactions"),
                 ),
         )
         .subcommand(
@@ -316,13 +322,16 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("slot_limit")
                         .long("slot-limit")
                         .takes_value(true)
-                        .help("Limit results to this many slots from the end of the epoch [default: full epoch]"),
+                        .help(
+                            "Limit results to this many slots from the end of the epoch [default: \
+                             full epoch]",
+                        ),
                 ),
         )
         .subcommand(
             SubCommand::with_name("gossip")
                 .about("Show the current gossip network nodes")
-                .alias("show-gossip")
+                .alias("show-gossip"),
         )
         .subcommand(
             SubCommand::with_name("stakes")
@@ -333,19 +342,19 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(false)
                         .help("Display balance in lamports instead of SOL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkeys")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkeys")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .multiple(true),
-                        "Only show stake accounts delegated to the provided vote accounts. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("withdraw_authority")
-                    .value_name("PUBKEY")
-                    .long("withdraw-authority"),
-                    "Only show stake accounts with the provided withdraw authority. "),
-                ),
+                    "Only show stake accounts delegated to the provided vote accounts. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("withdraw_authority")
+                        .value_name("PUBKEY")
+                        .long("withdraw-authority"),
+                    "Only show stake accounts with the provided withdraw authority. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("validators")
@@ -394,7 +403,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("keep_unstaked_delinquents")
                         .long("keep-unstaked-delinquents")
                         .takes_value(false)
-                        .help("Don't discard unstaked, delinquent validators")
+                        .help("Don't discard unstaked, delinquent validators"),
                 )
                 .arg(
                     Arg::with_name("delinquent_slot_distance")
@@ -402,25 +411,27 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("SLOT_DISTANCE")
                         .validator(is_slot)
-                        .help(
-                            concatcp!(
-                                "Minimum slot distance from the tip to consider a validator delinquent. [default: ",
-                                DELINQUENT_VALIDATOR_SLOT_DISTANCE,
-                                "]",
-                        ))
+                        .help(concatcp!(
+                            "Minimum slot distance from the tip to consider a validator \
+                             delinquent. [default: ",
+                            DELINQUENT_VALIDATOR_SLOT_DISTANCE,
+                            "]",
+                        )),
                 ),
         )
         .subcommand(
             SubCommand::with_name("transaction-history")
-                .about("Show historical transactions affecting the given address \
-                        from newest to oldest")
-                .arg(
-                    pubkey!(Arg::with_name("address")
+                .about(
+                    "Show historical transactions affecting the given address from newest to \
+                     oldest",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("address")
                         .index(1)
                         .value_name("ADDRESS")
                         .required(true),
-                        "Account address"),
-                )
+                    "Account address"
+                ))
                 .arg(
                     Arg::with_name("limit")
                         .long("limit")
@@ -442,18 +453,22 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("until")
                         .value_name("TRANSACTION_SIGNATURE")
                         .takes_value(true)
-                        .help("List until this transaction signature, if found before limit reached"),
+                        .help(
+                            "List until this transaction signature, if found before limit reached",
+                        ),
                 )
                 .arg(
                     Arg::with_name("show_transactions")
                         .long("show-transactions")
                         .takes_value(false)
                         .help("Display the full transactions"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("wait-for-max-stake")
-                .about("Wait for the max stake of any one node to drop below a percentage of total.")
+                .about(
+                    "Wait for the max stake of any one node to drop below a percentage of total.",
+                )
                 .arg(
                     Arg::with_name("max_percent")
                         .long("max-percent")
@@ -475,7 +490,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
-                        .help("Length of data field in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
+                        .help(
+                            "Length of data field in the account to calculate rent for, or \
+                             moniker: [nonce, stake, system, vote]",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -502,8 +520,8 @@ pub fn parse_catchup(
     // requirement of node_pubkey is relaxed only if our_localhost_port
     if our_localhost_port.is_none() && node_pubkey.is_none() {
         return Err(CliError::BadParameter(
-            "OUR_VALIDATOR_PUBKEY (and possibly OUR_URL) must be specified \
-             unless --our-localhost is given"
+            "OUR_VALIDATOR_PUBKEY (and possibly OUR_URL) must be specified unless --our-localhost \
+             is given"
                 .into(),
         ));
     }
@@ -737,8 +755,7 @@ pub fn process_catchup(
         if node_json_rpc_url.is_some() && node_json_rpc_url != gussed_default {
             // go to new line to leave this message on console
             println!(
-                "Prefering explicitly given rpc ({}) as us, \
-                 although --our-localhost is given\n",
+                "Prefering explicitly given rpc ({}) as us, although --our-localhost is given\n",
                 node_json_rpc_url.as_ref().unwrap()
             );
         } else {
@@ -754,8 +771,8 @@ pub fn process_catchup(
             (if node_pubkey.is_some() && node_pubkey != guessed_default {
                 // go to new line to leave this message on console
                 println!(
-                    "Prefering explicitly given node pubkey ({}) as us, \
-                     although --our-localhost is given\n",
+                    "Prefering explicitly given node pubkey ({}) as us, although --our-localhost \
+                     is given\n",
                     node_pubkey.unwrap()
                 );
                 node_pubkey
@@ -807,13 +824,18 @@ pub fn process_catchup(
 
     if reported_node_pubkey != node_pubkey {
         return Err(format!(
-            "The identity reported by node RPC URL does not match.  Expected: {node_pubkey:?}.  Reported: {reported_node_pubkey:?}"
+            "The identity reported by node RPC URL does not match.  Expected: {node_pubkey:?}.  \
+             Reported: {reported_node_pubkey:?}"
         )
         .into());
     }
 
     if rpc_client.get_identity()? == node_pubkey {
-        return Err("Both RPC URLs reference the same node, unable to monitor for catchup.  Try a different --url".into());
+        return Err(
+            "Both RPC URLs reference the same node, unable to monitor for catchup.  Try a \
+             different --url"
+                .into(),
+        );
     }
 
     let mut previous_rpc_slot = std::u64::MAX;
@@ -1213,44 +1235,45 @@ pub fn process_show_block_production(
         CliError::RpcRequestError("Failed to deserialize slot history".to_string())
     })?;
 
-    let (confirmed_blocks, start_slot) = if start_slot >= slot_history.oldest()
-        && end_slot <= slot_history.newest()
-    {
-        // Fast, more reliable path using the SlotHistory sysvar
+    let (confirmed_blocks, start_slot) =
+        if start_slot >= slot_history.oldest() && end_slot <= slot_history.newest() {
+            // Fast, more reliable path using the SlotHistory sysvar
 
-        let confirmed_blocks: Vec<_> = (start_slot..=end_slot)
-            .filter(|slot| slot_history.check(*slot) == slot_history::Check::Found)
-            .collect();
-        (confirmed_blocks, start_slot)
-    } else {
-        // Slow, less reliable path using `getBlocks`.
-        //
-        // "less reliable" because if the RPC node has holds in its ledger then the block production data will be
-        // incorrect.  This condition currently can't be detected over RPC
-        //
+            let confirmed_blocks: Vec<_> = (start_slot..=end_slot)
+                .filter(|slot| slot_history.check(*slot) == slot_history::Check::Found)
+                .collect();
+            (confirmed_blocks, start_slot)
+        } else {
+            // Slow, less reliable path using `getBlocks`.
+            //
+            // "less reliable" because if the RPC node has holds in its ledger then the block production data will be
+            // incorrect.  This condition currently can't be detected over RPC
+            //
 
-        let minimum_ledger_slot = rpc_client.minimum_ledger_slot()?;
-        if minimum_ledger_slot > end_slot {
-            return Err(format!(
-                    "Ledger data not available for slots {start_slot} to {end_slot} (minimum ledger slot is {minimum_ledger_slot})"
+            let minimum_ledger_slot = rpc_client.minimum_ledger_slot()?;
+            if minimum_ledger_slot > end_slot {
+                return Err(format!(
+                    "Ledger data not available for slots {start_slot} to {end_slot} (minimum \
+                     ledger slot is {minimum_ledger_slot})"
                 )
                 .into());
-        }
+            }
 
-        if minimum_ledger_slot > start_slot {
-            progress_bar.println(format!(
+            if minimum_ledger_slot > start_slot {
+                progress_bar.println(format!(
                     "{}",
                     style(format!(
-                        "Note: Requested start slot was {start_slot} but minimum ledger slot is {minimum_ledger_slot}"
+                        "Note: Requested start slot was {start_slot} but minimum ledger slot is \
+                         {minimum_ledger_slot}"
                     ))
                     .italic(),
                 ));
-            start_slot = minimum_ledger_slot;
-        }
+                start_slot = minimum_ledger_slot;
+            }
 
-        let confirmed_blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
-        (confirmed_blocks, start_slot)
-    };
+            let confirmed_blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
+            (confirmed_blocks, start_slot)
+        };
 
     let start_slot_index = (start_slot - first_slot_in_epoch) as usize;
     let end_slot_index = (end_slot - first_slot_in_epoch) as usize;
@@ -1281,7 +1304,8 @@ pub fn process_show_block_production(
     }
 
     progress_bar.set_message(format!(
-        "Processing {total_slots} slots containing {total_blocks_produced} blocks and {total_slots_skipped} empty slots..."
+        "Processing {total_slots} slots containing {total_blocks_produced} blocks and \
+         {total_slots_skipped} empty slots..."
     ));
 
     let mut confirmed_blocks_index = 0;

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -240,7 +240,9 @@ impl fmt::Display for CliClusterSoftwareVersions {
             f,
             "{}",
             style(format!(
-                "{software_version_title:<max_software_version_len$}  {stake_percent_title:>max_stake_percent_len$}  {rpc_percent_title:>max_rpc_percent_len$}",
+                "{software_version_title:<max_software_version_len$}  \
+                 {stake_percent_title:>max_stake_percent_len$}  \
+                 {rpc_percent_title:>max_rpc_percent_len$}",
             ))
             .bold(),
         )?;
@@ -318,8 +320,12 @@ impl fmt::Display for CliClusterFeatureSets {
             writeln!(
                 f,
                 "\n{}",
-                style("To activate features the tool and cluster feature sets must match, select a tool version that matches the cluster")
-                    .bold())?;
+                style(
+                    "To activate features the tool and cluster feature sets must match, select a \
+                     tool version that matches the cluster"
+                )
+                .bold()
+            )?;
         } else {
             if !self.stake_allowed {
                 write!(
@@ -349,7 +355,10 @@ impl fmt::Display for CliClusterFeatureSets {
             f,
             "{}",
             style(format!(
-                "{software_versions_title:<max_software_versions_len$}  {feature_set_title:<max_feature_set_len$}  {stake_percent_title:>max_stake_percent_len$}  {rpc_percent_title:>max_rpc_percent_len$}",
+                "{software_versions_title:<max_software_versions_len$}  \
+                 {feature_set_title:<max_feature_set_len$}  \
+                 {stake_percent_title:>max_stake_percent_len$}  \
+                 {rpc_percent_title:>max_rpc_percent_len$}",
             ))
             .bold(),
         )?;
@@ -402,8 +411,8 @@ fn check_rpc_genesis_hash(
         if rpc_genesis_hash != genesis_hash {
             return Err(format!(
                 "The genesis hash for the specified cluster {cluster_type:?} does not match the \
-                genesis hash reported by the specified RPC. Cluster genesis hash: {genesis_hash}, \
-                RPC reported genesis hash: {rpc_genesis_hash}"
+                 genesis hash reported by the specified RPC. Cluster genesis hash: \
+                 {genesis_hash}, RPC reported genesis hash: {rpc_genesis_hash}"
             )
             .into());
         }
@@ -927,11 +936,17 @@ fn process_activate(
 
     if !feature_activation_allowed(rpc_client, false)?.0 {
         match force {
-        ForceActivation::Almost =>
-            return Err("Add force argument once more to override the sanity check to force feature activation ".into()),
-        ForceActivation::Yes => println!("FEATURE ACTIVATION FORCED"),
-        ForceActivation::No =>
-            return Err("Feature activation is not allowed at this time".into()),
+            ForceActivation::Almost => {
+                return Err(
+                    "Add force argument once more to override the sanity check to force feature \
+                     activation "
+                        .into(),
+                )
+            }
+            ForceActivation::Yes => println!("FEATURE ACTIVATION FORCED"),
+            ForceActivation::No => {
+                return Err("Feature activation is not allowed at this time".into())
+            }
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,8 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
             let config_file = match matches.value_of("config_file") {
                 None => {
                     println!(
-                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                        "{} Either provide the `--config` arg or ensure home directory exists to \
+                         use the default config location",
                         style("No config file found.").bold()
                     );
                     return Ok(false);

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -48,20 +48,20 @@ impl NonceSubCommands for App<'_, '_> {
         self.subcommand(
             SubCommand::with_name("authorize-nonce-account")
                 .about("Assign account authority to a new entity")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_authority")
+                    "Address of the nonce account. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_authority")
                         .index(2)
                         .value_name("AUTHORITY_PUBKEY")
                         .required(true),
-                        "Account to be granted authority of the nonce account. "),
-                )
+                    "Account to be granted authority of the nonce account. "
+                ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -85,20 +85,26 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount_or_all)
-                        .help("The amount to load the nonce account with, in SOL; accepts keyword ALL"),
+                        .help(
+                            "The amount to load the nonce account with, in SOL; accepts keyword \
+                             ALL",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name(NONCE_AUTHORITY_ARG.name)
+                .arg(pubkey!(
+                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
                         .value_name("PUBKEY"),
-                        "Assign noncing authority to another entity. "),
-                )
+                    "Assign noncing authority to another entity. "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the NONCE_ACCOUNT pubkey",
+                        ),
                 )
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -107,24 +113,24 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("nonce")
                 .about("Get the current nonce value")
                 .alias("get-nonce")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account to display. "),
-                ),
+                    "Address of the nonce account to display. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("new-nonce")
                 .about("Generate a new nonce, rendering the existing nonce useless")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account. "),
-                )
+                    "Address of the nonce account. "
+                ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -133,13 +139,13 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("nonce-account")
                 .about("Show the contents of a nonce account")
                 .alias("show-nonce-account")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account to display. "),
-                )
+                    "Address of the nonce account to display. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -150,20 +156,20 @@ impl NonceSubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("withdraw-from-nonce-account")
                 .about("Withdraw SOL from the nonce account")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Nonce account to withdraw from. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Nonce account to withdraw from. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The account to which the SOL should be transferred. "),
-                )
+                    "The account to which the SOL should be transferred. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -179,15 +185,17 @@ impl NonceSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("upgrade-nonce-account")
-                .about("One-time idempotent upgrade of legacy nonce versions \
-                        in order to bump them out of chain blockhash domain.")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .about(
+                    "One-time idempotent upgrade of legacy nonce versions in order to bump them \
+                     out of chain blockhash domain.",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Nonce account to upgrade. "),
-                )
+                    "Nonce account to upgrade. "
+                ))
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
         )
@@ -502,7 +510,8 @@ pub fn process_create_nonce_account(
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(State::size())?;
     if lamports < minimum_balance {
         return Err(CliError::BadParameter(format!(
-            "need at least {minimum_balance} lamports for nonce account to be rent exempt, provided lamports: {lamports}"
+            "need at least {minimum_balance} lamports for nonce account to be rent exempt, \
+             provided lamports: {lamports}"
         ))
         .into());
     }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -63,10 +63,10 @@ use {
     },
 };
 
-pub const CLOSE_PROGRAM_WARNING: &str = "WARNING! \
-Closed programs cannot be recreated at the same program id. \
-Once a program is closed, it can never be invoked again. \
-To proceed with closing, rerun the `close` command with the `--bypass-warning` flag";
+pub const CLOSE_PROGRAM_WARNING: &str = "WARNING! Closed programs cannot be recreated at the same \
+                                         program id. Once a program is closed, it can never be \
+                                         invoked again. To proceed with closing, rerun the \
+                                         `close` command with the `--bypass-warning` flag";
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ProgramCliCommand {
@@ -145,7 +145,7 @@ impl ProgramSubCommands for App<'_, '_> {
                         .long("skip-fee-check")
                         .hidden(hidden_unless_forced())
                         .takes_value(false)
-                        .global(true)
+                        .global(true),
                 )
                 .subcommand(
                     SubCommand::with_name("deploy")
@@ -163,8 +163,10 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Intermediate buffer account to write data to, which can be used to resume a failed deploy \
-                                      [default: random address]")
+                                .help(
+                                    "Intermediate buffer account to write data to, which can be \
+                                     used to resume a failed deploy [default: random address]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("upgrade_authority")
@@ -172,19 +174,22 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("UPGRADE_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade authority [default: the default configured keypair]",
+                                ),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("program_id")
+                        .arg(pubkey!(
+                            Arg::with_name("program_id")
                                 .long("program-id")
                                 .value_name("PROGRAM_ID"),
-                                "Executable program's address, must be a keypair for initial deploys, can be a pubkey for upgrades \
-                                [default: address of keypair at /path/to/program-keypair.json if present, otherwise a random address]"),
-                        )
+                            "Executable program's address, must be a keypair for initial deploys, \
+                             can be a pubkey for upgrades [default: address of keypair at \
+                             /path/to/program-keypair.json if present, otherwise a random address]"
+                        ))
                         .arg(
                             Arg::with_name("final")
                                 .long("final")
-                                .help("The program will not be upgradeable")
+                                .help("The program will not be upgradeable"),
                         )
                         .arg(
                             Arg::with_name("max_len")
@@ -192,14 +197,19 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("max_len")
                                 .takes_value(true)
                                 .required(false)
-                                .help("Maximum length of the upgradeable program \
-                                      [default: twice the length of the original deployed program]")
+                                .help(
+                                    "Maximum length of the upgradeable program [default: twice \
+                                     the length of the original deployed program]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("allow_excessive_balance")
                                 .long("allow-excessive-deploy-account-balance")
                                 .takes_value(false)
-                                .help("Use the designated program id even if the account already holds a large balance of SOL")
+                                .help(
+                                    "Use the designated program id even if the account already \
+                                     holds a large balance of SOL",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -219,7 +229,9 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer account to write data into [default: random address]")
+                                .help(
+                                    "Buffer account to write data into [default: random address]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("buffer_authority")
@@ -227,7 +239,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer authority [default: the default configured keypair]")
+                                .help("Buffer authority [default: the default configured keypair]"),
                         )
                         .arg(
                             Arg::with_name("max_len")
@@ -235,8 +247,10 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("max_len")
                                 .takes_value(true)
                                 .required(false)
-                                .help("Maximum length of the upgradeable program \
-                                      [default: twice the length of the original deployed program]")
+                                .help(
+                                    "Maximum length of the upgradeable program [default: twice \
+                                     the length of the original deployed program]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -248,7 +262,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_PUBKEY")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Public key of the buffer")
+                                .help("Public key of the buffer"),
                         )
                         .arg(
                             Arg::with_name("buffer_authority")
@@ -256,15 +270,15 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer authority [default: the default configured keypair]")
+                                .help("Buffer authority [default: the default configured keypair]"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("new_buffer_authority")
+                        .arg(pubkey!(
+                            Arg::with_name("new_buffer_authority")
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
                                 .required(true),
-                                "Address of the new buffer authority"),
-                        )
+                            "Address of the new buffer authority"
+                        )),
                 )
                 .subcommand(
                     SubCommand::with_name("set-upgrade-authority")
@@ -275,7 +289,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the program to upgrade")
+                                .help("Address of the program to upgrade"),
                         )
                         .arg(
                             Arg::with_name("upgrade_authority")
@@ -283,7 +297,9 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("UPGRADE_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade authority [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("new_upgrade_authority")
@@ -291,21 +307,32 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("NEW_UPGRADE_AUTHORITY")
                                 .required_unless("final")
                                 .takes_value(true)
-                                .help("New upgrade authority (keypair or pubkey). It is strongly recommended to pass in a keypair to prevent mistakes in setting the upgrade authority. You can opt out of this behavior by passing --skip-new-upgrade-authority-signer-check if you are really confident that you are setting the correct authority. Alternatively, If you wish to make the program immutable, you should ignore this arg and pass the --final flag."
-                        )
+                                .help(
+                                    "New upgrade authority (keypair or pubkey). It is strongly \
+                                     recommended to pass in a keypair to prevent mistakes in \
+                                     setting the upgrade authority. You can opt out of this \
+                                     behavior by passing \
+                                     --skip-new-upgrade-authority-signer-check if you are really \
+                                     confident that you are setting the correct authority. \
+                                     Alternatively, If you wish to make the program immutable, \
+                                     you should ignore this arg and pass the --final flag.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("final")
                                 .long("final")
                                 .conflicts_with("new_upgrade_authority")
-                                .help("The program will not be upgradeable")
+                                .help("The program will not be upgradeable"),
                         )
                         .arg(
                             Arg::with_name("skip_new_upgrade_authority_signer_check")
                                 .long("skip-new-upgrade-authority-signer-check")
                                 .requires("new_upgrade_authority")
                                 .takes_value(false)
-                                .help("Set this flag if you don't want the new authority to sign the set-upgrade-authority transaction."),
+                                .help(
+                                    "Set this flag if you don't want the new authority to sign \
+                                     the set-upgrade-authority transaction.",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -316,7 +343,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the buffer or program to show")
+                                .help("Address of the buffer or program to show"),
                         )
                         .arg(
                             Arg::with_name("programs")
@@ -324,7 +351,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .conflicts_with("account")
                                 .conflicts_with("buffers")
                                 .required_unless_one(&["account", "buffers"])
-                                .help("Show every upgradeable program that matches the authority")
+                                .help("Show every upgradeable program that matches the authority"),
                         )
                         .arg(
                             Arg::with_name("buffers")
@@ -332,22 +359,22 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .conflicts_with("account")
                                 .conflicts_with("programs")
                                 .required_unless_one(&["account", "programs"])
-                                .help("Show every upgradeable buffer that matches the authority")
+                                .help("Show every upgradeable buffer that matches the authority"),
                         )
                         .arg(
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
                                 .conflicts_with("buffer_authority")
-                                .help("Show accounts for all authorities")
+                                .help("Show accounts for all authorities"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("buffer_authority")
+                        .arg(pubkey!(
+                            Arg::with_name("buffer_authority")
                                 .long("buffer-authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                                "Authority [default: the default configured keypair]"),
-                        )
+                            "Authority [default: the default configured keypair]"
+                        ))
                         .arg(
                             Arg::with_name("lamports")
                                 .long("lamports")
@@ -364,7 +391,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the buffer or program")
+                                .help("Address of the buffer or program"),
                         )
                         .arg(
                             Arg::with_name("output_location")
@@ -390,7 +417,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("buffers")
                                 .conflicts_with("account")
                                 .required_unless("account")
-                                .help("Close all buffer accounts that match the authority")
+                                .help("Close all buffer accounts that match the authority"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -399,15 +426,18 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade or buffer authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade or buffer authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
-
-                        .arg(
-                            pubkey!(Arg::with_name("recipient_account")
+                        .arg(pubkey!(
+                            Arg::with_name("recipient_account")
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
-                                "Address of the account to deposit the closed account's lamports [default: the default configured keypair]"),
-                        )
+                            "Address of the account to deposit the closed account's lamports \
+                             [default: the default configured keypair]"
+                        ))
                         .arg(
                             Arg::with_name("lamports")
                                 .long("lamports")
@@ -423,7 +453,9 @@ impl ProgramSubCommands for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("extend")
-                        .about("Extend the length of an upgradeable program to deploy larger programs")
+                        .about(
+                            "Extend the length of an upgradeable program to deploy larger programs",
+                        )
                         .arg(
                             Arg::with_name("program_id")
                                 .index(1)
@@ -440,14 +472,20 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_parsable::<u32>)
-                                .help("Number of bytes that will be allocated for the program's data account")
-                        )
-                )
+                                .help(
+                                    "Number of bytes that will be allocated for the program's \
+                                     data account",
+                                ),
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("Deploy has been removed. Use `solana program deploy` instead to deploy upgradeable programs")
-                .setting(AppSettings::Hidden)
+                .about(
+                    "Deploy has been removed. Use `solana program deploy` instead to deploy \
+                     upgradeable programs",
+                )
+                .setting(AppSettings::Hidden),
         )
     }
 }
@@ -1381,7 +1419,8 @@ fn get_programs(
             let results = get_accounts_with_filter(rpc_client, filters, 0)?;
             if results.len() != 1 {
                 return Err(format!(
-                    "Error: More than one Program associated with ProgramData account {programdata_address}"
+                    "Error: More than one Program associated with ProgramData account \
+                     {programdata_address}"
                 )
                 .into());
             }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -114,7 +114,10 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program account signer. The program data is written to the associated account.")
+                                .help(
+                                    "Program account signer. The program data is written to the \
+                                     associated account.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -122,7 +125,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -140,7 +145,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("buffer")
@@ -148,7 +153,10 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Optional intermediate buffer account to write data to, which can be used to resume a failed deploy")
+                                .help(
+                                    "Optional intermediate buffer account to write data to, which \
+                                     can be used to resume a failed deploy",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -156,7 +164,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -167,7 +177,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -175,7 +185,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -186,7 +198,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -194,7 +206,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -205,22 +219,22 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the program to show")
+                                .help("Address of the program to show"),
                         )
                         .arg(
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
                                 .conflicts_with("buffer_authority")
-                                .help("Show accounts for all authorities")
+                                .help("Show accounts for all authorities"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("authority")
+                        .arg(pubkey!(
+                            Arg::with_name("authority")
                                 .long("authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                                "Authority [default: the default configured keypair]"),
-                        ),
+                            "Authority [default: the default configured keypair]"
+                        )),
                 )
                 .subcommand(
                     SubCommand::with_name("dump")
@@ -231,7 +245,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the buffer or program")
+                                .help("Address of the buffer or program"),
                         )
                         .arg(
                             Arg::with_name("output_location")
@@ -241,7 +255,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .required(true)
                                 .help("/path/to/program.so"),
                         ),
-                )
+                ),
         )
     }
 }
@@ -955,7 +969,11 @@ fn build_create_buffer_message(
 
         if account.lamports < lamports_required || account.data.len() != expected_account_data_len {
             if program_address == buffer_address {
-                return Err("Buffer account passed could be for a different deploy? It has different size/lamports".into());
+                return Err(
+                    "Buffer account passed could be for a different deploy? It has different \
+                     size/lamports"
+                        .into(),
+                );
             }
 
             let (truncate_instructions, balance_needed) = build_truncate_instructions(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -144,7 +144,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create (or base of derived address if --seed is used)")
+                        .help(
+                            "Stake account to create (or base of derived address if --seed is \
+                             used)",
+                        ),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -153,28 +156,35 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to send to the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("custodian")
+                .arg(pubkey!(
+                    Arg::with_name("custodian")
                         .long("custodian")
                         .value_name("PUBKEY"),
-                        "Authority to modify lockups. ")
-                )
+                    "Authority to modify lockups. "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -182,7 +192,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name(STAKE_AUTHORITY_ARG.name)
@@ -190,7 +203,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(STAKE_AUTHORITY_ARG.help)
+                        .help(STAKE_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
@@ -198,7 +211,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(WITHDRAW_AUTHORITY_ARG.help)
+                        .help(WITHDRAW_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name("from")
@@ -212,7 +225,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("create-stake-account-checked")
@@ -224,7 +237,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create (or base of derived address if --seed is used)")
+                        .help(
+                            "Stake account to create (or base of derived address if --seed is \
+                             used)",
+                        ),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -233,15 +249,19 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to send to the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey",
+                        ),
                 )
                 .arg(
                     Arg::with_name(STAKE_AUTHORITY_ARG.name)
@@ -249,7 +269,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(STAKE_AUTHORITY_ARG.help)
+                        .help(STAKE_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
@@ -257,7 +277,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .help(WITHDRAW_AUTHORITY_ARG.help)
+                        .help(WITHDRAW_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name("from")
@@ -271,7 +291,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("delegate-stake")
@@ -281,28 +301,28 @@ impl StakeSubCommands for App<'_, '_> {
                         .long("force")
                         .takes_value(false)
                         .hidden(hidden_unless_forced()) // Don't document this argument to discourage its use
-                        .help("Override vote account sanity checks (use carefully!)")
+                        .help("Override vote account sanity checks (use carefully!)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to delegate")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                    "Stake account to delegate"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The vote account to which the stake will be delegated")
-                )
+                    "The vote account to which the stake will be delegated"
+                ))
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("redelegate-stake")
@@ -312,24 +332,24 @@ impl StakeSubCommands for App<'_, '_> {
                         .long("force")
                         .takes_value(false)
                         .hidden(hidden_unless_forced()) // Don't document this argument to discourage its use
-                        .help("Override vote account sanity checks (use carefully!)")
+                        .help("Override vote account sanity checks (use carefully!)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Existing delegated stake account that has been fully activated. \
-                        On success this stake account will be scheduled for deactivation and the rent-exempt balance \
-                        may be withdrawn once fully deactivated")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                    "Existing delegated stake account that has been fully activated. On success \
+                     this stake account will be scheduled for deactivation and the rent-exempt \
+                     balance may be withdrawn once fully deactivated"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("REDELEGATED_VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The vote account to which the stake will be redelegated")
-                )
+                    "The vote account to which the stake will be redelegated"
+                ))
                 .arg(
                     Arg::with_name("redelegation_stake_account")
                         .index(3)
@@ -337,42 +357,43 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create for the redelegation. \
-                               On success this stake account will be created and scheduled for activation with all \
-                               the stake in the existing stake account, exclusive of the rent-exempt balance retained \
-                               in the existing account")
+                        .help(
+                            "Stake account to create for the redelegation. On success this stake \
+                             account will be created and scheduled for activation with all the \
+                             stake in the existing stake account, exclusive of the rent-exempt \
+                             balance retained in the existing account",
+                        ),
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
-                .arg(memo_arg())
+                .arg(memo_arg()),
         )
-
         .subcommand(
             SubCommand::with_name("stake-authorize")
                 .about("Authorize a new signing keypair for the given stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                        "Stake account in which to set a new authority. ")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_stake_authority")
+                    "Stake account in which to set a new authority. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
                         .required_unless("new_withdraw_authority")
                         .value_name("PUBKEY"),
-                        "New authorized staker")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_withdraw_authority")
+                    "New authorized staker"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_withdraw_authority")
                         .long("new-withdraw-authority")
                         .required_unless("new_stake_authority")
                         .value_name("PUBKEY"),
-                        "New authorized withdrawer. ")
-                )
+                    "New authorized withdrawer. "
+                ))
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
                 .offline_args()
@@ -383,21 +404,27 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-authorize-checked")
-                .about("Authorize a new signing keypair for the given stake account, checking the authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .about(
+                    "Authorize a new signing keypair for the given stake account, checking the \
+                     authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                        "Stake account in which to set a new authority. ")
-                )
+                    "Stake account in which to set a new authority. "
+                ))
                 .arg(
                     Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
@@ -405,7 +432,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .required_unless("new_withdraw_authority")
-                        .help("New authorized staker")
+                        .help("New authorized staker"),
                 )
                 .arg(
                     Arg::with_name("new_withdraw_authority")
@@ -414,7 +441,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .required_unless("new_stake_authority")
-                        .help("New authorized withdrawer")
+                        .help("New authorized withdrawer"),
                 )
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
@@ -426,53 +453,62 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("deactivate-stake")
                 .about("Deactivate the delegated stake from the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to be deactivated (or base of derived address if --seed is used). ")
-                )
+                    "Stake account to be deactivated (or base of derived address if --seed is \
+                     used). "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of STAKE_ACCOUNT_ADDRESS")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of STAKE_ACCOUNT_ADDRESS",
+                        ),
                 )
                 .arg(
                     Arg::with_name("delinquent")
                         .long("delinquent")
                         .takes_value(false)
                         .conflicts_with(SIGN_ONLY_ARG.name)
-                        .help("Deactivate abandoned stake that is currently delegated to a delinquent vote account")
+                        .help(
+                            "Deactivate abandoned stake that is currently delegated to a \
+                             delinquent vote account",
+                        ),
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("split-stake")
                 .about("Duplicate a stake account, splitting the tokens between the two")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to split (or base of derived address if --seed is used). ")
-                )
+                    "Stake account to split (or base of derived address if --seed is used). "
+                ))
                 .arg(
                     Arg::with_name("split_stake_account")
                         .index(2)
@@ -480,7 +516,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Keypair of the new stake account")
+                        .help("Keypair of the new stake account"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -489,18 +525,20 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
-                        .help("The amount to move into the new stake account, in SOL")
+                        .help("The amount to move into the new stake account, in SOL"),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of SPLIT_STAKE_ACCOUNT")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of SPLIT_STAKE_ACCOUNT",
+                        ),
                 )
                 .arg(stake_authority_arg())
-                .offline_args_config(&SignOnlySplitNeedsRent{})
+                .offline_args_config(&SignOnlySplitNeedsRent {})
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
@@ -512,52 +550,55 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .requires("sign_only")
-                        .help("Offline signing only: the rent-exempt amount to move into the new \
-                                stake account, in SOL")
-                )
+                        .help(
+                            "Offline signing only: the rent-exempt amount to move into the new \
+                             stake account, in SOL",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("merge-stake")
                 .about("Merges one stake account into another")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to merge into")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("source_stake_account_pubkey")
+                    "Stake account to merge into"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("source_stake_account_pubkey")
                         .index(2)
                         .value_name("SOURCE_STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Source stake account for the merge.  If successful, this stake account \
-                         will no longer exist after the merge")
-                )
+                    "Source stake account for the merge.  If successful, this stake account will \
+                     no longer exist after the merge"
+                ))
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")
                 .about("Withdraw the unstaked SOL from the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account from which to withdraw (or base of derived address if --seed is used). ")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Stake account from which to withdraw (or base of derived address if --seed \
+                     is used). "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "Recipient of withdrawn SOL")
-                )
+                    "Recipient of withdrawn SOL"
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -565,15 +606,20 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to withdraw from the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to withdraw from the stake account, in SOL; accepts \
+                             keyword ALL",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of STAKE_ACCOUNT_ADDRESS")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of STAKE_ACCOUNT_ADDRESS",
+                        ),
                 )
                 .arg(withdraw_authority_arg())
                 .offline_args()
@@ -581,24 +627,27 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
                 .arg(custodian_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-set-lockup")
                 .about("Set Lockup for the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account for which to set lockup parameters. ")
-                )
+                    "Stake account for which to set lockup parameters. "
+                ))
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -606,48 +655,56 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_custodian")
+                .arg(pubkey!(
+                    Arg::with_name("new_custodian")
                         .long("new-custodian")
                         .value_name("PUBKEY"),
-                        "Identity of a new lockup custodian. ")
+                    "Identity of a new lockup custodian. "
+                ))
+                .group(
+                    ArgGroup::with_name("lockup_details")
+                        .args(&["lockup_epoch", "lockup_date", "new_custodian"])
+                        .multiple(true)
+                        .required(true),
                 )
-                .group(ArgGroup::with_name("lockup_details")
-                    .args(&["lockup_epoch", "lockup_date", "new_custodian"])
-                    .multiple(true)
-                    .required(true))
                 .arg(
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Keypair of the existing custodian [default: cli config pubkey]")
+                        .help("Keypair of the existing custodian [default: cli config pubkey]"),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-set-lockup-checked")
                 .about("Set Lockup for the stake account, checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account for which to set lockup parameters. ")
-                )
+                    "Stake account for which to set lockup parameters. "
+                ))
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -655,7 +712,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("new_custodian")
@@ -663,42 +723,44 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .help("Keypair of a new lockup custodian")
+                        .help("Keypair of a new lockup custodian"),
                 )
-                .group(ArgGroup::with_name("lockup_details")
-                    .args(&["lockup_epoch", "lockup_date", "new_custodian"])
-                    .multiple(true)
-                    .required(true))
+                .group(
+                    ArgGroup::with_name("lockup_details")
+                        .args(&["lockup_epoch", "lockup_date", "new_custodian"])
+                        .multiple(true)
+                        .required(true),
+                )
                 .arg(
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Keypair of the existing custodian [default: cli config pubkey]")
+                        .help("Keypair of the existing custodian [default: cli config pubkey]"),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-account")
                 .about("Show the contents of a stake account")
                 .alias("show-stake-account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The stake account to display. ")
-                )
+                    "The stake account to display. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL")
+                        .help("Display balance in lamports instead of SOL"),
                 )
                 .arg(
                     Arg::with_name("with_rewards")
@@ -710,7 +772,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("csv")
                         .long("csv")
                         .takes_value(false)
-                        .help("Format stake rewards data in csv")
+                        .help("Format stake rewards data in csv"),
                 )
                 .arg(
                     Arg::with_name("num_rewards_epochs")
@@ -720,7 +782,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
-                        .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
+                        .help(
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
+                        ),
                 ),
         )
         .subcommand(
@@ -731,7 +796,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL")
+                        .help("Display balance in lamports instead of SOL"),
                 )
                 .arg(
                     Arg::with_name("limit")
@@ -739,13 +804,12 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("NUM")
                         .default_value("10")
-                        .validator(|s| {
-                            s.parse::<usize>()
-                                .map(|_| ())
-                                .map_err(|e| e.to_string())
-                        })
-                        .help("Display NUM recent epochs worth of stake history in text mode. 0 for all")
-                )
+                        .validator(|s| s.parse::<usize>().map(|_| ()).map_err(|e| e.to_string()))
+                        .help(
+                            "Display NUM recent epochs worth of stake history in text mode. 0 for \
+                             all",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("stake-minimum-delegation")
@@ -754,8 +818,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display minimum delegation in lamports instead of SOL")
-                )
+                        .help("Display minimum delegation in lamports instead of SOL"),
+                ),
         )
     }
 }
@@ -1456,7 +1520,8 @@ pub fn process_create_stake_account(
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, provided lamports: {lamports}"
+                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
+                 provided lamports: {lamports}"
             ))
             .into());
         }
@@ -1919,7 +1984,8 @@ pub fn process_split_stake(
                 format!("Stake account {split_stake_account_address} already exists")
             } else {
                 format!(
-                    "Account {split_stake_account_address} already exists and is not a stake account"
+                    "Account {split_stake_account_address} already exists and is not a stake \
+                     account"
                 )
             };
             return Err(CliError::BadParameter(err_msg).into());
@@ -1930,7 +1996,8 @@ pub fn process_split_stake(
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, provided lamports: {lamports}"
+                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
+                 provided lamports: {lamports}"
             ))
             .into());
         }
@@ -2359,7 +2426,8 @@ pub(crate) fn check_current_authority(
 ) -> Result<(), CliError> {
     if !permitted_authorities.contains(provided_current_authority) {
         Err(CliError::RpcRequestError(format!(
-            "Invalid authority provided: {provided_current_authority:?}, expected {permitted_authorities:?}"
+            "Invalid authority provided: {provided_current_authority:?}, expected \
+             {permitted_authorities:?}"
         )))
     } else {
         Ok(())
@@ -2622,8 +2690,8 @@ pub fn process_delegate_stake(
             ))
         } else {
             Err(CliError::DynamicProgramError(format!(
-                "Unable to delegate.  Vote account appears delinquent \
-                 because its current root slot, {root_slot}, is less than {min_root_slot}"
+                "Unable to delegate.  Vote account appears delinquent because its current root \
+                 slot, {root_slot}, is less than {min_root_slot}"
             )))
         };
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -88,7 +88,11 @@ fn verify_keybase(
         if client.head(&url).send()?.status().is_success() {
             Ok(())
         } else {
-            Err(format!("keybase_username could not be confirmed at: {url}. Please add this pubkey file to your keybase profile to connect").into())
+            Err(format!(
+                "keybase_username could not be confirmed at: {url}. Please add this pubkey file \
+                 to your keybase profile to connect"
+            )
+            .into())
         }
     } else {
         Err(format!("keybase_username could not be parsed as String: {keybase_username}").into())
@@ -204,7 +208,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
                                 .value_name("DETAILS")
                                 .takes_value(true)
                                 .validator(check_details_length)
-                                .help("Validator description")
+                                .help("Validator description"),
                         )
                         .arg(
                             Arg::with_name("force")
@@ -223,9 +227,12 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
                                 .value_name("PUBKEY")
                                 .takes_value(true)
                                 .validator(is_pubkey)
-                                .help("The pubkey of the Validator info account; without this argument, returns all"),
+                                .help(
+                                    "The pubkey of the Validator info account; without this \
+                                     argument, returns all",
+                                ),
                         ),
-                )
+                ),
         )
     }
 }
@@ -607,7 +614,12 @@ mod tests {
         let max_short_string =
             "Max Length String KWpP299aFCBWvWg1MHpSuaoTsud7cv8zMJsh99aAtP8X1s26yrR1".to_string();
         // 300-character string
-        let max_long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut libero quam, volutpat et aliquet eu, varius in mi. Aenean vestibulum ex in tristique faucibus. Maecenas in imperdiet turpis. Nullam feugiat aliquet erat. Morbi malesuada turpis sed dui pulvinar lobortis. Pellentesque a lectus eu leo nullam.".to_string();
+        let max_long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut libero \
+                               quam, volutpat et aliquet eu, varius in mi. Aenean vestibulum ex \
+                               in tristique faucibus. Maecenas in imperdiet turpis. Nullam \
+                               feugiat aliquet erat. Morbi malesuada turpis sed dui pulvinar \
+                               lobortis. Pellentesque a lectus eu leo nullam."
+            .to_string();
         let mut info = Map::new();
         info.insert("name".to_string(), Value::String(max_short_string.clone()));
         info.insert(

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -70,15 +70,15 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Keypair of validator that will vote with this account"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("authorized_withdrawer")
+                .arg(pubkey!(
+                    Arg::with_name("authorized_withdrawer")
                         .index(3)
                         .value_name("WITHDRAWER_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .long("authorized-withdrawer"),
-                        "Public key of the authorized withdrawer")
-                )
+                    "Public key of the authorized withdrawer"
+                ))
                 .arg(
                     Arg::with_name("commission")
                         .long("commission")
@@ -87,43 +87,48 @@ impl VoteSubCommands for App<'_, '_> {
                         .default_value("100")
                         .help("The commission taken on reward redemption (0-100)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("authorized_voter")
+                .arg(pubkey!(
+                    Arg::with_name("authorized_voter")
                         .long("authorized-voter")
                         .value_name("VOTER_PUBKEY"),
-                        "Public key of the authorized voter [default: validator identity pubkey]. "),
-                )
+                    "Public key of the authorized voter [default: validator identity pubkey]. "
+                ))
                 .arg(
                     Arg::with_name("allow_unsafe_authorized_withdrawer")
                         .long("allow-unsafe-authorized-withdrawer")
                         .takes_value(false)
-                        .help("Allow an authorized withdrawer pubkey to be identical to the validator identity \
-                               account pubkey or vote account pubkey, which is normally an unsafe \
-                               configuration and should be avoided."),
+                        .help(
+                            "Allow an authorized withdrawer pubkey to be identical to the \
+                             validator identity account pubkey or vote account pubkey, which is \
+                             normally an unsafe configuration and should be avoided.",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the VOTE ACCOUNT pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the VOTE ACCOUNT pubkey",
+                        ),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-voter")
                 .about("Authorize a new vote signing keypair for the given vote account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized voter. "),
-                )
+                    "Vote account in which to set the authorized voter. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -132,29 +137,29 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Current authorized vote signer."),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_authorized_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("new_authorized_pubkey")
                         .index(3)
                         .value_name("NEW_AUTHORIZED_PUBKEY")
                         .required(true),
-                        "New authorized vote signer. "),
-                )
+                    "New authorized vote signer. "
+                ))
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer")
                 .about("Authorize a new withdraw signing keypair for the given vote account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized withdrawer. "),
-                )
+                    "Vote account in which to set the authorized withdrawer. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -163,30 +168,32 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Current authorized withdrawer."),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_authorized_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("new_authorized_pubkey")
                         .index(3)
                         .value_name("AUTHORIZED_PUBKEY")
                         .required(true),
-                        "New authorized withdrawer. "),
-                )
+                    "New authorized withdrawer. "
+                ))
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-voter-checked")
-                .about("Authorize a new vote signing keypair for the given vote account, \
-                    checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .about(
+                    "Authorize a new vote signing keypair for the given vote account, checking \
+                     the new authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized voter. "),
-                )
+                    "Vote account in which to set the authorized voter. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -207,19 +214,21 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer-checked")
-                .about("Authorize a new withdraw signing keypair for the given vote account, \
-                    checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .about(
+                    "Authorize a new withdraw signing keypair for the given vote account, \
+                     checking the new authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized withdrawer. "),
-                )
+                    "Vote account in which to set the authorized withdrawer. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -240,18 +249,18 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-update-validator")
                 .about("Update the vote account's validator identity")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to update. "),
-                )
+                    "Vote account to update. "
+                ))
                 .arg(
                     Arg::with_name("new_identity_account")
                         .index(2)
@@ -274,18 +283,18 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-update-commission")
                 .about("Update the vote account's commission")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to update. "),
-                )
+                    "Vote account to update. "
+                ))
                 .arg(
                     Arg::with_name("commission")
                         .index(2)
@@ -293,7 +302,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_percentage)
-                        .help("The new commission")
+                        .help("The new commission"),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -308,19 +317,19 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-account")
                 .about("Show the contents of a vote account")
                 .alias("show-vote-account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account pubkey. "),
-                )
+                    "Vote account pubkey. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -347,26 +356,29 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
-                        .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
+                        .help(
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
+                        ),
                 ),
         )
         .subcommand(
             SubCommand::with_name("withdraw-from-vote-account")
                 .about("Withdraw lamports from a vote account into a specified account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account from which to withdraw. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Vote account from which to withdraw. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The recipient of withdrawn SOL. "),
-                )
+                    "The recipient of withdrawn SOL. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -374,7 +386,10 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount_or_all)
-                        .help("The amount to withdraw, in SOL; accepts keyword ALL, which for this command means account balance minus rent-exempt minimum"),
+                        .help(
+                            "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
+                             command means account balance minus rent-exempt minimum",
+                        ),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -388,26 +403,25 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg()
-            )
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("close-vote-account")
                 .about("Close a vote account and withdraw all funds remaining")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to be closed. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Vote account to be closed. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The recipient of all withdrawn SOL. "),
-                )
+                    "The recipient of all withdrawn SOL. "
+                ))
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
@@ -418,8 +432,7 @@ impl VoteSubCommands for App<'_, '_> {
                 )
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg()
-            )
+                .arg(compute_unit_price_arg()),
         )
     }
 }
@@ -451,15 +464,15 @@ pub fn parse_create_vote_account(
     if !allow_unsafe {
         if authorized_withdrawer == vote_account_pubkey.unwrap() {
             return Err(CliError::BadParameter(
-                "Authorized withdrawer pubkey is identical to vote \
-                                               account pubkey, an unsafe configuration"
+                "Authorized withdrawer pubkey is identical to vote account pubkey, an unsafe \
+                 configuration"
                     .to_owned(),
             ));
         }
         if authorized_withdrawer == identity_pubkey.unwrap() {
             return Err(CliError::BadParameter(
-                "Authorized withdrawer pubkey is identical to identity \
-                                               account pubkey, an unsafe configuration"
+                "Authorized withdrawer pubkey is identical to identity account pubkey, an unsafe \
+                 configuration"
                     .to_owned(),
             ));
         }
@@ -956,8 +969,10 @@ pub fn process_vote_authorize(
                 if let Some(signer) = new_authorized_signer {
                     if signer.is_interactive() {
                         return Err(CliError::BadParameter(format!(
-                            "invalid new authorized vote signer {new_authorized_pubkey:?}. Interactive vote signers not supported"
-                        )).into());
+                            "invalid new authorized vote signer {new_authorized_pubkey:?}. \
+                             Interactive vote signers not supported"
+                        ))
+                        .into());
                     }
                 }
             }
@@ -1337,7 +1352,9 @@ pub fn process_withdraw_from_vote_account(
             let balance_remaining = current_balance.saturating_sub(withdraw_amount);
             if balance_remaining < minimum_balance && balance_remaining != 0 {
                 return Err(CliError::BadParameter(format!(
-                    "Withdraw amount too large. The vote account balance must be at least {} SOL to remain rent exempt", lamports_to_sol(minimum_balance)
+                    "Withdraw amount too large. The vote account balance must be at least {} SOL \
+                     to remain rent exempt",
+                    lamports_to_sol(minimum_balance)
                 ))
                 .into());
             }

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -60,13 +60,13 @@ impl WalletSubCommands for App<'_, '_> {
             SubCommand::with_name("account")
                 .about("Show the contents of an account")
                 .alias("account")
-                .arg(
-                    pubkey!(Arg::with_name("account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("account_pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
                         .required(true),
-                        "Account key URI. ")
-                )
+                    "Account key URI. "
+                ))
                 .arg(
                     Arg::with_name("output_file")
                         .long("output-file")
@@ -104,22 +104,22 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The airdrop amount to request, in SOL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("to")
+                .arg(pubkey!(
+                    Arg::with_name("to")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS"),
-                        "The account address of airdrop recipient. "),
-                ),
+                    "The account address of airdrop recipient. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("balance")
                 .about("Get your balance")
-                .arg(
-                    pubkey!(Arg::with_name("pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS"),
-                        "The account address of the balance to check. ")
-                )
+                    "The account address of the balance to check. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -138,23 +138,19 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The transaction signature to confirm"),
                 )
-                .after_help(// Formatted specifically for the manually-indented heredoc string
-                   "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
-                  \n\
-                  \nAccount modes:\
-                  \n  |srwx|\
-                  \n    s: signed\
-                  \n    r: readable (always true)\
-                  \n    w: writable\
-                  \n    x: program account (inner instructions excluded)\
-                   "
+                .after_help(
+                    // Formatted specifically for the manually-indented heredoc string
+                    "Note: This will show more detailed information for finalized transactions \
+                     with verbose mode (-v/--verbose).\n\nAccount modes:\n  |srwx|\n    s: \
+                     signed\n    r: readable (always true)\n    w: writable\n    x: program \
+                     account (inner instructions excluded)",
                 ),
         )
         .subcommand(
             SubCommand::with_name("create-address-with-seed")
                 .about(
-                    "Generate a derived account address with a seed. \
-                    For program derived addresses (PDAs), use the find-program-derived-address command instead"
+                    "Generate a derived account address with a seed. For program derived \
+                     addresses (PDAs), use the find-program-derived-address command instead",
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -172,49 +168,48 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \n\
-                             or one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, \nor \
+                             one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("from")
+                .arg(pubkey!(
+                    Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_PUBKEY")
                         .required(false),
-                        "From (base) key, [default: cli config keypair]. "),
+                    "From (base) key, [default: cli config keypair]. "
+                )),
+        )
+        .subcommand(
+            SubCommand::with_name("find-program-derived-address")
+                .about("Generate a program derived account address with a seed")
+                .arg(
+                    Arg::with_name("program_id")
+                        .index(1)
+                        .value_name("PROGRAM_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help(
+                            "The program_id that the address will ultimately be used for, \nor \
+                             one of NONCE, STAKE, and VOTE keywords",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("seeds")
+                        .min_values(0)
+                        .value_name("SEED")
+                        .takes_value(true)
+                        .validator(is_structured_seed)
+                        .help(
+                            "The seeds. \nEach one must match the pattern PREFIX:VALUE. \nPREFIX \
+                             can be one of [string, pubkey, hex, u8] \nor matches the pattern \
+                             [u,i][16,32,64,128][le,be] (for example u64le) for number values \
+                             \n[u,i] - represents whether the number is unsigned or signed, \
+                             \n[16,32,64,128] - represents the bit length, and \n[le,be] - \
+                             represents the byte order - little endian or big endian",
+                        ),
                 ),
         )
-            .subcommand(
-                SubCommand::with_name("find-program-derived-address")
-                    .about("Generate a program derived account address with a seed")
-                    .arg(
-                        Arg::with_name("program_id")
-                                .index(1)
-                                .value_name("PROGRAM_ID")
-                                .takes_value(true)
-                                .required(true)
-                                .help(
-                                    "The program_id that the address will ultimately be used for, \n\
-                                    or one of NONCE, STAKE, and VOTE keywords",
-                                ),
-                        )
-                    .arg(
-                        Arg::with_name("seeds")
-                            .min_values(0)
-                            .value_name("SEED")
-                            .takes_value(true)
-                            .validator(is_structured_seed)
-                            .help(
-                                "The seeds. \n\
-                                Each one must match the pattern PREFIX:VALUE. \n\
-                                PREFIX can be one of [string, pubkey, hex, u8] \n\
-                                or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) for number values \n\
-                                [u,i] - represents whether the number is unsigned or signed, \n\
-                                [16,32,64,128] - represents the bit length, and \n\
-                                [le,be] - represents the byte order - little endian or big endian"
-                            ),
-                    ),
-            )
         .subcommand(
             SubCommand::with_name("decode-transaction")
                 .about("Decode a serialized transaction")
@@ -239,7 +234,10 @@ impl WalletSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("resolve-signer")
-                .about("Checks that a signer is valid, and returns its specific path; useful for signers that may be specified generally, eg. usb://ledger")
+                .about(
+                    "Checks that a signer is valid, and returns its specific path; useful for \
+                     signers that may be specified generally, eg. usb://ledger",
+                )
                 .arg(
                     Arg::with_name("signer")
                         .index(1)
@@ -247,20 +245,20 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("The signer path to resolve")
-                )
+                        .help("The signer path to resolve"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("transfer")
                 .about("Transfer funds between system accounts")
                 .alias("pay")
-                .arg(
-                    pubkey!(Arg::with_name("to")
+                .arg(pubkey!(
+                    Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The account address of recipient. "),
-                )
+                    "The account address of recipient. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
@@ -270,17 +268,20 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The amount to send, in SOL; accepts keyword ALL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("from")
+                .arg(pubkey!(
+                    Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_ADDRESS"),
-                        "Source account of funds (if different from client local account). "),
-                )
+                    "Source account of funds (if different from client local account). "
+                ))
                 .arg(
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(
                     Arg::with_name("derived_address_seed")
@@ -289,7 +290,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("SEED_STRING")
                         .requires("derived_address_program_id")
                         .validator(is_derived_address_seed)
-                        .hidden(hidden_unless_forced())
+                        .hidden(hidden_unless_forced()),
                 )
                 .arg(
                     Arg::with_name("derived_address_program_id")
@@ -297,13 +298,13 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("PROGRAM_ID")
                         .requires("derived_address_seed")
-                        .hidden(hidden_unless_forced())
+                        .hidden(hidden_unless_forced()),
                 )
                 .arg(
                     Arg::with_name("allow_unfunded_recipient")
                         .long("allow-unfunded-recipient")
                         .takes_value(false)
-                        .help("Complete the transfer even if the recipient address is not funded")
+                        .help("Complete the transfer even if the recipient address is not funded"),
                 )
                 .offline_args()
                 .nonce_args(false)
@@ -320,7 +321,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("STRING")
                         .required(true)
-                        .help("The message text to be signed")
+                        .help("The message text to be signed"),
                 )
                 .arg(
                     Arg::with_name("version")
@@ -331,10 +332,10 @@ impl WalletSubCommands for App<'_, '_> {
                         .default_value("0")
                         .validator(|p| match p.parse::<u8>() {
                             Err(_) => Err(String::from("Must be unsigned integer")),
-                            Ok(_) => { Ok(()) }
+                            Ok(_) => Ok(()),
                         })
-                        .help("The off-chain message version")
-                )
+                        .help("The off-chain message version"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("verify-offchain-signature")
@@ -345,7 +346,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("STRING")
                         .required(true)
-                        .help("The text of the original message")
+                        .help("The text of the original message"),
                 )
                 .arg(
                     Arg::with_name("signature")
@@ -353,7 +354,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("SIGNATURE")
                         .takes_value(true)
                         .required(true)
-                        .help("The message signature to verify")
+                        .help("The message signature to verify"),
                 )
                 .arg(
                     Arg::with_name("version")
@@ -364,17 +365,17 @@ impl WalletSubCommands for App<'_, '_> {
                         .default_value("0")
                         .validator(|p| match p.parse::<u8>() {
                             Err(_) => Err(String::from("Must be unsigned integer")),
-                            Ok(_) => { Ok(()) }
+                            Ok(_) => Ok(()),
                         })
-                        .help("The off-chain message version")
+                        .help("The off-chain message version"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("signer")
+                .arg(pubkey!(
+                    Arg::with_name("signer")
                         .long("signer")
                         .value_name("PUBKEY")
                         .required(false),
-                        "The pubkey of the message signer (if different from config default)")
-                )
+                    "The pubkey of the message signer (if different from config default)"
+                )),
         )
     }
 }
@@ -889,9 +890,8 @@ pub fn process_transfer(
             .value;
         if recipient_balance == 0 {
             return Err(format!(
-                "The recipient address ({to}) is not funded. \
-                                Add `--allow-unfunded-recipient` to complete the transfer \
-                               "
+                "The recipient address ({to}) is not funded. Add `--allow-unfunded-recipient` to \
+                 complete the transfer "
             )
             .into());
         }

--- a/client/src/connection_cache.rs
+++ b/client/src/connection_cache.rs
@@ -102,7 +102,8 @@ impl ConnectionCache {
 
     #[deprecated(
         since = "1.15.0",
-        note = "This method does not do anything. Please use `new_with_client_options` instead to set the client certificate."
+        note = "This method does not do anything. Please use `new_with_client_options` instead to \
+                set the client certificate."
     )]
     pub fn update_client_certificate(
         &mut self,
@@ -114,7 +115,8 @@ impl ConnectionCache {
 
     #[deprecated(
         since = "1.15.0",
-        note = "This method does not do anything. Please use `new_with_client_options` instead to set staked nodes information."
+        note = "This method does not do anything. Please use `new_with_client_options` instead to \
+                set staked nodes information."
     )]
     pub fn set_staked_nodes(
         &mut self,

--- a/client/src/nonblocking/quic_client.rs
+++ b/client/src/nonblocking/quic_client.rs
@@ -1,6 +1,7 @@
 #[deprecated(
     since = "1.15.0",
-    note = "Please use `solana_quic_client::nonblocking::quic_client::QuicClientConnection` instead."
+    note = "Please use `solana_quic_client::nonblocking::quic_client::QuicClientConnection` \
+            instead."
 )]
 pub use solana_quic_client::nonblocking::quic_client::QuicClientConnection as QuicTpuConnection;
 pub use solana_quic_client::nonblocking::quic_client::{

--- a/client/src/nonblocking/tpu_connection.rs
+++ b/client/src/nonblocking/tpu_connection.rs
@@ -1,5 +1,6 @@
 #[deprecated(
     since = "1.15.0",
-    note = "Please use `solana_connection_cache::nonblocking::client_connection::ClientConnection` instead."
+    note = "Please use \
+            `solana_connection_cache::nonblocking::client_connection::ClientConnection` instead."
 )]
 pub use solana_connection_cache::nonblocking::client_connection::ClientConnection as TpuConnection;

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -183,7 +183,8 @@ impl AccountsHashVerifier {
                     .count();
                 assert!(
                     num_eah_packages <= 1,
-                    "Only a single EAH accounts package is allowed at a time! count: {num_eah_packages}"
+                    "Only a single EAH accounts package is allowed at a time! count: \
+                     {num_eah_packages}"
                 );
 
                 // Get the two highest priority requests, `y` and `z`.
@@ -316,7 +317,10 @@ impl AccountsHashVerifier {
                     .accounts
                     .accounts_db
                     .get_accounts_hash(base_slot)
-                    .expect("incremental snapshot requires accounts hash and capitalization from the full snapshot it is based on");
+                    .expect(
+                        "incremental snapshot requires accounts hash and capitalization from the \
+                         full snapshot it is based on",
+                    );
                 let (incremental_accounts_hash, incremental_capitalization) =
                     Self::_calculate_incremental_accounts_hash(accounts_package, base_slot);
                 let bank_incremental_snapshot_persistence = BankIncrementalSnapshotPersistence {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -738,9 +738,10 @@ impl Tower {
                 // `switch < last` is needed not to warn! this message just because of using
                 // newer snapshots on validator restart
                 let message = format!(
-                            "bank_forks doesn't have corresponding data for the stray restored \
-                           last vote({last_voted_slot}), meaning some inconsistency between saved tower and ledger."
-                        );
+                    "bank_forks doesn't have corresponding data for the stray restored last \
+                     vote({last_voted_slot}), meaning some inconsistency between saved tower and \
+                     ledger."
+                );
                 warn!("{}", message);
                 datapoint_warn!("tower_warn", ("warn", message, String));
             }
@@ -845,8 +846,9 @@ impl Tower {
                 return suspended_decision_due_to_major_unsynced_ledger();
             } else {
                 panic!(
-                            "Should never consider switching to ancestor ({switch_slot}) of last vote: {last_voted_slot}, ancestors({last_vote_ancestors:?})",
-                        );
+                    "Should never consider switching to ancestor ({switch_slot}) of last vote: \
+                     {last_voted_slot}, ancestors({last_vote_ancestors:?})",
+                );
             }
         }
 
@@ -1058,8 +1060,13 @@ impl Tower {
             if let Some(fork_stake) = voted_stakes.get(&lockout.slot()) {
                 let lockout_stake = *fork_stake as f64 / total_stake as f64;
                 trace!(
-                    "fork_stake slot: {}, vote slot: {}, lockout: {} fork_stake: {} total_stake: {}",
-                    slot, lockout.slot(), lockout_stake, fork_stake, total_stake
+                    "fork_stake slot: {}, vote slot: {}, lockout: {} fork_stake: {} total_stake: \
+                     {}",
+                    slot,
+                    lockout.slot(),
+                    lockout_stake,
+                    fork_stake,
+                    total_stake
                 );
                 if lockout.confirmation_count() as usize > self.threshold_depth {
                     for old_vote in &self.vote_state.votes {
@@ -1181,9 +1188,8 @@ impl Tower {
                 // While this validator's voting is suspended this way,
                 // suspended_decision_due_to_major_unsynced_ledger() will be also touched.
                 let message = format!(
-                    "For some reason, we're REPROCESSING slots which has already been \
-                     voted and ROOTED by us; \
-                     VOTING will be SUSPENDED UNTIL {last_voted_slot}!",
+                    "For some reason, we're REPROCESSING slots which has already been voted and \
+                     ROOTED by us; VOTING will be SUSPENDED UNTIL {last_voted_slot}!",
                 );
                 error!("{}", message);
                 datapoint_error!("tower_error", ("error", message, String));
@@ -1311,7 +1317,8 @@ impl Tower {
             self.last_vote = VoteTransaction::from(Vote::default());
         } else {
             info!(
-                "{} restored votes (out of {}) were on different fork or are upcoming votes on unrooted slots: {:?}!",
+                "{} restored votes (out of {}) were on different fork or are upcoming votes on \
+                 unrooted slots: {:?}!",
                 self.voted_slots().len(),
                 original_votes_len,
                 self.voted_slots()
@@ -1388,8 +1395,8 @@ pub enum TowerError {
     WrongTower(String),
 
     #[error(
-        "The tower is too old: \
-        newest slot in tower ({0}) << oldest slot in available history ({1})"
+        "The tower is too old: newest slot in tower ({0}) << oldest slot in available history \
+         ({1})"
     )]
     TooOldTower(Slot, Slot),
 
@@ -1466,13 +1473,15 @@ pub fn reconcile_blockstore_roots_with_external_source(
                 Ordering::Equal => false,
                 Ordering::Less => panic!(
                     "last_blockstore_root({last_blockstore_root}) is skipped while traversing \
-                     blockstore (currently at {current}) from external root ({external_source:?})!?",
+                     blockstore (currently at {current}) from external root \
+                     ({external_source:?})!?",
                 ),
             })
             .collect();
         if !new_roots.is_empty() {
             info!(
-                "Reconciling slots as root based on external root: {:?} (external: {:?}, blockstore: {})",
+                "Reconciling slots as root based on external root: {:?} (external: {:?}, \
+                 blockstore: {})",
                 new_roots, external_source, last_blockstore_root
             );
 
@@ -1495,9 +1504,9 @@ pub fn reconcile_blockstore_roots_with_external_source(
             // That's because we might have a chance of recovering properly with
             // newer snapshot.
             warn!(
-                "Couldn't find any ancestor slots from external source ({:?}) \
-                 towards blockstore root ({}); blockstore pruned or only \
-                 tower moved into new ledger or just hard fork?",
+                "Couldn't find any ancestor slots from external source ({:?}) towards blockstore \
+                 root ({}); blockstore pruned or only tower moved into new ledger or just hard \
+                 fork?",
                 external_source, last_blockstore_root,
             );
         }
@@ -2958,9 +2967,10 @@ pub mod test {
     }
 
     #[test]
-    #[should_panic(expected = "last_blockstore_root(3) is skipped while \
-                               traversing blockstore (currently at 1) from \
-                               external root (Tower(4))!?")]
+    #[should_panic(
+        expected = "last_blockstore_root(3) is skipped while traversing blockstore (currently at \
+                    1) from external root (Tower(4))!?"
+    )]
     fn test_reconcile_blockstore_roots_with_tower_panic_no_common_root() {
         solana_logger::setup();
         let ledger_path = get_tmp_ledger_path_auto_delete!();
@@ -3229,7 +3239,8 @@ pub mod test {
         let result = tower.adjust_lockouts_after_replay(MAX_ENTRIES, &slot_history);
         assert_eq!(
             format!("{}", result.unwrap_err()),
-            "The tower is too old: newest slot in tower (0) << oldest slot in available history (1)"
+            "The tower is too old: newest slot in tower (0) << oldest slot in available history \
+             (1)"
         );
     }
 
@@ -3308,7 +3319,8 @@ pub mod test {
         let result = tower.adjust_lockouts_after_replay(MAX_ENTRIES, &slot_history);
         assert_eq!(
             format!("{}", result.unwrap_err()),
-            "The tower is fatally inconsistent with blockstore: not too old once after got too old?"
+            "The tower is fatally inconsistent with blockstore: not too old once after got too \
+             old?"
         );
     }
 

--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -144,7 +144,11 @@ impl ForkInfo {
     ) {
         if let Some(latest_invalid_ancestor) = self.latest_invalid_ancestor {
             if latest_invalid_ancestor <= newly_valid_ancestor {
-                info!("Fork choice for {:?} clearing latest invalid ancestor {:?} because {:?} was duplicate confirmed", my_key, latest_invalid_ancestor, newly_valid_ancestor);
+                info!(
+                    "Fork choice for {:?} clearing latest invalid ancestor {:?} because {:?} was \
+                     duplicate confirmed",
+                    my_key, latest_invalid_ancestor, newly_valid_ancestor
+                );
                 self.latest_invalid_ancestor = None;
             }
         }
@@ -1188,8 +1192,9 @@ impl HeaviestSubtreeForkChoice {
                             // validator has been running, so we must be able to fetch best_slots for all of
                             // them.
                             panic!(
-                                "a bank at last_voted_slot({last_voted_slot_hash:?}) is a frozen bank so must have been \
-                                        added to heaviest_subtree_fork_choice at time of freezing",
+                                "a bank at last_voted_slot({last_voted_slot_hash:?}) is a frozen \
+                                 bank so must have been added to heaviest_subtree_fork_choice at \
+                                 time of freezing",
                             )
                         } else {
                             // fork_infos doesn't have corresponding data for the stale stray last vote,

--- a/core/src/repair/ancestor_hashes_service.rs
+++ b/core/src/repair/ancestor_hashes_service.rs
@@ -557,8 +557,11 @@ impl AncestorHashesService {
                         // order to vote.
                         // This fits the alternate criteria we use in `find_epoch_slots_frozen_dead_slots`
                         // so we can upgrade it to `repairable_dead_slot_pool`.
-                        info!("{pruned_slot} is part of a popular pruned fork however we previously marked it as dead.
-                            Upgrading as dead duplicate confirmed");
+                        info!(
+                            "{pruned_slot} is part of a popular pruned fork however we previously \
+                             marked it as dead.
+                            Upgrading as dead duplicate confirmed"
+                        );
                         dead_slot_pool.remove(&pruned_slot);
                         repairable_dead_slot_pool.insert(pruned_slot);
                     } else if repairable_dead_slot_pool.contains(&pruned_slot) {
@@ -566,8 +569,12 @@ impl AncestorHashesService {
                         // ignore the additional information that `pruned_slot` is popular pruned.
                         // This is similar to the above case where `pruned_slot` was first pruned
                         // and then marked dead duplicate confirmed.
-                        info!("Received pruned duplicate confirmed status for {pruned_slot} that was previously marked
-                            dead duplicate confirmed. Ignoring and processing it as dead duplicate confirmed.");
+                        info!(
+                            "Received pruned duplicate confirmed status for {pruned_slot} that \
+                             was previously marked
+                            dead duplicate confirmed. Ignoring and processing it as dead duplicate \
+                             confirmed."
+                        );
                     } else {
                         popular_pruned_slot_pool.insert(pruned_slot);
                     }

--- a/core/src/repair/cluster_slot_state_verifier.rs
+++ b/core/src/repair/cluster_slot_state_verifier.rs
@@ -451,7 +451,8 @@ fn check_epoch_slots_hash_against_bank_status(
             assert!(is_popular_pruned);
             // The cluster sample found the troublesome slot which caused this fork to be pruned
             warn!(
-                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, but we
+                "EpochSlots sample returned slot {slot} with hash {epoch_slots_frozen_hash}, but \
+                 we
                 have pruned it due to incorrect ancestry"
             );
         }
@@ -671,9 +672,13 @@ fn on_epoch_slots_frozen(
 }
 
 fn on_popular_pruned_fork(slot: Slot) -> Vec<ResultingStateChange> {
-    warn!("{slot} is part of a pruned fork which has reached the DUPLICATE_THRESHOLD aggregating across descendants
-            and slot versions. It is suspected to be duplicate or have an ancestor that is duplicate.
-            Notifying ancestor_hashes_service");
+    warn!(
+        "{slot} is part of a pruned fork which has reached the DUPLICATE_THRESHOLD aggregating \
+         across descendants
+            and slot versions. It is suspected to be duplicate or have an ancestor that is \
+         duplicate.
+            Notifying ancestor_hashes_service"
+    );
     vec![ResultingStateChange::SendAncestorHashesReplayUpdate(
         AncestorHashesReplayUpdate::PopularPrunedFork(slot),
     )]

--- a/core/src/repair/duplicate_repair_status.rs
+++ b/core/src/repair/duplicate_repair_status.rs
@@ -320,13 +320,15 @@ impl AncestorRequestStatus {
                         let mismatch_our_frozen_hash = blockstore.get_bank_hash(mismatch_slot);
                         info!(
                             "When processing the ancestor sample for {}, there was a mismatch
-                            for {mismatch_slot}: we had frozen hash {:?} and the cluster agreed upon
-                            {mismatch_agreed_upon_hash}. However for a later ancestor {ancestor_slot}
-                            we have agreement on {our_frozen_hash} as the bank hash. This should never
+                            for {mismatch_slot}: we had frozen hash {:?} and the cluster agreed \
+                             upon
+                            {mismatch_agreed_upon_hash}. However for a later ancestor \
+                             {ancestor_slot}
+                            we have agreement on {our_frozen_hash} as the bank hash. This should \
+                             never
                             be possible, something is wrong or the cluster sample is invalid.
                             Rejecting and queuing the ancestor hashes request for retry",
-                            self.requested_mismatched_slot,
-                            mismatch_our_frozen_hash
+                            self.requested_mismatched_slot, mismatch_our_frozen_hash
                         );
                         return DuplicateAncestorDecision::InvalidSample;
                     }
@@ -346,12 +348,18 @@ impl AncestorRequestStatus {
                         let (mismatch_slot, mismatch_agreed_upon_hash) =
                             agreed_response[*mismatch_i];
                         info!(
-                            "When processing the ancestor sample for {}, an earlier ancestor {mismatch_slot}
-                            was agreed upon by the cluster with hash {mismatch_agreed_upon_hash} but not
-                            frozen in our blockstore. However for a later ancestor {ancestor_slot} we have
-                            agreement on {our_frozen_hash} as the bank hash. This should only be possible if
-                            we have just started from snapshot and immediately encountered a duplicate block on
-                            a popular pruned fork, otherwise something is seriously wrong. Continuing with the
+                            "When processing the ancestor sample for {}, an earlier ancestor \
+                             {mismatch_slot}
+                            was agreed upon by the cluster with hash {mismatch_agreed_upon_hash} \
+                             but not
+                            frozen in our blockstore. However for a later ancestor {ancestor_slot} \
+                             we have
+                            agreement on {our_frozen_hash} as the bank hash. This should only be \
+                             possible if
+                            we have just started from snapshot and immediately encountered a \
+                             duplicate block on
+                            a popular pruned fork, otherwise something is seriously wrong. \
+                             Continuing with the
                             repair",
                             self.requested_mismatched_slot
                         );

--- a/core/src/repair/repair_generic_traversal.rs
+++ b/core/src/repair/repair_generic_traversal.rs
@@ -139,7 +139,8 @@ pub fn get_closest_completion(
                             (
                                 "error",
                                 format!(
-                                    "last_index + 1 < shred_count. last_index={last_index} shred_count={shred_count}",
+                                    "last_index + 1 < shred_count. last_index={last_index} \
+                                     shred_count={shred_count}",
                                 ),
                                 String
                             ),
@@ -153,9 +154,9 @@ pub fn get_closest_completion(
                             (
                                 "error",
                                 format!(
-                                    "last_index < slot_meta.consumed. last_index={} slot_meta.consumed={}",
-                                    last_index,
-                                    slot_meta.consumed,
+                                    "last_index < slot_meta.consumed. last_index={} \
+                                     slot_meta.consumed={}",
+                                    last_index, slot_meta.consumed,
                                 ),
                                 String
                             ),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -185,10 +185,10 @@ impl PartitionInfo {
         heaviest_fork_failures: Vec<HeaviestForkFailures>,
     ) {
         if self.partition_start_time.is_none() && partition_detected {
-            warn!("PARTITION DETECTED waiting to join heaviest fork: {} last vote: {:?}, reset slot: {}",
-                heaviest_slot,
-                last_voted_slot,
-                reset_bank_slot,
+            warn!(
+                "PARTITION DETECTED waiting to join heaviest fork: {} last vote: {:?}, reset \
+                 slot: {}",
+                heaviest_slot, last_voted_slot, reset_bank_slot,
             );
             datapoint_info!(
                 "replay_stage-partition-start",
@@ -1157,10 +1157,9 @@ impl ReplayStage {
                 ) {
                     if retransmit_info.reached_retransmit_threshold() {
                         info!(
-                            "Retrying retransmit: latest_leader_slot={} slot={} retransmit_info={:?}",
-                            latest_leader_slot,
-                            slot,
-                            &retransmit_info,
+                            "Retrying retransmit: latest_leader_slot={} slot={} \
+                             retransmit_info={:?}",
+                            latest_leader_slot, slot, &retransmit_info,
                         );
                         datapoint_info!(
                             metric_name,
@@ -1350,7 +1349,9 @@ impl ReplayStage {
                     }
 
                     // Should not dump slots for which we were the leader
-                    if Some(*my_pubkey) == leader_schedule_cache.slot_leader_at(*duplicate_slot, None) {
+                    if Some(*my_pubkey)
+                        == leader_schedule_cache.slot_leader_at(*duplicate_slot, None)
+                    {
                         if let Some(bank) = bank_forks.read().unwrap().get(*duplicate_slot) {
                             bank_hash_details::write_bank_hash_details_file(&bank)
                                 .map_err(|err| {
@@ -1360,11 +1361,13 @@ impl ReplayStage {
                         } else {
                             warn!("Unable to get bank for slot {duplicate_slot} from bank forks");
                         }
-                        panic!("We are attempting to dump a block that we produced. \
-                            This indicates that we are producing duplicate blocks, \
-                            or that there is a bug in our runtime/replay code which \
-                            causes us to compute different bank hashes than the rest of the cluster. \
-                            We froze slot {duplicate_slot} with hash {frozen_hash:?} while the cluster hash is {correct_hash}");
+                        panic!(
+                            "We are attempting to dump a block that we produced. This indicates \
+                             that we are producing duplicate blocks, or that there is a bug in \
+                             our runtime/replay code which causes us to compute different bank \
+                             hashes than the rest of the cluster. We froze slot {duplicate_slot} \
+                             with hash {frozen_hash:?} while the cluster hash is {correct_hash}"
+                        );
                     }
 
                     let attempt_no = purge_repair_slot_counter
@@ -1372,11 +1375,13 @@ impl ReplayStage {
                         .and_modify(|x| *x += 1)
                         .or_insert(1);
                     if *attempt_no > MAX_REPAIR_RETRY_LOOP_ATTEMPTS {
-                        panic!("We have tried to repair duplicate slot: {duplicate_slot} more than {MAX_REPAIR_RETRY_LOOP_ATTEMPTS} times \
-                            and are unable to freeze a block with bankhash {correct_hash}, \
-                            instead we have a block with bankhash {frozen_hash:?}. \
-                            This is most likely a bug in the runtime. \
-                            At this point manual intervention is needed to make progress. Exiting");
+                        panic!(
+                            "We have tried to repair duplicate slot: {duplicate_slot} more than \
+                             {MAX_REPAIR_RETRY_LOOP_ATTEMPTS} times and are unable to freeze a \
+                             block with bankhash {correct_hash}, instead we have a block with \
+                             bankhash {frozen_hash:?}. This is most likely a bug in the runtime. \
+                             At this point manual intervention is needed to make progress. Exiting"
+                        );
                     }
 
                     Self::purge_unconfirmed_duplicate_slot(
@@ -1437,8 +1442,15 @@ impl ReplayStage {
         } in ancestor_duplicate_slots_receiver.try_iter()
         {
             warn!(
-                "{} ReplayStage notified of duplicate slot from ancestor hashes service but we observed as {}: {:?}",
-                pubkey, if request_type.is_pruned() {"pruned"} else {"dead"}, (epoch_slots_frozen_slot, epoch_slots_frozen_hash),
+                "{} ReplayStage notified of duplicate slot from ancestor hashes service but we \
+                 observed as {}: {:?}",
+                pubkey,
+                if request_type.is_pruned() {
+                    "pruned"
+                } else {
+                    "dead"
+                },
+                (epoch_slots_frozen_slot, epoch_slots_frozen_hash),
             );
             let epoch_slots_frozen_state = EpochSlotsFrozenState::new_from_state(
                 epoch_slots_frozen_slot,
@@ -1570,7 +1582,11 @@ impl ReplayStage {
                 // replay on successful repair of the parent. If this block is also a duplicate, it
                 // will be handled in the next round of repair/replay - so we just clear the dead
                 // flag for now.
-                warn!("not purging descendant {} of slot {} as it is dead. resetting dead flag instead", slot, duplicate_slot);
+                warn!(
+                    "not purging descendant {} of slot {} as it is dead. resetting dead flag \
+                     instead",
+                    slot, duplicate_slot
+                );
                 // Clear the "dead" flag allowing ReplayStage to start replaying
                 // this slot once the parent is repaired
                 blockstore.remove_dead_slot(slot).unwrap();
@@ -1933,8 +1949,12 @@ impl ReplayStage {
             );
 
             if !Self::check_propagation_for_start_leader(poh_slot, parent_slot, progress_map) {
-                let latest_unconfirmed_leader_slot = progress_map.get_latest_leader_slot_must_exist(parent_slot)
-                    .expect("In order for propagated check to fail, latest leader must exist in progress map");
+                let latest_unconfirmed_leader_slot = progress_map
+                    .get_latest_leader_slot_must_exist(parent_slot)
+                    .expect(
+                        "In order for propagated check to fail, latest leader must exist in \
+                         progress map",
+                    );
                 if poh_slot != skipped_slots_info.last_skipped_slot {
                     datapoint_info!(
                         "replay_stage-skip_leader_slot",
@@ -2337,8 +2357,11 @@ impl ReplayStage {
             .find(|keypair| keypair.pubkey() == authorized_voter_pubkey)
         {
             None => {
-                warn!("The authorized keypair {} for vote account {} is not available.  Unable to vote",
-                      authorized_voter_pubkey, vote_account_pubkey);
+                warn!(
+                    "The authorized keypair {} for vote account {} is not available.  Unable to \
+                     vote",
+                    authorized_voter_pubkey, vote_account_pubkey
+                );
                 return None;
             }
             Some(authorized_voter_keypair) => authorized_voter_keypair,
@@ -2405,7 +2428,8 @@ impl ReplayStage {
         {
             last_vote_refresh_time.last_print_time = Instant::now();
             info!(
-                "Last landed vote for slot {} in bank {} is greater than the current last vote for slot: {} tracked by Tower",
+                "Last landed vote for slot {} in bank {} is greater than the current last vote \
+                 for slot: {} tracked by Tower",
                 my_latest_landed_vote,
                 heaviest_bank_on_same_fork.slot(),
                 last_voted_slot
@@ -2863,8 +2887,8 @@ impl ReplayStage {
                 let replay_progress = bank_progress.replay_progress.clone();
                 let r_replay_progress = replay_progress.read().unwrap();
                 debug!(
-                    "bank {} has completed replay from blockstore, \
-                     contribute to update cost with {:?}",
+                    "bank {} has completed replay from blockstore, contribute to update cost with \
+                     {:?}",
                     bank.slot(),
                     r_replay_stats.batch_execute.totals
                 );
@@ -3580,7 +3604,8 @@ impl ReplayStage {
                     // thus it's safe to use as the reset bank.
                     let reset_bank = Some(heaviest_bank);
                     info!(
-                        "Waiting to switch vote to {}, resetting to slot {:?} for now, latest duplicate ancestor: {:?}",
+                        "Waiting to switch vote to {}, resetting to slot {:?} for now, latest \
+                         duplicate ancestor: {:?}",
                         heaviest_bank.slot(),
                         reset_bank.as_ref().map(|b| b.slot()),
                         latest_duplicate_ancestor,

--- a/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
+++ b/core/src/snapshot_packager_service/snapshot_gossip_manager.rs
@@ -102,9 +102,10 @@ impl SnapshotGossipManager {
             .as_mut()
             .expect("there must already be a full snapshot hash");
         assert_eq!(
-            base_slot, latest_snapshot_hashes.full.0.0,
-            "the incremental snapshot's base slot ({}) must match the latest full snapshot's slot ({})",
-            base_slot, latest_snapshot_hashes.full.0.0,
+            base_slot, latest_snapshot_hashes.full.0 .0,
+            "the incremental snapshot's base slot ({}) must match the latest full snapshot's slot \
+             ({})",
+            base_slot, latest_snapshot_hashes.full.0 .0,
         );
         latest_snapshot_hashes.incremental = Some(incremental_snapshot_hash);
     }
@@ -129,8 +130,8 @@ impl SnapshotGossipManager {
                     .collect(),
             )
             .expect(
-                "Bug! The programmer contract has changed for push_snapshot_hashes() \
-                 and a new error case has been added that has not been handled here.",
+                "Bug! The programmer contract has changed for push_snapshot_hashes() and a new \
+                 error case has been added that has not been handled here.",
             );
     }
 }

--- a/core/src/system_monitor_service.rs
+++ b/core/src/system_monitor_service.rs
@@ -466,8 +466,13 @@ impl SystemMonitorService {
             .map(|(key, interesting_limit, current_value)| {
                 datapoint_warn!("os-config", (key, *current_value, i64));
                 match interesting_limit {
-                    InterestingLimit::Recommend(recommended_value) if current_value < recommended_value => {
-                        warn!("  {key}: recommended={recommended_value} current={current_value}, too small");
+                    InterestingLimit::Recommend(recommended_value)
+                        if current_value < recommended_value =>
+                    {
+                        warn!(
+                            "  {key}: recommended={recommended_value} current={current_value}, \
+                             too small"
+                        );
                         false
                     }
                     InterestingLimit::Recommend(recommended_value) => {

--- a/core/src/tpu_entry_notifier.rs
+++ b/core/src/tpu_entry_notifier.rs
@@ -85,14 +85,16 @@ impl TpuEntryNotifier {
             starting_transaction_index: *current_transaction_index,
         }) {
             warn!(
-                "Failed to send slot {slot:?} entry {index:?} from Tpu to EntryNotifierService, error {err:?}",
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to EntryNotifierService, \
+                 error {err:?}",
             );
         }
         *current_transaction_index += entry.transactions.len();
 
         if let Err(err) = broadcast_entry_sender.send((bank, (entry, tick_height))) {
             warn!(
-                "Failed to send slot {slot:?} entry {index:?} from Tpu to BroadcastStage, error {err:?}",
+                "Failed to send slot {slot:?} entry {index:?} from Tpu to BroadcastStage, error \
+                 {err:?}",
             );
             // If the BroadcastStage channel is closed, the validator has halted. Try to exit
             // gracefully.

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -579,8 +579,8 @@ impl Validator {
                 )
                 .map_err(|err| {
                     format!(
-                        "Failed to backup and clear shreds with incorrect \
-                        shred version from blockstore: {err:?}"
+                        "Failed to backup and clear shreds with incorrect shred version from \
+                         blockstore: {err:?}"
                     )
                 })?;
             }
@@ -653,9 +653,8 @@ impl Validator {
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_block_metadata_notifier());
 
         info!(
-            "Geyser plugin: accounts_update_notifier: {}, \
-            transaction_notifier: {}, \
-            entry_notifier: {}",
+            "Geyser plugin: accounts_update_notifier: {}, transaction_notifier: {}, \
+             entry_notifier: {}",
             accounts_update_notifier.is_some(),
             transaction_notifier.is_some(),
             entry_notifier.is_some()
@@ -1568,7 +1567,8 @@ fn check_poh_speed(
             info!("PoH speed check: Will sleep {}ns per slot.", extra_ns);
         } else {
             return Err(format!(
-                "PoH is slower than cluster target tick rate! mine: {my_ns_per_slot} cluster: {target_ns_per_slot}.",
+                "PoH is slower than cluster target tick rate! mine: {my_ns_per_slot} cluster: \
+                 {target_ns_per_slot}.",
             ));
         }
     }
@@ -1643,20 +1643,21 @@ fn post_process_restored_tower(
             }
             if should_require_tower && voting_has_been_active {
                 return Err(format!(
-                    "Requested mandatory tower restore failed: {err}. \
-                     And there is an existing vote_account containing actual votes. \
-                     Aborting due to possible conflicting duplicate votes"
+                    "Requested mandatory tower restore failed: {err}. And there is an existing \
+                     vote_account containing actual votes. Aborting due to possible conflicting \
+                     duplicate votes"
                 ));
             }
             if err.is_file_missing() && !voting_has_been_active {
                 // Currently, don't protect against spoofed snapshots with no tower at all
                 info!(
-                    "Ignoring expected failed tower restore because this is the initial \
-                      validator start with the vote account..."
+                    "Ignoring expected failed tower restore because this is the initial validator \
+                     start with the vote account..."
                 );
             } else {
                 error!(
-                    "Rebuilding a new tower from the latest vote account due to failed tower restore: {}",
+                    "Rebuilding a new tower from the latest vote account due to failed tower \
+                     restore: {}",
                     err
                 );
             }
@@ -1722,7 +1723,8 @@ fn load_blockstore(
     if let Some(expected_genesis_hash) = config.expected_genesis_hash {
         if genesis_hash != expected_genesis_hash {
             return Err(format!(
-                "genesis hash mismatch: hash={genesis_hash} expected={expected_genesis_hash}. Delete the ledger directory to continue: {ledger_path:?}",
+                "genesis hash mismatch: hash={genesis_hash} expected={expected_genesis_hash}. \
+                 Delete the ledger directory to continue: {ledger_path:?}",
             ));
         }
     }
@@ -2243,8 +2245,8 @@ fn wait_for_supermajority(
                 std::cmp::Ordering::Less => return Ok(false),
                 std::cmp::Ordering::Greater => {
                     error!(
-                        "Ledger does not have enough data to wait for supermajority, \
-                             please enable snapshot fetch. Has {} needs {}",
+                        "Ledger does not have enough data to wait for supermajority, please \
+                         enable snapshot fetch. Has {} needs {}",
                         bank.slot(),
                         wait_for_supermajority_slot
                     );

--- a/core/src/verified_vote_packets.rs
+++ b/core/src/verified_vote_packets.rs
@@ -264,7 +264,9 @@ impl VerifiedVotePackets {
                             {
                                 if slot > gossip_vote.slot {
                                     warn!(
-                                        "Originally {} submitted full tower votes, but now has reverted to incremental votes. Converting back to old format.",
+                                        "Originally {} submitted full tower votes, but now has \
+                                         reverted to incremental votes. Converting back to old \
+                                         format.",
                                         vote_account_key
                                     );
                                     let mut votes = BTreeMap::new();
@@ -848,7 +850,10 @@ mod tests {
         if let IncrementalVotes(votes) = verified_vote_packets.0.get(&vote_account_key).unwrap() {
             assert!(votes.contains_key(&(42, hash)));
         } else {
-            panic!("Although feature is active, incremental votes should not be stored as full tower votes");
+            panic!(
+                "Although feature is active, incremental votes should not be stored as full tower \
+                 votes"
+            );
         }
     }
 

--- a/core/src/warm_quic_cache_service.rs
+++ b/core/src/warm_quic_cache_service.rs
@@ -41,7 +41,7 @@ impl WarmQuicCacheService {
                 let slot_jitter = thread_rng().gen_range(-CACHE_JITTER_SLOT..CACHE_JITTER_SLOT);
                 let mut maybe_last_leader = None;
                 while !exit.load(Ordering::Relaxed) {
-                    let leader_pubkey =  poh_recorder
+                    let leader_pubkey = poh_recorder
                         .read()
                         .unwrap()
                         .leader_after_n_slots((CACHE_OFFSET_SLOT + slot_jitter) as u64);
@@ -51,12 +51,15 @@ impl WarmQuicCacheService {
                         {
                             maybe_last_leader = Some(leader_pubkey);
                             if let Some(Ok(addr)) = cluster_info
-                                .lookup_contact_info(&leader_pubkey, |node| node.tpu(Protocol::QUIC))
+                                .lookup_contact_info(&leader_pubkey, |node| {
+                                    node.tpu(Protocol::QUIC)
+                                })
                             {
                                 let conn = connection_cache.get_connection(&addr);
                                 if let Err(err) = conn.send_data(&[]) {
                                     warn!(
-                                        "Failed to warmup QUIC connection to the leader {:?}, Error {:?}",
+                                        "Failed to warmup QUIC connection to the leader {:?}, \
+                                         Error {:?}",
                                         leader_pubkey, err
                                     );
                                 }

--- a/core/tests/fork-selection.rs
+++ b/core/tests/fork-selection.rs
@@ -561,14 +561,15 @@ fn test_with_partitions(
                 trunk.0
             };
             println!(
-                    "time: {}, tip converged: {}, trunk id: {}, trunk time: {}, trunk converged {}, trunk height {}",
-                    time,
-                    calc_tip_converged(&towers, &converge_map),
-                    trunk.0,
-                    trunk_time,
-                    trunk.1,
-                    calc_fork_depth(&fork_tree, trunk.0)
-                );
+                "time: {}, tip converged: {}, trunk id: {}, trunk time: {}, trunk converged {}, \
+                 trunk height {}",
+                time,
+                calc_tip_converged(&towers, &converge_map),
+                trunk.0,
+                trunk_time,
+                trunk.1,
+                calc_fork_depth(&fork_tree, trunk.0)
+            );
             if break_early && calc_tip_converged(&towers, &converge_map) == len {
                 break;
             }

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -726,8 +726,14 @@ fn test_bank_forks_incremental_snapshot(
         INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS * 5;
     const LAST_SLOT: Slot = FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS * 2 - 1;
 
-    info!("Running bank forks incremental snapshot test, full snapshot interval: {} slots, incremental snapshot interval: {} slots, last slot: {}, set root interval: {} slots",
-              FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS, INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS, LAST_SLOT, SET_ROOT_INTERVAL);
+    info!(
+        "Running bank forks incremental snapshot test, full snapshot interval: {} slots, \
+         incremental snapshot interval: {} slots, last slot: {}, set root interval: {} slots",
+        FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+        INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
+        LAST_SLOT,
+        SET_ROOT_INTERVAL
+    );
 
     let snapshot_test_config = SnapshotTestConfig::new(
         snapshot_version,
@@ -736,8 +742,20 @@ fn test_bank_forks_incremental_snapshot(
         FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
     );
-    trace!("SnapshotTestConfig:\naccounts_dir: {}\nbank_snapshots_dir: {}\nfull_snapshot_archives_dir: {}\nincremental_snapshot_archives_dir: {}",
-            snapshot_test_config.accounts_dir.display(), snapshot_test_config.bank_snapshots_dir.path().display(), snapshot_test_config.full_snapshot_archives_dir.path().display(), snapshot_test_config.incremental_snapshot_archives_dir.path().display());
+    trace!(
+        "SnapshotTestConfig:\naccounts_dir: {}\nbank_snapshots_dir: \
+         {}\nfull_snapshot_archives_dir: {}\nincremental_snapshot_archives_dir: {}",
+        snapshot_test_config.accounts_dir.display(),
+        snapshot_test_config.bank_snapshots_dir.path().display(),
+        snapshot_test_config
+            .full_snapshot_archives_dir
+            .path()
+            .display(),
+        snapshot_test_config
+            .incremental_snapshot_archives_dir
+            .path()
+            .display()
+    );
 
     let bank_forks = snapshot_test_config.bank_forks.clone();
     let mint_keypair = &snapshot_test_config.genesis_config_info.mint_keypair;
@@ -960,12 +978,9 @@ fn test_snapshots_with_background_services(
 
     info!("Running snapshots with background services test...");
     trace!(
-        "Test configuration parameters:\
-        \n\tfull snapshot archive interval: {} slots\
-        \n\tincremental snapshot archive interval: {} slots\
-        \n\tbank snapshot interval: {} slots\
-        \n\tset root interval: {} slots\
-        \n\tlast slot: {}",
+        "Test configuration parameters:\n\tfull snapshot archive interval: {} \
+         slots\n\tincremental snapshot archive interval: {} slots\n\tbank snapshot interval: {} \
+         slots\n\tset root interval: {} slots\n\tlast slot: {}",
         FULL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         INCREMENTAL_SNAPSHOT_ARCHIVE_INTERVAL_SLOTS,
         BANK_SNAPSHOT_INTERVAL_SLOTS,
@@ -1097,7 +1112,8 @@ fn test_snapshots_with_background_services(
             {
                 assert!(
                     timer.elapsed() < MAX_WAIT_DURATION,
-                    "Waiting for full snapshot {slot} exceeded the {MAX_WAIT_DURATION:?} maximum wait duration!",
+                    "Waiting for full snapshot {slot} exceeded the {MAX_WAIT_DURATION:?} maximum \
+                     wait duration!",
                 );
                 std::thread::sleep(Duration::from_secs(1));
             }
@@ -1115,7 +1131,8 @@ fn test_snapshots_with_background_services(
             {
                 assert!(
                     timer.elapsed() < MAX_WAIT_DURATION,
-                    "Waiting for incremental snapshot {slot} exceeded the {MAX_WAIT_DURATION:?} maximum wait duration!",
+                    "Waiting for incremental snapshot {slot} exceeded the {MAX_WAIT_DURATION:?} \
+                     maximum wait duration!",
                 );
                 std::thread::sleep(Duration::from_secs(1));
             }

--- a/dos/src/cli.rs
+++ b/dos/src/cli.rs
@@ -168,7 +168,10 @@ fn validate_input(params: &DosClientParameters) {
     if params.data_type != DataType::Transaction {
         let tp = &params.transaction_params;
         if tp.valid_blockhash || tp.valid_signatures || tp.unique_transactions {
-            eprintln!("Arguments valid-blockhash, valid-sign, unique-transactions are ignored if data-type != transaction");
+            eprintln!(
+                "Arguments valid-blockhash, valid-sign, unique-transactions are ignored if \
+                 data-type != transaction"
+            );
             exit(1);
         }
     }

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -879,10 +879,9 @@ impl EntrySlice for [Entry] {
             if entry.is_tick() {
                 if *tick_hash_count != hashes_per_tick {
                     warn!(
-                        "invalid tick hash count!: entry: {:#?}, tick_hash_count: {}, hashes_per_tick: {}",
-                        entry,
-                        tick_hash_count,
-                        hashes_per_tick
+                        "invalid tick hash count!: entry: {:#?}, tick_hash_count: {}, \
+                         hashes_per_tick: {}",
+                        entry, tick_hash_count, hashes_per_tick
                     );
                     return false;
                 }

--- a/faucet/src/bin/faucet.rs
+++ b/faucet/src/bin/faucet.rs
@@ -63,8 +63,8 @@ async fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .help(
-                    "Allow requests from a particular IP address without request limit; \
-                    recipient address will be used to check request limits instead",
+                    "Allow requests from a particular IP address without request limit; recipient \
+                     address will be used to check request limits instead",
                 ),
         )
         .get_matches();

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -126,8 +126,8 @@ impl Faucet {
         if let Some((per_request_cap, per_time_cap)) = per_request_cap.zip(per_time_cap) {
             if per_time_cap < per_request_cap {
                 warn!(
-                    "per_time_cap {} SOL < per_request_cap {} SOL; \
-                    maximum single requests will fail",
+                    "per_time_cap {} SOL < per_request_cap {} SOL; maximum single requests will \
+                     fail",
                     lamports_to_sol(per_time_cap),
                     lamports_to_sol(per_request_cap),
                 );
@@ -363,13 +363,17 @@ pub async fn run_faucet(
 ) {
     let listener = TcpListener::bind(&faucet_addr).await;
     if let Some(sender) = sender {
-        sender.send(
-            listener.as_ref().map(|listener| listener.local_addr().unwrap())
-                .map_err(|err| {
-                    format!(
-                        "Unable to bind faucet to {faucet_addr:?}, check the address is not already in use: {err}"
-                    )
-                })
+        sender
+            .send(
+                listener
+                    .as_ref()
+                    .map(|listener| listener.local_addr().unwrap())
+                    .map_err(|err| {
+                        format!(
+                            "Unable to bind faucet to {faucet_addr:?}, check the address is not \
+                             already in use: {err}"
+                        )
+                    }),
             )
             .unwrap();
     }

--- a/frozen-abi/src/abi_digester.rs
+++ b/frozen-abi/src/abi_digester.rs
@@ -198,7 +198,11 @@ impl AbiDigester {
         label: &'static str,
         variant: &'static str,
     ) -> Result<(), DigestError> {
-        assert!(self.for_enum, "derive AbiEnumVisitor or implement it for the enum, which contains a variant ({label}) named {variant}");
+        assert!(
+            self.for_enum,
+            "derive AbiEnumVisitor or implement it for the enum, which contains a variant \
+             ({label}) named {variant}"
+        );
         Ok(())
     }
 
@@ -217,7 +221,10 @@ impl AbiDigester {
                 .unwrap_or("unknown-test-thread")
                 .replace(':', "_");
             if thread_name == "main" {
-                error!("Bad thread name detected for dumping; Maybe, --test-threads=1? Sorry, SOLANA_ABI_DUMP_DIR doesn't work under 1; increase it");
+                error!(
+                    "Bad thread name detected for dumping; Maybe, --test-threads=1? Sorry, \
+                     SOLANA_ABI_DUMP_DIR doesn't work under 1; increase it"
+                );
             }
 
             let path = format!("{dir}/{thread_name}_{hash}",);

--- a/genesis-utils/src/lib.rs
+++ b/genesis-utils/src/lib.rs
@@ -19,7 +19,8 @@ fn check_genesis_hash(
     if let Some(expected_genesis_hash) = expected_genesis_hash {
         if expected_genesis_hash != genesis_hash {
             return Err(format!(
-                "Genesis hash mismatch: expected {expected_genesis_hash} but downloaded genesis hash is {genesis_hash}",
+                "Genesis hash mismatch: expected {expected_genesis_hash} but downloaded genesis \
+                 hash is {genesis_hash}",
             ));
         }
     }
@@ -94,7 +95,8 @@ fn set_and_verify_expected_genesis_hash(
 
     if expected_genesis_hash != rpc_genesis_hash {
         return Err(format!(
-            "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis hash is {rpc_genesis_hash}"
+            "Genesis hash mismatch: expected {expected_genesis_hash} but RPC node genesis hash is \
+             {rpc_genesis_hash}"
         ));
     }
 

--- a/genesis/src/main.rs
+++ b/genesis/src/main.rs
@@ -159,7 +159,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("RFC3339 DATE TIME")
                 .validator(is_rfc3339_datetime)
                 .takes_value(true)
-                .help("Time when the bootstrap validator will start the cluster [default: current system time]"),
+                .help(
+                    "Time when the bootstrap validator will start the cluster [default: current \
+                     system time]",
+                ),
         )
         .arg(
             Arg::with_name("bootstrap_validator")
@@ -235,8 +238,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_target_lamports_per_signature)
                 .help(
-                    "The cost in lamports that the cluster will charge for signature \
-                     verification when the cluster is operating at target-signatures-per-slot",
+                    "The cost in lamports that the cluster will charge for signature verification \
+                     when the cluster is operating at target-signatures-per-slot",
                 ),
         )
         .arg(
@@ -246,8 +249,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_lamports_per_byte_year)
                 .help(
-                    "The cost in lamports that the cluster will charge per byte per year \
-                     for accounts with data",
+                    "The cost in lamports that the cluster will charge per byte per year for \
+                     accounts with data",
                 ),
         )
         .arg(
@@ -257,8 +260,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_rent_exemption_threshold)
                 .help(
-                    "amount of time (in years) the balance has to include rent for \
-                     to qualify as rent exempted account",
+                    "amount of time (in years) the balance has to include rent for to qualify as \
+                     rent exempted account",
                 ),
         )
         .arg(
@@ -295,10 +298,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value(default_target_signatures_per_slot)
                 .help(
-                    "Used to estimate the desired processing capacity of the cluster. \
-                    When the latest slot processes fewer/greater signatures than this \
-                    value, the lamports-per-signature fee will decrease/increase for \
-                    the next slot. A value of 0 disables signature-based fee adjustments",
+                    "Used to estimate the desired processing capacity of the cluster. When the \
+                     latest slot processes fewer/greater signatures than this value, the \
+                     lamports-per-signature fee will decrease/increase for the next slot. A value \
+                     of 0 disables signature-based fee adjustments",
                 ),
         )
         .arg(
@@ -315,10 +318,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .default_value("auto")
                 .help(
-                    "How many PoH hashes to roll before emitting the next tick. \
-                     If \"auto\", determine based on --target-tick-duration \
-                     and the hash rate of this computer. If \"sleep\", for development \
-                     sleep for --target-tick-duration instead of hashing",
+                    "How many PoH hashes to roll before emitting the next tick. If \"auto\", \
+                     determine based on --target-tick-duration and the hash rate of this \
+                     computer. If \"sleep\", for development sleep for --target-tick-duration \
+                     instead of hashing",
                 ),
         )
         .arg(
@@ -341,8 +344,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             Arg::with_name("enable_warmup_epochs")
                 .long("enable-warmup-epochs")
                 .help(
-                    "When enabled epochs start short and will grow. \
-                     Useful for warming up stake quickly during development"
+                    "When enabled epochs start short and will grow. Useful for warming up stake \
+                     quickly during development",
                 ),
         )
         .arg(
@@ -359,9 +362,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .possible_values(&ClusterType::STRINGS)
                 .takes_value(true)
                 .default_value(default_cluster_type)
-                .help(
-                    "Selects the features that will be enabled for the cluster"
-                ),
+                .help("Selects the features that will be enabled for the cluster"),
         )
         .arg(
             Arg::with_name("max_genesis_archive_unpacked_size")
@@ -369,9 +370,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_genesis_archive_unpacked_size)
-                .help(
-                    "maximum total uncompressed file size of created genesis archive",
-                ),
+                .help("maximum total uncompressed file size of created genesis archive"),
         )
         .arg(
             Arg::with_name("bpf_program")
@@ -389,7 +388,10 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                 .takes_value(true)
                 .number_of_values(4)
                 .multiple(true)
-                .help("Install an upgradeable SBF program at the given address with the given upgrade authority (or \"none\")"),
+                .help(
+                    "Install an upgradeable SBF program at the given address with the given \
+                     upgrade authority (or \"none\")",
+                ),
         )
         .arg(
             Arg::with_name("inflation")
@@ -1019,18 +1021,25 @@ mod tests {
 
         assert_eq!(genesis_config.accounts.len(), 4);
 
-        let yaml_string_keypair = "---
-\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,96,179,117,255,239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,230,249,47,150,168,163,159,83,233,97,18,25,238,103,25,253,108]\":
+        let yaml_string_keypair =
+            "---
+\"[17,12,234,59,35,246,168,6,64,36,169,164,219,96,253,79,238,202,164,160,195,89,9,96,179,117,255,\
+             239,32,64,124,66,233,130,19,107,172,54,86,32,119,148,4,39,199,40,122,230,249,47,150,\
+             168,163,159,83,233,97,18,25,238,103,25,253,108]\":
   balance: 20
   owner: 9ZfsP6Um1KU8d5gNzTsEbSJxanKYp5EPF36qUu4FJqgp
   data: Y2F0IGRvZw==
   executable: true
-\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,213,125,244,182,26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,247,235,222,27,219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":
+\"[36,246,244,43,37,214,110,50,134,148,148,8,205,82,233,67,223,245,122,5,149,232,213,125,244,182,\
+             26,29,56,224,70,45,42,163,71,62,222,33,229,54,73,136,53,174,128,103,247,235,222,27,\
+             219,129,180,77,225,174,220,74,201,123,97,155,159,234]\":
   balance: 15
   owner: F9dmtjJPi8vfLu1EJN4KkyoGdXGmVfSAhxz35Qo9RDCJ
   data: bW9ua2V5IGVsZXBoYW50
   executable: false
-\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,215,156,80,251,114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,51,76,120,27,166,200,237,16,200,31,23,5,57,22,131,221]\":
+\"[103,27,132,107,42,149,72,113,24,138,225,109,209,31,158,6,26,11,8,76,24,128,131,215,156,80,251,\
+             114,103,220,111,235,56,22,87,5,209,56,53,12,224,170,10,66,82,42,11,138,51,76,120,27,\
+             166,200,237,16,200,31,23,5,57,22,131,221]\":
   balance: 30
   owner: AwAR5mAbNPbvQ4CvMeBxwWE8caigQoMC2chkWAbh2b9V
   data: Y29tYSBtb2Nh

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -188,7 +188,8 @@ impl GeyserPluginManager {
             return Err(jsonrpc_core::Error {
                 code: ErrorCode::InvalidRequest,
                 message: format!(
-                    "There already exists a plugin named {} loaded, while reloading {name}. Did not load requested plugin",
+                    "There already exists a plugin named {} loaded, while reloading {name}. Did \
+                     not load requested plugin",
                     new_plugin.name()
                 ),
                 data: None,
@@ -312,7 +313,8 @@ pub(crate) fn load_plugin_from_config(
         Ok(file) => file,
         Err(err) => {
             return Err(GeyserPluginManagerError::CannotOpenConfigFile(format!(
-                "Failed to open the plugin config file {geyser_plugin_config_file:?}, error: {err:?}"
+                "Failed to open the plugin config file {geyser_plugin_config_file:?}, error: \
+                 {err:?}"
             )));
         }
     };
@@ -328,7 +330,8 @@ pub(crate) fn load_plugin_from_config(
         Ok(value) => value,
         Err(err) => {
             return Err(GeyserPluginManagerError::InvalidConfigFileFormat(format!(
-                "The config file {geyser_plugin_config_file:?} is not in a valid Json5 format, error: {err:?}"
+                "The config file {geyser_plugin_config_file:?} is not in a valid Json5 format, \
+                 error: {err:?}"
             )));
         }
     };

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -15,7 +15,8 @@
 
 #[deprecated(
     since = "1.10.6",
-    note = "Please use `solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE}` instead"
+    note = "Please use `solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, \
+            VALIDATOR_PORT_RANGE}` instead"
 )]
 #[allow(deprecated)]
 pub use solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE};
@@ -813,7 +814,9 @@ impl ClusterInfo {
                 }
 
                 let node_version = self.get_node_version(node.pubkey());
-                if my_shred_version != 0 && (node.shred_version() != 0 && node.shred_version() != my_shred_version) {
+                if my_shred_version != 0
+                    && (node.shred_version() != 0 && node.shred_version() != my_shred_version)
+                {
                     different_shred_nodes = different_shred_nodes.saturating_add(1);
                     None
                 } else {
@@ -822,7 +825,8 @@ impl ClusterInfo {
                     }
                     let ip_addr = node.gossip().as_ref().map(SocketAddr::ip).ok();
                     Some(format!(
-                        "{:15} {:2}| {:5} | {:44} |{:^9}| {:5}|  {:5}| {:5}| {:5}| {:5}| {:5}| {:5}| {}\n",
+                        "{:15} {:2}| {:5} | {:44} |{:^9}| {:5}|  {:5}| {:5}| {:5}| {:5}| {:5}| \
+                         {:5}| {}\n",
                         node.gossip()
                             .ok()
                             .filter(|addr| self.socket_addr_space.check(addr))
@@ -831,7 +835,11 @@ impl ClusterInfo {
                             .as_ref()
                             .map(IpAddr::to_string)
                             .unwrap_or_else(|| String::from("none")),
-                        if node.pubkey() == &my_pubkey { "me" } else { "" },
+                        if node.pubkey() == &my_pubkey {
+                            "me"
+                        } else {
+                            ""
+                        },
                         now.saturating_sub(last_updated),
                         node.pubkey(),
                         if let Some(node_version) = node_version {
@@ -842,10 +850,16 @@ impl ClusterInfo {
                         self.addr_to_string(&ip_addr, &node.gossip().ok()),
                         self.addr_to_string(&ip_addr, &node.tpu_vote().ok()),
                         self.addr_to_string(&ip_addr, &node.tpu(contact_info::Protocol::UDP).ok()),
-                        self.addr_to_string(&ip_addr, &node.tpu_forwards(contact_info::Protocol::UDP).ok()),
+                        self.addr_to_string(
+                            &ip_addr,
+                            &node.tpu_forwards(contact_info::Protocol::UDP).ok()
+                        ),
                         self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::UDP).ok()),
                         self.addr_to_string(&ip_addr, &node.tvu(contact_info::Protocol::QUIC).ok()),
-                        self.addr_to_string(&ip_addr, &node.serve_repair(contact_info::Protocol::UDP).ok()),
+                        self.addr_to_string(
+                            &ip_addr,
+                            &node.serve_repair(contact_info::Protocol::UDP).ok()
+                        ),
                         node.shred_version(),
                     ))
                 }

--- a/gossip/src/main.rs
+++ b/gossip/src/main.rs
@@ -106,8 +106,11 @@ fn parse_matches() -> ArgMatches<'static> {
                         .value_name("HOST")
                         .takes_value(true)
                         .validator(solana_net_utils::is_host)
-                        .help("Gossip DNS name or IP address for the node to advertise in gossip \
-                               [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]"),
+                        .help(
+                            "Gossip DNS name or IP address for the node to advertise in gossip \
+                             [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not \
+                             provided]",
+                        ),
                 )
                 .arg(
                     Arg::with_name("identity")

--- a/gossip/tests/crds_gossip.rs
+++ b/gossip/tests/crds_gossip.rs
@@ -446,16 +446,17 @@ fn network_run_push(
             .map(|node| node.gossip.push.num_pending(&node.gossip.crds))
             .sum();
         trace!(
-                "network_run_push_{}: now: {} queue: {} bytes: {} num_msgs: {} prunes: {} stake_pruned: {} delivered: {}",
-                num,
-                now,
-                total,
-                bytes,
-                num_msgs,
-                prunes,
-                stake_pruned,
-                delivered,
-            );
+            "network_run_push_{}: now: {} queue: {} bytes: {} num_msgs: {} prunes: {} \
+             stake_pruned: {} delivered: {}",
+            num,
+            now,
+            total,
+            bytes,
+            num_msgs,
+            prunes,
+            stake_pruned,
+            delivered,
+        );
     }
 
     network.stake_pruned += stake_pruned;
@@ -599,15 +600,16 @@ fn network_run_pull(
             break;
         }
         trace!(
-                "network_run_pull_{}: now: {} connections: {} convergance: {} bytes: {} msgs: {} overhead: {}",
-                num,
-                now,
-                total,
-                convergance,
-                bytes,
-                msgs,
-                overhead
-            );
+            "network_run_pull_{}: now: {} connections: {} convergance: {} bytes: {} msgs: {} \
+             overhead: {}",
+            num,
+            now,
+            total,
+            convergance,
+            bytes,
+            msgs,
+            overhead
+        );
     }
     (convergance, bytes)
 }

--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -305,7 +305,8 @@ fn check_env_path_for_bin_dir(config: &Config) {
 
     if !found {
         println!(
-            "\nPlease update your PATH environment variable to include the solana programs:\n    PATH=\"{}:$PATH\"\n",
+            "\nPlease update your PATH environment variable to include the solana programs:\n    \
+             PATH=\"{}:$PATH\"\n",
             config.active_release_bin_dir().to_str().unwrap()
         );
     }
@@ -367,7 +368,10 @@ fn get_windows_path_var() -> Result<Option<String>, String> {
             if let Some(s) = string_from_winreg_value(&val) {
                 Ok(Some(s))
             } else {
-                println!("the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid Unicode. Not modifying the PATH variable");
+                println!(
+                    "the registry key HKEY_CURRENT_USER\\Environment\\PATH does not contain valid \
+                     Unicode. Not modifying the PATH variable"
+                );
                 Ok(None)
             }
         }
@@ -439,9 +443,14 @@ fn add_to_path(new_path: &str) -> bool {
 
     println!(
         "\n{}\n  {}\n\n{}",
-        style("The HKEY_CURRENT_USER/Environment/PATH registry key has been modified to include:").bold(),
+        style("The HKEY_CURRENT_USER/Environment/PATH registry key has been modified to include:")
+            .bold(),
         new_path,
-        style("Future applications will automatically have the correct environment, but you may need to restart your current shell.").bold()
+        style(
+            "Future applications will automatically have the correct environment, but you may \
+             need to restart your current shell."
+        )
+        .bold()
     );
     true
 }
@@ -524,9 +533,14 @@ fn add_to_path(new_path: &str) -> bool {
     if modified_rcfiles {
         println!(
             "\n{}\n  {}\n",
-            style("Close and reopen your terminal to apply the PATH changes or run the following in your existing shell:").bold().blue(),
+            style(
+                "Close and reopen your terminal to apply the PATH changes or run the following in \
+                 your existing shell:"
+            )
+            .bold()
+            .blue(),
             shell_export_string
-       );
+        );
     }
 
     modified_rcfiles
@@ -1006,8 +1020,9 @@ pub fn init_or_update(config_file: &str, is_init: bool, check_only: bool) -> Res
                                         == active_release_version.channel
                                     {
                                         println!(
-                                        "Install is up to date. {release_semver} is the latest compatible release"
-                                    );
+                                            "Install is up to date. {release_semver} is the \
+                                             latest compatible release"
+                                        );
                                         return Ok(false);
                                     }
                                 }
@@ -1293,8 +1308,8 @@ pub fn list(config_file: &str) -> Result<(), String> {
 
     let entries = fs::read_dir(&config.releases_dir).map_err(|err| {
         format!(
-            "Failed to read install directory, \
-            double check that your configuration file is correct: {err}"
+            "Failed to read install directory, double check that your configuration file is \
+             correct: {err}"
         )
     })?;
 

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -258,11 +258,14 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .help("Filepath or URL to a keypair"),
-                )
+                ),
         )
         .subcommand(
             Command::new("new")
-                .about("Generate new keypair file from a random seed phrase and optional BIP39 passphrase")
+                .about(
+                    "Generate new keypair file from a random seed phrase and optional BIP39 \
+                     passphrase",
+                )
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("outfile")
@@ -278,19 +281,13 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .long("force")
                         .help("Overwrite the output file if it exists"),
                 )
-                .arg(
-                    Arg::new("silent")
-                        .short('s')
-                        .long("silent")
-                        .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
-                )
-                .arg(
-                    derivation_path_arg()
-                )
+                .arg(Arg::new("silent").short('s').long("silent").help(
+                    "Do not display seed phrase. Useful when piping output to other programs that \
+                     prompt for user input, like gpg",
+                ))
+                .arg(derivation_path_arg())
                 .key_generation_common_args()
-                .arg(no_outfile_arg()
-                    .conflicts_with_all(&["outfile", "silent"])
-                )
+                .arg(no_outfile_arg().conflicts_with_all(&["outfile", "silent"])),
         )
         .subcommand(
             Command::new("grind")
@@ -310,7 +307,11 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .multiple_occurrences(true)
                         .multiple_values(true)
                         .validator(grind_validator_starts_with)
-                        .help("Saves specified number of keypairs whos public key starts with the indicated prefix\nExample: --starts-with sol:4\nPREFIX type is Base58\nCOUNT type is u64"),
+                        .help(
+                            "Saves specified number of keypairs whos public key starts with the \
+                             indicated prefix\nExample: --starts-with sol:4\nPREFIX type is \
+                             Base58\nCOUNT type is u64",
+                        ),
                 )
                 .arg(
                     Arg::new("ends_with")
@@ -321,7 +322,11 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .multiple_occurrences(true)
                         .multiple_values(true)
                         .validator(grind_validator_ends_with)
-                        .help("Saves specified number of keypairs whos public key ends with the indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is Base58\nCOUNT type is u64"),
+                        .help(
+                            "Saves specified number of keypairs whos public key ends with the \
+                             indicated suffix\nExample: --ends-with ana:4\nSUFFIX type is \
+                             Base58\nCOUNT type is u64",
+                        ),
                 )
                 .arg(
                     Arg::new("starts_and_ends_with")
@@ -332,7 +337,12 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .multiple_occurrences(true)
                         .multiple_values(true)
                         .validator(grind_validator_starts_and_ends_with)
-                        .help("Saves specified number of keypairs whos public key starts and ends with the indicated perfix and suffix\nExample: --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is Base58\nCOUNT type is u64"),
+                        .help(
+                            "Saves specified number of keypairs whos public key starts and ends \
+                             with the indicated perfix and suffix\nExample: \
+                             --starts-and-ends-with sol:ana:4\nPREFIX and SUFFIX type is \
+                             Base58\nCOUNT type is u64",
+                        ),
                 )
                 .arg(
                     Arg::new("num_threads")
@@ -343,22 +353,18 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .default_value(num_threads)
                         .help("Specify the number of grind threads"),
                 )
-                .arg(
-                    Arg::new("use_mnemonic")
-                        .long("use-mnemonic")
-                        .help("Generate using a mnemonic key phrase.  Expect a significant slowdown in this mode"),
-                )
-                .arg(
-                    derivation_path_arg()
-                        .requires("use_mnemonic")
-                )
+                .arg(Arg::new("use_mnemonic").long("use-mnemonic").help(
+                    "Generate using a mnemonic key phrase.  Expect a significant slowdown in this \
+                     mode",
+                ))
+                .arg(derivation_path_arg().requires("use_mnemonic"))
                 .key_generation_common_args()
                 .arg(
                     no_outfile_arg()
-                    // Require a seed phrase to avoid generating a keypair
-                    // but having no way to get the private key
-                    .requires("use_mnemonic")
-                )
+                        // Require a seed phrase to avoid generating a keypair
+                        // but having no way to get the private key
+                        .requires("use_mnemonic"),
+                ),
         )
         .subcommand(
             Command::new("pubkey")
@@ -389,7 +395,7 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .short('f')
                         .long("force")
                         .help("Overwrite the output file if it exists"),
-                )
+                ),
         )
         .subcommand(
             Command::new("recover")
@@ -422,7 +428,6 @@ fn app<'a>(num_threads: &'a str, crate_version: &'a str) -> Command<'a> {
                         .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
                         .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
                 ),
-
         )
 }
 
@@ -504,8 +509,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 let phrase: &str = mnemonic.phrase();
                 let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                 println!(
-                    "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new keypair:\n{}\n{}",
-                    &divider, keypair.pubkey(), &divider, passphrase_message, phrase, &divider
+                    "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new \
+                     keypair:\n{}\n{}",
+                    &divider,
+                    keypair.pubkey(),
+                    &divider,
+                    passphrase_message,
+                    phrase,
+                    &divider
                 );
             }
         }
@@ -567,7 +578,9 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                 && starts_and_ends_with_args.is_empty()
             {
                 return Err(
-                    "Error: No keypair search criteria provided (--starts-with or --ends-with or --starts-and-ends-with)".into()
+                    "Error: No keypair search criteria provided (--starts-with or --ends-with or \
+                     --starts-and-ends-with)"
+                        .into(),
                 );
             }
 
@@ -648,15 +661,21 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                             let mnemonic = Mnemonic::new(mnemonic_type, language);
                             let seed = Seed::new(&mnemonic, &passphrase);
                             let keypair = match derivation_path {
-                                Some(_) => keypair_from_seed_and_derivation_path(seed.as_bytes(), derivation_path.clone()),
+                                Some(_) => keypair_from_seed_and_derivation_path(
+                                    seed.as_bytes(),
+                                    derivation_path.clone(),
+                                ),
                                 None => keypair_from_seed(seed.as_bytes()),
-                            }.unwrap();
+                            }
+                            .unwrap();
                             (keypair, mnemonic.phrase().to_string())
                         } else {
                             (Keypair::new(), "".to_string())
                         };
                         // Skip keypairs that will never match the user specified prefix
-                        if skip_len_44_pubkeys && keypair.pubkey() >= smallest_length_44_public_key::PUBKEY {
+                        if skip_len_44_pubkeys
+                            && keypair.pubkey() >= smallest_length_44_public_key::PUBKEY
+                        {
                             continue;
                         }
                         let mut pubkey = bs58::encode(keypair.pubkey()).into_string();
@@ -685,7 +704,10 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                                     .count
                                     .fetch_sub(1, Ordering::Relaxed);
                                 if !no_outfile {
-                                    write_keypair_file(&keypair, &format!("{}.json", keypair.pubkey()))
+                                    write_keypair_file(
+                                        &keypair,
+                                        &format!("{}.json", keypair.pubkey()),
+                                    )
                                     .unwrap();
                                     println!(
                                         "Wrote keypair to {}",
@@ -693,12 +715,16 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                                     );
                                 }
                                 if use_mnemonic {
-                                    let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
+                                    let divider =
+                                        String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                                     println!(
                                         "{}\nFound matching key {}",
-                                        &divider, keypair.pubkey());
+                                        &divider,
+                                        keypair.pubkey()
+                                    );
                                     println!(
-                                        "\nSave this seed phrase{} to recover your new keypair:\n{}\n{}",
+                                        "\nSave this seed phrase{} to recover your new \
+                                         keypair:\n{}\n{}",
                                         passphrase_message, phrase, &divider
                                     );
                                 }

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -453,7 +453,10 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                     debug!("worker {}: received slot {}", i, slot);
 
                     if !args.force {
-                        match destination_bigtable_clone.confirmed_block_exists(slot).await {
+                        match destination_bigtable_clone
+                            .confirmed_block_exists(slot)
+                            .await
+                        {
                             Ok(exist) => {
                                 if exist {
                                     skip_slots_clone.lock().unwrap().push(slot);
@@ -461,7 +464,11 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                             Err(err) => {
-                                error!("confirmed_block_exists() failed from the destination Bigtable, slot: {}, err: {}", slot, err);
+                                error!(
+                                    "confirmed_block_exists() failed from the destination \
+                                     Bigtable, slot: {}, err: {}",
+                                    slot, err
+                                );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
                             }
@@ -481,33 +488,44 @@ async fn copy(args: CopyArgs) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                             Err(err) => {
-                                error!("failed to get a confirmed block from the source Bigtable, slot: {}, err: {}", slot, err);
+                                error!(
+                                    "failed to get a confirmed block from the source Bigtable, \
+                                     slot: {}, err: {}",
+                                    slot, err
+                                );
                                 failed_slots_clone.lock().unwrap().push(slot);
                                 continue;
                             }
                         };
                     } else {
                         let confirmed_block =
-                        match source_bigtable_clone.get_confirmed_block(slot).await {
-                            Ok(block) => match VersionedConfirmedBlock::try_from(block) {
-                                Ok(block) => block,
+                            match source_bigtable_clone.get_confirmed_block(slot).await {
+                                Ok(block) => match VersionedConfirmedBlock::try_from(block) {
+                                    Ok(block) => block,
+                                    Err(err) => {
+                                        error!(
+                                            "failed to convert confirmed block to versioned \
+                                             confirmed block, slot: {}, err: {}",
+                                            slot, err
+                                        );
+                                        failed_slots_clone.lock().unwrap().push(slot);
+                                        continue;
+                                    }
+                                },
+                                Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
+                                    debug!("block not found, slot: {}", slot);
+                                    block_not_found_slots_clone.lock().unwrap().push(slot);
+                                    continue;
+                                }
                                 Err(err) => {
-                                    error!("failed to convert confirmed block to versioned confirmed block, slot: {}, err: {}", slot, err);
+                                    error!(
+                                        "failed to get confirmed block, slot: {}, err: {}",
+                                        slot, err
+                                    );
                                     failed_slots_clone.lock().unwrap().push(slot);
                                     continue;
                                 }
-                            },
-                            Err(solana_storage_bigtable::Error::BlockNotFound(slot)) => {
-                                debug!("block not found, slot: {}", slot);
-                                block_not_found_slots_clone.lock().unwrap().push(slot);
-                                continue;
-                            }
-                            Err(err) => {
-                                error!("failed to get confirmed block, slot: {}, err: {}", slot, err);
-                                failed_slots_clone.lock().unwrap().push(slot);
-                                continue;
-                            }
-                        };
+                            };
 
                         match destination_bigtable_clone
                             .upload_confirmed_block(slot, confirmed_block)
@@ -609,7 +627,7 @@ impl BigTableSubCommand for App<'_, '_> {
                         .takes_value(true)
                         .value_name("INSTANCE_NAME")
                         .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
-                        .help("Name of the target Bigtable instance")
+                        .help("Name of the target Bigtable instance"),
                 )
                 .arg(
                     Arg::with_name("rpc_bigtable_app_profile_id")
@@ -618,7 +636,7 @@ impl BigTableSubCommand for App<'_, '_> {
                         .takes_value(true)
                         .value_name("APP_PROFILE_ID")
                         .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
-                        .help("Bigtable application profile id to use in requests")
+                        .help("Bigtable application profile id to use in requests"),
                 )
                 .subcommand(
                     SubCommand::with_name("upload")
@@ -648,9 +666,9 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .long("force")
                                 .takes_value(false)
                                 .help(
-                                    "Force reupload of any blocks already present in BigTable instance\
-                                    Note: reupload will *not* delete any data from the tx-by-addr table;\
-                                    Use with care.",
+                                    "Force reupload of any blocks already present in BigTable \
+                                     instanceNote: reupload will *not* delete any data from the \
+                                     tx-by-addr table;Use with care.",
                                 ),
                         ),
                 )
@@ -658,24 +676,25 @@ impl BigTableSubCommand for App<'_, '_> {
                     SubCommand::with_name("delete-slots")
                         .about("Delete ledger information from BigTable")
                         .arg(
-                                Arg::with_name("slots")
-                                    .index(1)
-                                    .value_name("SLOTS")
-                                    .takes_value(true)
-                                    .multiple(true)
-                                    .required(true)
-                                    .help("Slots to delete"),
-                                )
-                            .arg(
-                                Arg::with_name("force")
-                                    .long("force")
-                                    .takes_value(false)
-                                    .help(
-                                        "Deletions are only performed when the force flag is enabled. \
-                                        If force is not enabled, show stats about what ledger data \
-                                        will be deleted in a real deletion. "),
-                            ),
+                            Arg::with_name("slots")
+                                .index(1)
+                                .value_name("SLOTS")
+                                .takes_value(true)
+                                .multiple(true)
+                                .required(true)
+                                .help("Slots to delete"),
                         )
+                        .arg(
+                            Arg::with_name("force")
+                                .long("force")
+                                .takes_value(false)
+                                .help(
+                                    "Deletions are only performed when the force flag is enabled. \
+                                     If force is not enabled, show stats about what ledger data \
+                                     will be deleted in a real deletion. ",
+                                ),
+                        ),
+                )
                 .subcommand(
                     SubCommand::with_name("first-available-block")
                         .about("Get the first available block in the storage"),
@@ -708,8 +727,10 @@ impl BigTableSubCommand for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("compare-blocks")
-                        .about("Find the missing confirmed blocks of an owned bigtable for a given range \
-                                by comparing to a reference bigtable")
+                        .about(
+                            "Find the missing confirmed blocks of an owned bigtable for a given \
+                             range by comparing to a reference bigtable",
+                        )
                         .arg(
                             Arg::with_name("starting_slot")
                                 .validator(is_slot)
@@ -745,7 +766,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("INSTANCE_NAME")
                                 .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
-                                .help("Name of the reference Bigtable instance to compare to")
+                                .help("Name of the reference Bigtable instance to compare to"),
                         )
                         .arg(
                             Arg::with_name("reference_app_profile_id")
@@ -753,7 +774,9 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("APP_PROFILE_ID")
                                 .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
-                                .help("Reference Bigtable application profile id to use in requests")
+                                .help(
+                                    "Reference Bigtable application profile id to use in requests",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -785,8 +808,8 @@ impl BigTableSubCommand for App<'_, '_> {
                 .subcommand(
                     SubCommand::with_name("transaction-history")
                         .about(
-                            "Show historical transactions affecting the given address \
-                             from newest to oldest",
+                            "Show historical transactions affecting the given address from newest \
+                             to oldest",
                         )
                         .arg(
                             Arg::with_name("address")
@@ -814,9 +837,9 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .validator(is_slot)
                                 .default_value("1000")
                                 .help(
-                                    "Number of transaction signatures to query at once. \
-                                       Smaller: more responsive/lower throughput. \
-                                       Larger: less responsive/higher throughput",
+                                    "Number of transaction signatures to query at once. Smaller: \
+                                     more responsive/lower throughput. Larger: less \
+                                     responsive/higher throughput",
                                 ),
                         )
                         .arg(
@@ -850,7 +873,8 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .conflicts_with("emulated_source")
                                 .help(
-                                    "Source Bigtable credential filepath (credential may be readonly)",
+                                    "Source Bigtable credential filepath (credential may be \
+                                     readonly)",
                                 ),
                         )
                         .arg(
@@ -859,9 +883,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("EMULATED_SOURCE")
                                 .takes_value(true)
                                 .conflicts_with("source_credential_path")
-                                .help(
-                                    "Source Bigtable emulated source",
-                                ),
+                                .help("Source Bigtable emulated source"),
                         )
                         .arg(
                             Arg::with_name("source_instance_name")
@@ -869,7 +891,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("SOURCE_INSTANCE_NAME")
                                 .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
-                                .help("Source Bigtable instance name")
+                                .help("Source Bigtable instance name"),
                         )
                         .arg(
                             Arg::with_name("source_app_profile_id")
@@ -877,7 +899,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("SOURCE_APP_PROFILE_ID")
                                 .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
-                                .help("Source Bigtable app profile id")
+                                .help("Source Bigtable app profile id"),
                         )
                         .arg(
                             Arg::with_name("destination_credential_path")
@@ -886,7 +908,8 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .conflicts_with("emulated_destination")
                                 .help(
-                                    "Destination Bigtable credential filepath (credential must have Bigtable write permissions)",
+                                    "Destination Bigtable credential filepath (credential must \
+                                     have Bigtable write permissions)",
                                 ),
                         )
                         .arg(
@@ -895,9 +918,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("EMULATED_DESTINATION")
                                 .takes_value(true)
                                 .conflicts_with("destination_credential_path")
-                                .help(
-                                    "Destination Bigtable emulated destination",
-                                ),
+                                .help("Destination Bigtable emulated destination"),
                         )
                         .arg(
                             Arg::with_name("destination_instance_name")
@@ -905,7 +926,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("DESTINATION_INSTANCE_NAME")
                                 .default_value(solana_storage_bigtable::DEFAULT_INSTANCE_NAME)
-                                .help("Destination Bigtable instance name")
+                                .help("Destination Bigtable instance name"),
                         )
                         .arg(
                             Arg::with_name("destination_app_profile_id")
@@ -913,7 +934,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .value_name("DESTINATION_APP_PROFILE_ID")
                                 .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
-                                .help("Destination Bigtable app profile id")
+                                .help("Destination Bigtable app profile id"),
                         )
                         .arg(
                             Arg::with_name("starting_slot")
@@ -922,9 +943,7 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .value_name("START_SLOT")
                                 .takes_value(true)
                                 .required(true)
-                                .help(
-                                    "Start copying at this slot",
-                                ),
+                                .help("Start copying at this slot"),
                         )
                         .arg(
                             Arg::with_name("ending_slot")
@@ -932,26 +951,28 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .validator(is_slot)
                                 .value_name("END_SLOT")
                                 .takes_value(true)
-                                .help("Stop copying at this slot (inclusive, START_SLOT ..= END_SLOT)"),
+                                .help(
+                                    "Stop copying at this slot (inclusive, START_SLOT ..= \
+                                     END_SLOT)",
+                                ),
                         )
                         .arg(
                             Arg::with_name("force")
-                            .long("force")
-                            .value_name("FORCE")
-                            .takes_value(false)
-                            .help(
-                                "Force copy of blocks already present in destination Bigtable instance",
-                            ),
+                                .long("force")
+                                .value_name("FORCE")
+                                .takes_value(false)
+                                .help(
+                                    "Force copy of blocks already present in destination Bigtable \
+                                     instance",
+                                ),
                         )
                         .arg(
                             Arg::with_name("dry_run")
-                            .long("dry-run")
-                            .value_name("DRY_RUN")
-                            .takes_value(false)
-                            .help(
-                                "Dry run. It won't upload any blocks",
-                            ),
-                        )
+                                .long("dry-run")
+                                .value_name("DRY_RUN")
+                                .takes_value(false)
+                                .help("Dry run. It won't upload any blocks"),
+                        ),
                 ),
         )
     }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -109,8 +109,8 @@ pub fn load_and_process_ledger(
         })
     };
 
-    let start_slot_msg = "The starting slot will be the latest snapshot slot, or genesis if \
-        the --no-snapshot flag is specified or if no snapshots are found.";
+    let start_slot_msg = "The starting slot will be the latest snapshot slot, or genesis if the \
+                          --no-snapshot flag is specified or if no snapshots are found.";
     match process_options.halt_at_slot {
         // Skip the following checks for sentinel values of Some(0) and None.
         // For Some(0), no slots will be be replayed after starting_slot.
@@ -120,7 +120,7 @@ pub fn load_and_process_ledger(
             if halt_slot < starting_slot {
                 eprintln!(
                     "Unable to process blockstore from starting slot {starting_slot} to \
-                    {halt_slot}; the ending slot is less than the starting slot. {start_slot_msg}"
+                     {halt_slot}; the ending slot is less than the starting slot. {start_slot_msg}"
                 );
                 exit(1);
             }
@@ -128,8 +128,8 @@ pub fn load_and_process_ledger(
             if !blockstore.slot_range_connected(starting_slot, halt_slot) {
                 eprintln!(
                     "Unable to process blockstore from starting slot {starting_slot} to \
-                    {halt_slot}; the blockstore does not contain a replayable chain between these \
-                    slots. {start_slot_msg}"
+                     {halt_slot}; the blockstore does not contain a replayable chain between \
+                     these slots. {start_slot_msg}"
                 );
                 exit(1);
             }
@@ -367,8 +367,8 @@ pub fn open_blockstore(
     let shred_storage_type = get_shred_storage_type(
         ledger_path,
         &format!(
-            "Shred storage type cannot be inferred for ledger at {ledger_path:?}, \
-         using default RocksLevel",
+            "Shred storage type cannot be inferred for ledger at {ledger_path:?}, using default \
+             RocksLevel",
         ),
     );
 
@@ -401,13 +401,13 @@ pub fn open_blockstore(
 
             if missing_blockstore && is_secondary {
                 eprintln!(
-                    "Failed to open blockstore at {ledger_path:?}, it \
-                    is missing at least one critical file: {err:?}"
+                    "Failed to open blockstore at {ledger_path:?}, it is missing at least one \
+                     critical file: {err:?}"
                 );
             } else if missing_column && is_secondary {
                 eprintln!(
-                    "Failed to open blockstore at {ledger_path:?}, it \
-                    does not have all necessary columns: {err:?}"
+                    "Failed to open blockstore at {ledger_path:?}, it does not have all necessary \
+                     columns: {err:?}"
                 );
             } else {
                 eprintln!("Failed to open blockstore at {ledger_path:?}: {err:?}");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -244,7 +244,8 @@ fn output_slot(
                 println!("  {meta:?} is_full: {is_full}");
             } else {
                 println!(
-                    "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, is_full: {}",
+                    "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, \
+                     is_full: {}",
                     num_shreds,
                     meta.parent_slot,
                     meta.next_slots,
@@ -880,7 +881,8 @@ fn print_blockstore_file_metadata(
     for file in live_files {
         if sst_file_name.is_none() || file.name.eq(sst_file_name.as_ref().unwrap()) {
             println!(
-                "[{}] cf_name: {}, level: {}, start_slot: {:?}, end_slot: {:?}, size: {}, num_entries: {}",
+                "[{}] cf_name: {}, level: {}, start_slot: {:?}, end_slot: {:?}, size: {}, \
+                 num_entries: {}",
                 file.name,
                 file.column_family_name,
                 file.level,
@@ -942,7 +944,8 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
                 let result = cost_tracker.try_add(&tx_cost);
                 if result.is_err() {
                     println!(
-                        "Slot: {slot}, CostModel rejected transaction {transaction:?}, reason {result:?}",
+                        "Slot: {slot}, CostModel rejected transaction {transaction:?}, reason \
+                         {result:?}",
                     );
                 }
                 for (program_id, _instruction) in transaction.message().program_instructions_iter()
@@ -953,7 +956,8 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
     }
 
     println!(
-        "Slot: {slot}, Entries: {num_entries}, Transactions: {num_transactions}, Programs {num_programs}",
+        "Slot: {slot}, Entries: {num_entries}, Transactions: {num_transactions}, Programs \
+         {num_programs}",
     );
     println!("  Programs: {program_ids:?}");
 
@@ -1011,7 +1015,7 @@ fn get_latest_optimistic_slots(
         if hash_and_timestamp_opt.is_none() {
             warn!(
                 "Slot {slot} is an ancestor of latest optimistically confirmed slot \
-                {latest_slot}, but was not marked as optimistically confirmed in blockstore."
+                 {latest_slot}, but was not marked as optimistically confirmed in blockstore."
             );
         }
         (slot, hash_and_timestamp_opt, contains_nonvote_tx)
@@ -1117,16 +1121,22 @@ fn main() {
         .value_name("MEGABYTES")
         .validator(is_parsable::<usize>)
         .takes_value(true)
-        .help("How much memory the accounts index can consume. If this is exceeded, some account index entries will be stored on disk.");
+        .help(
+            "How much memory the accounts index can consume. If this is exceeded, some account \
+             index entries will be stored on disk.",
+        );
     let disable_disk_index = Arg::with_name("disable_accounts_disk_index")
         .long("disable-accounts-disk-index")
-        .help("Disable the disk-based accounts index. It is enabled by default. The entire accounts index will be kept in memory.")
+        .help(
+            "Disable the disk-based accounts index. It is enabled by default. The entire accounts \
+             index will be kept in memory.",
+        )
         .conflicts_with("accounts_index_memory_limit_mb");
     let accountsdb_skip_shrink = Arg::with_name("accounts_db_skip_shrink")
         .long("accounts-db-skip-shrink")
         .help(
-            "Enables faster starting of ledger-tool by skipping shrink. \
-                      This option is for use during testing.",
+            "Enables faster starting of ledger-tool by skipping shrink. This option is for use \
+             during testing.",
         );
     let accountsdb_verify_refcounts = Arg::with_name("accounts_db_verify_refcounts")
         .long("accounts-db-verify-refcounts")
@@ -1134,12 +1144,14 @@ fn main() {
             "Debug option to scan all AppendVecs and verify account index refcounts prior to clean",
         )
         .hidden(hidden_unless_forced());
-    let accounts_db_test_skip_rewrites_but_include_in_bank_hash = Arg::with_name("accounts_db_test_skip_rewrites")
-        .long("accounts-db-test-skip-rewrites")
-        .help(
-            "Debug option to skip rewrites for rent-exempt accounts but still add them in bank delta hash calculation",
-        )
-        .hidden(hidden_unless_forced());
+    let accounts_db_test_skip_rewrites_but_include_in_bank_hash =
+        Arg::with_name("accounts_db_test_skip_rewrites")
+            .long("accounts-db-test-skip-rewrites")
+            .help(
+                "Debug option to skip rewrites for rent-exempt accounts but still add them in \
+                 bank delta hash calculation",
+            )
+            .hidden(hidden_unless_forced());
     let account_paths_arg = Arg::with_name("account_paths")
         .long("accounts")
         .value_name("PATHS")
@@ -1156,9 +1168,8 @@ fn main() {
         .takes_value(true)
         .multiple(true)
         .help(
-            "Persistent accounts-index location. \
-             May be specified multiple times. \
-             [default: [ledger]/accounts_index]",
+            "Persistent accounts-index location. May be specified multiple times. [default: \
+             [ledger]/accounts_index]",
         );
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")
@@ -1187,19 +1198,26 @@ fn main() {
         )
         .hidden(hidden_unless_forced());
     let halt_at_slot_store_hash_raw_data = Arg::with_name("halt_at_slot_store_hash_raw_data")
-            .long("halt-at-slot-store-hash-raw-data")
-            .help("After halting at slot, run an accounts hash calculation and store the raw hash data for debugging.")
-            .hidden(hidden_unless_forced());
+        .long("halt-at-slot-store-hash-raw-data")
+        .help(
+            "After halting at slot, run an accounts hash calculation and store the raw hash data \
+             for debugging.",
+        )
+        .hidden(hidden_unless_forced());
     let verify_index_arg = Arg::with_name("verify_accounts_index")
         .long("verify-accounts-index")
         .takes_value(false)
         .help("For debugging and tests on accounts index.");
-    let limit_load_slot_count_from_snapshot_arg = Arg::with_name("limit_load_slot_count_from_snapshot")
-        .long("limit-load-slot-count-from-snapshot")
-        .value_name("SLOT")
-        .validator(is_slot)
-        .takes_value(true)
-        .help("For debugging and profiling with large snapshots, artificially limit how many slots are loaded from a snapshot.");
+    let limit_load_slot_count_from_snapshot_arg =
+        Arg::with_name("limit_load_slot_count_from_snapshot")
+            .long("limit-load-slot-count-from-snapshot")
+            .value_name("SLOT")
+            .validator(is_slot)
+            .takes_value(true)
+            .help(
+                "For debugging and profiling with large snapshots, artificially limit how many \
+                 slots are loaded from a snapshot.",
+            );
     let hard_forks_arg = Arg::with_name("hard_forks")
         .long("hard-fork")
         .value_name("SLOT")
@@ -1223,9 +1241,8 @@ fn main() {
         .value_name("NUM_HASHES|\"sleep\"")
         .takes_value(true)
         .help(
-            "How many PoH hashes to roll before emitting the next tick. \
-             If \"sleep\", for development \
-             sleep for the target tick duration instead of hashing",
+            "How many PoH hashes to roll before emitting the next tick. If \"sleep\", for \
+             development sleep for the target tick duration instead of hashing",
         );
     let snapshot_version_arg = Arg::with_name("snapshot_version")
         .long("snapshot-version")
@@ -1252,30 +1269,32 @@ fn main() {
 
     let default_max_full_snapshot_archives_to_retain =
         &DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
-    let maximum_full_snapshot_archives_to_retain = Arg::with_name(
-        "maximum_full_snapshots_to_retain",
-    )
-    .long("maximum-full-snapshots-to-retain")
-    .alias("maximum-snapshots-to-retain")
-    .value_name("NUMBER")
-    .takes_value(true)
-    .default_value(default_max_full_snapshot_archives_to_retain)
-    .validator(validate_maximum_full_snapshot_archives_to_retain)
-    .help(
-        "The maximum number of full snapshot archives to hold on to when purging older snapshots.",
-    );
+    let maximum_full_snapshot_archives_to_retain =
+        Arg::with_name("maximum_full_snapshots_to_retain")
+            .long("maximum-full-snapshots-to-retain")
+            .alias("maximum-snapshots-to-retain")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .default_value(default_max_full_snapshot_archives_to_retain)
+            .validator(validate_maximum_full_snapshot_archives_to_retain)
+            .help(
+                "The maximum number of full snapshot archives to hold on to when purging older \
+                 snapshots.",
+            );
 
     let default_max_incremental_snapshot_archives_to_retain =
         &DEFAULT_MAX_INCREMENTAL_SNAPSHOT_ARCHIVES_TO_RETAIN.to_string();
-    let maximum_incremental_snapshot_archives_to_retain = Arg::with_name(
-        "maximum_incremental_snapshots_to_retain",
-    )
-    .long("maximum-incremental-snapshots-to-retain")
-    .value_name("NUMBER")
-    .takes_value(true)
-    .default_value(default_max_incremental_snapshot_archives_to_retain)
-    .validator(validate_maximum_incremental_snapshot_archives_to_retain)
-    .help("The maximum number of incremental snapshot archives to hold on to when purging older snapshots.");
+    let maximum_incremental_snapshot_archives_to_retain =
+        Arg::with_name("maximum_incremental_snapshots_to_retain")
+            .long("maximum-incremental-snapshots-to-retain")
+            .value_name("NUMBER")
+            .takes_value(true)
+            .default_value(default_max_incremental_snapshot_archives_to_retain)
+            .validator(validate_maximum_incremental_snapshot_archives_to_retain)
+            .help(
+                "The maximum number of incremental snapshot archives to hold on to when purging \
+                 older snapshots.",
+            );
 
     let geyser_plugin_args = Arg::with_name("geyser_plugin_config")
         .long("geyser-plugin-config")
@@ -1328,27 +1347,30 @@ fn main() {
                     "tolerate_corrupted_tail_records",
                     "absolute_consistency",
                     "point_in_time",
-                    "skip_any_corrupted_record"])
-                .help(
-                    "Mode to recovery the ledger db write ahead log"
-                ),
+                    "skip_any_corrupted_record",
+                ])
+                .help("Mode to recovery the ledger db write ahead log"),
         )
         .arg(
             Arg::with_name("force_update_to_open")
                 .long("force-update-to-open")
                 .takes_value(false)
                 .global(true)
-                .help("Allow commands that would otherwise not alter the \
-                       blockstore to make necessary updates in order to open it"),
+                .help(
+                    "Allow commands that would otherwise not alter the blockstore to make \
+                     necessary updates in order to open it",
+                ),
         )
         .arg(
             Arg::with_name("ignore_ulimit_nofile_error")
                 .long("ignore-ulimit-nofile-error")
                 .value_name("FORMAT")
                 .global(true)
-                .help("Allow opening the blockstore to succeed even if the desired open file \
-                    descriptor limit cannot be configured. Use with caution as some commands may \
-                    run fine with a reduced file descriptor limit while others will not"),
+                .help(
+                    "Allow opening the blockstore to succeed even if the desired open file \
+                     descriptor limit cannot be configured. Use with caution as some commands may \
+                     run fine with a reduced file descriptor limit while others will not",
+                ),
         )
         .arg(
             Arg::with_name("snapshot_archive_path")
@@ -1383,8 +1405,10 @@ fn main() {
                 .global(true)
                 .takes_value(true)
                 .possible_values(&["json", "json-compact"])
-                .help("Return information in specified output format, \
-                       currently only available for bigtable and program subcommands"),
+                .help(
+                    "Return information in specified output format, currently only available for \
+                     bigtable and program subcommands",
+                ),
         )
         .arg(
             Arg::with_name("verbose")
@@ -1398,702 +1422,756 @@ fn main() {
         .bigtable_subcommand()
         .subcommand(
             SubCommand::with_name("print")
-            .about("Print the ledger")
-            .arg(&starting_slot_arg)
-            .arg(&allow_dead_slots_arg)
-            .arg(&ending_slot_arg)
-            .arg(
-                Arg::with_name("num_slots")
-                    .long("num-slots")
-                    .value_name("SLOT")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .help("Number of slots to print"),
-            )
-            .arg(
-                Arg::with_name("only_rooted")
-                    .long("only-rooted")
-                    .takes_value(false)
-                    .help("Only print root slots"),
-            )
+                .about("Print the ledger")
+                .arg(&starting_slot_arg)
+                .arg(&allow_dead_slots_arg)
+                .arg(&ending_slot_arg)
+                .arg(
+                    Arg::with_name("num_slots")
+                        .long("num-slots")
+                        .value_name("SLOT")
+                        .validator(is_slot)
+                        .takes_value(true)
+                        .help("Number of slots to print"),
+                )
+                .arg(
+                    Arg::with_name("only_rooted")
+                        .long("only-rooted")
+                        .takes_value(false)
+                        .help("Only print root slots"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("copy")
-            .about("Copy the ledger")
-            .arg(&starting_slot_arg)
-            .arg(&ending_slot_arg)
-            .arg(
-                Arg::with_name("target_db")
-                    .long("target-db")
-                    .value_name("DIR")
-                    .takes_value(true)
-                    .help("Target db"),
-            )
+                .about("Copy the ledger")
+                .arg(&starting_slot_arg)
+                .arg(&ending_slot_arg)
+                .arg(
+                    Arg::with_name("target_db")
+                        .long("target-db")
+                        .value_name("DIR")
+                        .takes_value(true)
+                        .help("Target db"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("slot")
-            .about("Print the contents of one or more slots")
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .required(true)
-                    .help("Slots to print"),
-            )
-            .arg(&allow_dead_slots_arg)
+                .about("Print the contents of one or more slots")
+                .arg(
+                    Arg::with_name("slots")
+                        .index(1)
+                        .value_name("SLOTS")
+                        .validator(is_slot)
+                        .takes_value(true)
+                        .multiple(true)
+                        .required(true)
+                        .help("Slots to print"),
+                )
+                .arg(&allow_dead_slots_arg),
         )
         .subcommand(
             SubCommand::with_name("dead-slots")
-            .arg(&starting_slot_arg)
-            .about("Print all the dead slots in the ledger")
+                .arg(&starting_slot_arg)
+                .about("Print all the dead slots in the ledger"),
         )
         .subcommand(
             SubCommand::with_name("duplicate-slots")
-            .arg(&starting_slot_arg)
-            .about("Print all the duplicate slots in the ledger")
+                .arg(&starting_slot_arg)
+                .about("Print all the duplicate slots in the ledger"),
         )
         .subcommand(
             SubCommand::with_name("set-dead-slot")
-            .about("Mark one or more slots dead")
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .required(true)
-                    .help("Slots to mark dead"),
-            )
+                .about("Mark one or more slots dead")
+                .arg(
+                    Arg::with_name("slots")
+                        .index(1)
+                        .value_name("SLOTS")
+                        .validator(is_slot)
+                        .takes_value(true)
+                        .multiple(true)
+                        .required(true)
+                        .help("Slots to mark dead"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("remove-dead-slot")
-            .about("Remove the dead flag for a slot")
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .required(true)
-                    .help("Slots to mark as not dead"),
-            )
+                .about("Remove the dead flag for a slot")
+                .arg(
+                    Arg::with_name("slots")
+                        .index(1)
+                        .value_name("SLOTS")
+                        .validator(is_slot)
+                        .takes_value(true)
+                        .multiple(true)
+                        .required(true)
+                        .help("Slots to mark as not dead"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("genesis")
-            .about("Prints the ledger's genesis config")
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(
-                Arg::with_name("accounts")
-                    .long("accounts")
-                    .takes_value(false)
-                    .help("Print the ledger's genesis accounts"),
-            )
-            .arg(
-                Arg::with_name("no_account_data")
-                    .long("no-account-data")
-                    .takes_value(false)
-                    .requires("accounts")
-                    .help("Do not print account data when printing account contents."),
-            )
-            .arg(&accounts_data_encoding_arg)
+                .about("Prints the ledger's genesis config")
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(
+                    Arg::with_name("accounts")
+                        .long("accounts")
+                        .takes_value(false)
+                        .help("Print the ledger's genesis accounts"),
+                )
+                .arg(
+                    Arg::with_name("no_account_data")
+                        .long("no-account-data")
+                        .takes_value(false)
+                        .requires("accounts")
+                        .help("Do not print account data when printing account contents."),
+                )
+                .arg(&accounts_data_encoding_arg),
         )
         .subcommand(
             SubCommand::with_name("genesis-hash")
-            .about("Prints the ledger's genesis hash")
-            .arg(&max_genesis_archive_unpacked_size_arg)
+                .about("Prints the ledger's genesis hash")
+                .arg(&max_genesis_archive_unpacked_size_arg),
         )
         .subcommand(
             SubCommand::with_name("parse_full_frozen")
-            .about("Parses log for information about critical events about \
-                    ancestors of the given `ending_slot`")
-            .arg(&starting_slot_arg)
-            .arg(&ending_slot_arg)
-            .arg(
-                Arg::with_name("log_path")
-                    .long("log-path")
-                    .value_name("PATH")
-                    .takes_value(true)
-                    .help("path to log file to parse"),
-            )
+                .about(
+                    "Parses log for information about critical events about ancestors of the \
+                     given `ending_slot`",
+                )
+                .arg(&starting_slot_arg)
+                .arg(&ending_slot_arg)
+                .arg(
+                    Arg::with_name("log_path")
+                        .long("log-path")
+                        .value_name("PATH")
+                        .takes_value(true)
+                        .help("path to log file to parse"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("modify-genesis")
-            .about("Modifies genesis parameters")
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&hashes_per_tick)
-            .arg(
-                Arg::with_name("cluster_type")
-                    .long("cluster-type")
-                    .possible_values(&ClusterType::STRINGS)
-                    .takes_value(true)
-                    .help(
-                        "Selects the features that will be enabled for the cluster"
-                    ),
-            )
-            .arg(
-                Arg::with_name("output_directory")
-                    .index(1)
-                    .value_name("DIR")
-                    .takes_value(true)
-                    .help("Output directory for the modified genesis config"),
-            )
+                .about("Modifies genesis parameters")
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&hashes_per_tick)
+                .arg(
+                    Arg::with_name("cluster_type")
+                        .long("cluster-type")
+                        .possible_values(&ClusterType::STRINGS)
+                        .takes_value(true)
+                        .help("Selects the features that will be enabled for the cluster"),
+                )
+                .arg(
+                    Arg::with_name("output_directory")
+                        .index(1)
+                        .value_name("DIR")
+                        .takes_value(true)
+                        .help("Output directory for the modified genesis config"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("shred-version")
-            .about("Prints the ledger's shred hash")
-            .arg(&hard_forks_arg)
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .about("Prints the ledger's shred hash")
+                .arg(&hard_forks_arg)
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash),
         )
         .subcommand(
             SubCommand::with_name("shred-meta")
-            .about("Prints raw shred metadata")
-            .arg(&starting_slot_arg)
-            .arg(&ending_slot_arg)
+                .about("Prints raw shred metadata")
+                .arg(&starting_slot_arg)
+                .arg(&ending_slot_arg),
         )
         .subcommand(
             SubCommand::with_name("bank-hash")
-            .about("Prints the hash of the working bank after reading the ledger")
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&halt_at_slot_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .about("Prints the hash of the working bank after reading the ledger")
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&halt_at_slot_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash),
         )
         .subcommand(
             SubCommand::with_name("bounds")
-            .about(
-                "Print lowest and highest non-empty slots. \
-                Note that there may be empty slots within the bounds",
-            )
-            .arg(
-                Arg::with_name("all")
-                    .long("all")
-                    .takes_value(false)
-                    .required(false)
-                    .help("Additionally print all the non-empty slots within the bounds"),
-            )
+                .about(
+                    "Print lowest and highest non-empty slots. Note that there may be empty slots \
+                     within the bounds",
+                )
+                .arg(
+                    Arg::with_name("all")
+                        .long("all")
+                        .takes_value(false)
+                        .required(false)
+                        .help("Additionally print all the non-empty slots within the bounds"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("json")
-            .about("Print the ledger in JSON format")
-            .arg(&starting_slot_arg)
-            .arg(&allow_dead_slots_arg)
+                .about("Print the ledger in JSON format")
+                .arg(&starting_slot_arg)
+                .arg(&allow_dead_slots_arg),
         )
         .subcommand(
             SubCommand::with_name("verify")
-            .about("Verify the ledger")
-            .arg(&no_snapshot_arg)
-            .arg(&account_paths_arg)
-            .arg(&accounts_hash_cache_path_arg)
-            .arg(&accounts_index_path_arg)
-            .arg(&halt_at_slot_arg)
-            .arg(&limit_load_slot_count_from_snapshot_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_skip_shrink)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
-            .arg(&verify_index_arg)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&ancient_append_vecs)
-            .arg(&halt_at_slot_store_hash_raw_data)
-            .arg(&hard_forks_arg)
-            .arg(&accounts_db_test_hash_calculation_arg)
-            .arg(&no_os_memory_stats_reporting_arg)
-            .arg(&allow_dead_slots_arg)
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&debug_key_arg)
-            .arg(&geyser_plugin_args)
-            .arg(&use_snapshot_archives_at_startup)
-            .arg(
-                Arg::with_name("skip_poh_verify")
-                    .long("skip-poh-verify")
-                    .takes_value(false)
-                    .help(
-                        "Deprecated, please use --skip-verification.\n\
-                         Skip ledger PoH and transaction verification."
-                    ),
-            )
-            .arg(
-                Arg::with_name("skip_verification")
-                    .long("skip-verification")
-                    .takes_value(false)
-                    .help("Skip ledger PoH and transaction verification."),
-            )
-            .arg(
-                Arg::with_name("enable_rpc_transaction_history")
-                    .long("enable-rpc-transaction-history")
-                    .takes_value(false)
-                    .help("Store transaction info for processed slots into local ledger"),
-            )
-            .arg(
-                Arg::with_name("run_final_hash_calc")
-                    .long("run-final-accounts-hash-calculation")
-                    .takes_value(false)
-                    .help("After 'verify' completes, run a final accounts hash calculation. Final hash calculation could race with accounts background service tasks and assert."),
-            )
-            .arg(
-                Arg::with_name("partitioned_epoch_rewards_compare_calculation")
-                    .long("partitioned-epoch-rewards-compare-calculation")
-                    .takes_value(false)
-                    .help("Do normal epoch rewards distribution, but also calculate rewards using the partitioned rewards code path and compare the resulting vote and stake accounts")
-                    .hidden(hidden_unless_forced())
-            )
-            .arg(
-                Arg::with_name("partitioned_epoch_rewards_force_enable_single_slot")
-                    .long("partitioned-epoch-rewards-force-enable-single-slot")
-                    .takes_value(false)
-                    .help("Force the partitioned rewards distribution, but distribute all rewards in the first slot in the epoch. This should match consensus with the normal rewards distribution.")
-                    .conflicts_with("partitioned_epoch_rewards_compare_calculation")
-                    .hidden(hidden_unless_forced())
-            )
-            .arg(
-                Arg::with_name("print_accounts_stats")
-                    .long("print-accounts-stats")
-                    .takes_value(false)
-                    .help("After verifying the ledger, print some information about the account stores"),
-            )
-            .arg(
-                Arg::with_name("write_bank_file")
-                    .long("write-bank-file")
-                    .takes_value(false)
-                    .help("After verifying the ledger, write a file that contains the information \
-                        that went into computing the completed bank's bank hash. The file will be \
-                        written within <LEDGER_DIR>/bank_hash_details/"),
-            )
-        ).subcommand(
+                .about("Verify the ledger")
+                .arg(&no_snapshot_arg)
+                .arg(&account_paths_arg)
+                .arg(&accounts_hash_cache_path_arg)
+                .arg(&accounts_index_path_arg)
+                .arg(&halt_at_slot_arg)
+                .arg(&limit_load_slot_count_from_snapshot_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_skip_shrink)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .arg(&verify_index_arg)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&ancient_append_vecs)
+                .arg(&halt_at_slot_store_hash_raw_data)
+                .arg(&hard_forks_arg)
+                .arg(&accounts_db_test_hash_calculation_arg)
+                .arg(&no_os_memory_stats_reporting_arg)
+                .arg(&allow_dead_slots_arg)
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&debug_key_arg)
+                .arg(&geyser_plugin_args)
+                .arg(&use_snapshot_archives_at_startup)
+                .arg(
+                    Arg::with_name("skip_poh_verify")
+                        .long("skip-poh-verify")
+                        .takes_value(false)
+                        .help(
+                            "Deprecated, please use --skip-verification.\nSkip ledger PoH and \
+                             transaction verification.",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("skip_verification")
+                        .long("skip-verification")
+                        .takes_value(false)
+                        .help("Skip ledger PoH and transaction verification."),
+                )
+                .arg(
+                    Arg::with_name("enable_rpc_transaction_history")
+                        .long("enable-rpc-transaction-history")
+                        .takes_value(false)
+                        .help("Store transaction info for processed slots into local ledger"),
+                )
+                .arg(
+                    Arg::with_name("run_final_hash_calc")
+                        .long("run-final-accounts-hash-calculation")
+                        .takes_value(false)
+                        .help(
+                            "After 'verify' completes, run a final accounts hash calculation. \
+                             Final hash calculation could race with accounts background service \
+                             tasks and assert.",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("partitioned_epoch_rewards_compare_calculation")
+                        .long("partitioned-epoch-rewards-compare-calculation")
+                        .takes_value(false)
+                        .help(
+                            "Do normal epoch rewards distribution, but also calculate rewards \
+                             using the partitioned rewards code path and compare the resulting \
+                             vote and stake accounts",
+                        )
+                        .hidden(hidden_unless_forced()),
+                )
+                .arg(
+                    Arg::with_name("partitioned_epoch_rewards_force_enable_single_slot")
+                        .long("partitioned-epoch-rewards-force-enable-single-slot")
+                        .takes_value(false)
+                        .help(
+                            "Force the partitioned rewards distribution, but distribute all \
+                             rewards in the first slot in the epoch. This should match consensus \
+                             with the normal rewards distribution.",
+                        )
+                        .conflicts_with("partitioned_epoch_rewards_compare_calculation")
+                        .hidden(hidden_unless_forced()),
+                )
+                .arg(
+                    Arg::with_name("print_accounts_stats")
+                        .long("print-accounts-stats")
+                        .takes_value(false)
+                        .help(
+                            "After verifying the ledger, print some information about the account \
+                             stores",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("write_bank_file")
+                        .long("write-bank-file")
+                        .takes_value(false)
+                        .help(
+                            "After verifying the ledger, write a file that contains the \
+                             information that went into computing the completed bank's bank hash. \
+                             The file will be written within <LEDGER_DIR>/bank_hash_details/",
+                        ),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("graph")
-            .about("Create a Graphviz rendering of the ledger")
-            .arg(&no_snapshot_arg)
-            .arg(&account_paths_arg)
-            .arg(&accounts_hash_cache_path_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&halt_at_slot_arg)
-            .arg(&hard_forks_arg)
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&use_snapshot_archives_at_startup)
-            .arg(
-                Arg::with_name("include_all_votes")
-                    .long("include-all-votes")
-                    .help("Include all votes in the graph"),
-            )
-            .arg(
-                Arg::with_name("graph_filename")
-                    .index(1)
-                    .value_name("FILENAME")
-                    .takes_value(true)
-                    .help("Output file"),
-            )
-            .arg(
-                Arg::with_name("vote_account_mode")
-                    .long("vote-account-mode")
-                    .takes_value(true)
-                    .value_name("MODE")
-                    .default_value(default_graph_vote_account_mode.as_ref())
-                    .possible_values(GraphVoteAccountMode::ALL_MODE_STRINGS)
-                    .help("Specify if and how to graph vote accounts. Enabling will incur significant rendering overhead, especially `with-history`")
-            )
-        ).subcommand(
+                .about("Create a Graphviz rendering of the ledger")
+                .arg(&no_snapshot_arg)
+                .arg(&account_paths_arg)
+                .arg(&accounts_hash_cache_path_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&halt_at_slot_arg)
+                .arg(&hard_forks_arg)
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&use_snapshot_archives_at_startup)
+                .arg(
+                    Arg::with_name("include_all_votes")
+                        .long("include-all-votes")
+                        .help("Include all votes in the graph"),
+                )
+                .arg(
+                    Arg::with_name("graph_filename")
+                        .index(1)
+                        .value_name("FILENAME")
+                        .takes_value(true)
+                        .help("Output file"),
+                )
+                .arg(
+                    Arg::with_name("vote_account_mode")
+                        .long("vote-account-mode")
+                        .takes_value(true)
+                        .value_name("MODE")
+                        .default_value(default_graph_vote_account_mode.as_ref())
+                        .possible_values(GraphVoteAccountMode::ALL_MODE_STRINGS)
+                        .help(
+                            "Specify if and how to graph vote accounts. Enabling will incur \
+                             significant rendering overhead, especially `with-history`",
+                        ),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("create-snapshot")
-            .about("Create a new ledger snapshot")
-            .arg(&no_snapshot_arg)
-            .arg(&account_paths_arg)
-            .arg(&accounts_hash_cache_path_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&accountsdb_skip_shrink)
-            .arg(&ancient_append_vecs)
-            .arg(&hard_forks_arg)
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&snapshot_version_arg)
-            .arg(&maximum_full_snapshot_archives_to_retain)
-            .arg(&maximum_incremental_snapshot_archives_to_retain)
-            .arg(&geyser_plugin_args)
-            .arg(&use_snapshot_archives_at_startup)
-            .arg(
-                Arg::with_name("snapshot_slot")
-                    .index(1)
-                    .value_name("SLOT")
-                    .validator(|value| {
-                        if value.parse::<Slot>().is_ok()
-                            || value == "ROOT"
-                        {
-                            Ok(())
-                        } else {
-                            Err(format!(
-                                "Unable to parse as a number or the keyword ROOT, provided: {value}"
-                            ))
-                        }
-                    })
-                    .takes_value(true)
-                    .help("Slot at which to create the snapshot; accepts keyword ROOT for the highest root"),
-            )
-            .arg(
-                Arg::with_name("output_directory")
-                    .index(2)
-                    .value_name("DIR")
-                    .takes_value(true)
-                    .help("Output directory for the snapshot [default: --snapshot-archive-path if present else --ledger directory]"),
-            )
-            .arg(
-                Arg::with_name("warp_slot")
-                    .required(false)
-                    .long("warp-slot")
-                    .takes_value(true)
-                    .value_name("WARP_SLOT")
-                    .validator(is_slot)
-                    .help("After loading the snapshot slot warp the ledger to WARP_SLOT, \
-                           which could be a slot in a galaxy far far away"),
-            )
-            .arg(
-                Arg::with_name("faucet_lamports")
-                    .short("t")
-                    .long("faucet-lamports")
-                    .value_name("LAMPORTS")
-                    .takes_value(true)
-                    .requires("faucet_pubkey")
-                    .help("Number of lamports to assign to the faucet"),
-            )
-            .arg(
-                Arg::with_name("faucet_pubkey")
-                    .short("m")
-                    .long("faucet-pubkey")
-                    .value_name("PUBKEY")
-                    .takes_value(true)
-                    .validator(is_pubkey_or_keypair)
-                    .requires("faucet_lamports")
-                    .help("Path to file containing the faucet's pubkey"),
-            )
-            .arg(
-                Arg::with_name("bootstrap_validator")
-                    .short("b")
-                    .long("bootstrap-validator")
-                    .value_name("IDENTITY_PUBKEY VOTE_PUBKEY STAKE_PUBKEY")
-                    .takes_value(true)
-                    .validator(is_pubkey_or_keypair)
-                    .number_of_values(3)
-                    .multiple(true)
-                    .help("The bootstrap validator's identity, vote and stake pubkeys"),
-            )
-            .arg(
-                Arg::with_name("bootstrap_stake_authorized_pubkey")
-                    .long("bootstrap-stake-authorized-pubkey")
-                    .value_name("BOOTSTRAP STAKE AUTHORIZED PUBKEY")
-                    .takes_value(true)
-                    .validator(is_pubkey_or_keypair)
-                    .help(
-                        "Path to file containing the pubkey authorized to manage the bootstrap \
-                         validator's stake [default: --bootstrap-validator IDENTITY_PUBKEY]",
-                    ),
-            )
-            .arg(
-                Arg::with_name("bootstrap_validator_lamports")
-                    .long("bootstrap-validator-lamports")
-                    .value_name("LAMPORTS")
-                    .takes_value(true)
-                    .default_value(default_bootstrap_validator_lamports)
-                    .help("Number of lamports to assign to the bootstrap validator"),
-            )
-            .arg(
-                Arg::with_name("bootstrap_validator_stake_lamports")
-                    .long("bootstrap-validator-stake-lamports")
-                    .value_name("LAMPORTS")
-                    .takes_value(true)
-                    .default_value(default_bootstrap_validator_stake_lamports)
-                    .help("Number of lamports to assign to the bootstrap validator's stake account"),
-            )
-            .arg(
-                Arg::with_name("rent_burn_percentage")
-                    .long("rent-burn-percentage")
-                    .value_name("NUMBER")
-                    .takes_value(true)
-                    .help("Adjust percentage of collected rent to burn")
-                    .validator(is_valid_percentage),
-            )
-            .arg(&hashes_per_tick)
-            .arg(
-                Arg::with_name("accounts_to_remove")
-                    .required(false)
-                    .long("remove-account")
-                    .takes_value(true)
-                    .value_name("PUBKEY")
-                    .validator(is_pubkey)
-                    .multiple(true)
-                    .help("List of accounts to remove while creating the snapshot"),
-            )
-            .arg(
-                Arg::with_name("feature_gates_to_deactivate")
-                    .required(false)
-                    .long("deactivate-feature-gate")
-                    .takes_value(true)
-                    .value_name("PUBKEY")
-                    .validator(is_pubkey)
-                    .multiple(true)
-                    .help("List of feature gates to deactivate while creating the snapshot")
-            )
-            .arg(
-                Arg::with_name("vote_accounts_to_destake")
-                    .required(false)
-                    .long("destake-vote-account")
-                    .takes_value(true)
-                    .value_name("PUBKEY")
-                    .validator(is_pubkey)
-                    .multiple(true)
-                    .help("List of validator vote accounts to destake")
-            )
-            .arg(
-                Arg::with_name("remove_stake_accounts")
-                    .required(false)
-                    .long("remove-stake-accounts")
-                    .takes_value(false)
-                    .help("Remove all existing stake accounts from the new snapshot")
-            )
-            .arg(
-                Arg::with_name("incremental")
-                    .long("incremental")
-                    .takes_value(false)
-                    .help("Create an incremental snapshot instead of a full snapshot. This requires \
-                          that the ledger is loaded from a full snapshot, which will be used as the \
-                          base for the incremental snapshot.")
-                    .conflicts_with("no_snapshot")
-            )
-            .arg(
-                Arg::with_name("minimized")
-                    .long("minimized")
-                    .takes_value(false)
-                    .help("Create a minimized snapshot instead of a full snapshot. This snapshot \
-                          will only include information needed to replay the ledger from the \
-                          snapshot slot to the ending slot.")
-                    .conflicts_with("incremental")
-                    .requires("ending_slot")
-            )
-            .arg(
-                Arg::with_name("ending_slot")
-                    .long("ending-slot")
-                    .takes_value(true)
-                    .value_name("ENDING_SLOT")
-                    .help("Ending slot for minimized snapshot creation")
-            )
-            .arg(
-                Arg::with_name("snapshot_archive_format")
-                    .long("snapshot-archive-format")
-                    .possible_values(SUPPORTED_ARCHIVE_COMPRESSION)
-                    .default_value(DEFAULT_ARCHIVE_COMPRESSION)
-                    .value_name("ARCHIVE_TYPE")
-                    .takes_value(true)
-                    .help("Snapshot archive format to use.")
-                    .conflicts_with("no_snapshot")
-            )
-        ).subcommand(
+                .about("Create a new ledger snapshot")
+                .arg(&no_snapshot_arg)
+                .arg(&account_paths_arg)
+                .arg(&accounts_hash_cache_path_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&accountsdb_skip_shrink)
+                .arg(&ancient_append_vecs)
+                .arg(&hard_forks_arg)
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&snapshot_version_arg)
+                .arg(&maximum_full_snapshot_archives_to_retain)
+                .arg(&maximum_incremental_snapshot_archives_to_retain)
+                .arg(&geyser_plugin_args)
+                .arg(&use_snapshot_archives_at_startup)
+                .arg(
+                    Arg::with_name("snapshot_slot")
+                        .index(1)
+                        .value_name("SLOT")
+                        .validator(|value| {
+                            if value.parse::<Slot>().is_ok() || value == "ROOT" {
+                                Ok(())
+                            } else {
+                                Err(format!(
+                                    "Unable to parse as a number or the keyword ROOT, provided: \
+                                     {value}"
+                                ))
+                            }
+                        })
+                        .takes_value(true)
+                        .help(
+                            "Slot at which to create the snapshot; accepts keyword ROOT for the \
+                             highest root",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("output_directory")
+                        .index(2)
+                        .value_name("DIR")
+                        .takes_value(true)
+                        .help(
+                            "Output directory for the snapshot [default: --snapshot-archive-path \
+                             if present else --ledger directory]",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("warp_slot")
+                        .required(false)
+                        .long("warp-slot")
+                        .takes_value(true)
+                        .value_name("WARP_SLOT")
+                        .validator(is_slot)
+                        .help(
+                            "After loading the snapshot slot warp the ledger to WARP_SLOT, which \
+                             could be a slot in a galaxy far far away",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("faucet_lamports")
+                        .short("t")
+                        .long("faucet-lamports")
+                        .value_name("LAMPORTS")
+                        .takes_value(true)
+                        .requires("faucet_pubkey")
+                        .help("Number of lamports to assign to the faucet"),
+                )
+                .arg(
+                    Arg::with_name("faucet_pubkey")
+                        .short("m")
+                        .long("faucet-pubkey")
+                        .value_name("PUBKEY")
+                        .takes_value(true)
+                        .validator(is_pubkey_or_keypair)
+                        .requires("faucet_lamports")
+                        .help("Path to file containing the faucet's pubkey"),
+                )
+                .arg(
+                    Arg::with_name("bootstrap_validator")
+                        .short("b")
+                        .long("bootstrap-validator")
+                        .value_name("IDENTITY_PUBKEY VOTE_PUBKEY STAKE_PUBKEY")
+                        .takes_value(true)
+                        .validator(is_pubkey_or_keypair)
+                        .number_of_values(3)
+                        .multiple(true)
+                        .help("The bootstrap validator's identity, vote and stake pubkeys"),
+                )
+                .arg(
+                    Arg::with_name("bootstrap_stake_authorized_pubkey")
+                        .long("bootstrap-stake-authorized-pubkey")
+                        .value_name("BOOTSTRAP STAKE AUTHORIZED PUBKEY")
+                        .takes_value(true)
+                        .validator(is_pubkey_or_keypair)
+                        .help(
+                            "Path to file containing the pubkey authorized to manage the \
+                             bootstrap validator's stake [default: --bootstrap-validator \
+                             IDENTITY_PUBKEY]",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("bootstrap_validator_lamports")
+                        .long("bootstrap-validator-lamports")
+                        .value_name("LAMPORTS")
+                        .takes_value(true)
+                        .default_value(default_bootstrap_validator_lamports)
+                        .help("Number of lamports to assign to the bootstrap validator"),
+                )
+                .arg(
+                    Arg::with_name("bootstrap_validator_stake_lamports")
+                        .long("bootstrap-validator-stake-lamports")
+                        .value_name("LAMPORTS")
+                        .takes_value(true)
+                        .default_value(default_bootstrap_validator_stake_lamports)
+                        .help(
+                            "Number of lamports to assign to the bootstrap validator's stake \
+                             account",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("rent_burn_percentage")
+                        .long("rent-burn-percentage")
+                        .value_name("NUMBER")
+                        .takes_value(true)
+                        .help("Adjust percentage of collected rent to burn")
+                        .validator(is_valid_percentage),
+                )
+                .arg(&hashes_per_tick)
+                .arg(
+                    Arg::with_name("accounts_to_remove")
+                        .required(false)
+                        .long("remove-account")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_pubkey)
+                        .multiple(true)
+                        .help("List of accounts to remove while creating the snapshot"),
+                )
+                .arg(
+                    Arg::with_name("feature_gates_to_deactivate")
+                        .required(false)
+                        .long("deactivate-feature-gate")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_pubkey)
+                        .multiple(true)
+                        .help("List of feature gates to deactivate while creating the snapshot"),
+                )
+                .arg(
+                    Arg::with_name("vote_accounts_to_destake")
+                        .required(false)
+                        .long("destake-vote-account")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_pubkey)
+                        .multiple(true)
+                        .help("List of validator vote accounts to destake"),
+                )
+                .arg(
+                    Arg::with_name("remove_stake_accounts")
+                        .required(false)
+                        .long("remove-stake-accounts")
+                        .takes_value(false)
+                        .help("Remove all existing stake accounts from the new snapshot"),
+                )
+                .arg(
+                    Arg::with_name("incremental")
+                        .long("incremental")
+                        .takes_value(false)
+                        .help(
+                            "Create an incremental snapshot instead of a full snapshot. This \
+                             requires that the ledger is loaded from a full snapshot, which will \
+                             be used as the base for the incremental snapshot.",
+                        )
+                        .conflicts_with("no_snapshot"),
+                )
+                .arg(
+                    Arg::with_name("minimized")
+                        .long("minimized")
+                        .takes_value(false)
+                        .help(
+                            "Create a minimized snapshot instead of a full snapshot. This \
+                             snapshot will only include information needed to replay the ledger \
+                             from the snapshot slot to the ending slot.",
+                        )
+                        .conflicts_with("incremental")
+                        .requires("ending_slot"),
+                )
+                .arg(
+                    Arg::with_name("ending_slot")
+                        .long("ending-slot")
+                        .takes_value(true)
+                        .value_name("ENDING_SLOT")
+                        .help("Ending slot for minimized snapshot creation"),
+                )
+                .arg(
+                    Arg::with_name("snapshot_archive_format")
+                        .long("snapshot-archive-format")
+                        .possible_values(SUPPORTED_ARCHIVE_COMPRESSION)
+                        .default_value(DEFAULT_ARCHIVE_COMPRESSION)
+                        .value_name("ARCHIVE_TYPE")
+                        .takes_value(true)
+                        .help("Snapshot archive format to use.")
+                        .conflicts_with("no_snapshot"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("accounts")
-            .about("Print account stats and contents after processing the ledger")
-            .arg(&no_snapshot_arg)
-            .arg(&account_paths_arg)
-            .arg(&accounts_hash_cache_path_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&halt_at_slot_arg)
-            .arg(&hard_forks_arg)
-            .arg(&geyser_plugin_args)
-            .arg(&accounts_data_encoding_arg)
-            .arg(&use_snapshot_archives_at_startup)
-            .arg(
-                Arg::with_name("include_sysvars")
-                    .long("include-sysvars")
-                    .takes_value(false)
-                    .help("Include sysvars too"),
-            )
-            .arg(
-                Arg::with_name("no_account_contents")
-                    .long("no-account-contents")
-                    .takes_value(false)
-                    .help("Do not print contents of each account, which is very slow with lots of accounts."),
-            )
-            .arg(Arg::with_name("no_account_data")
-                .long("no-account-data")
-                .takes_value(false)
-                .help("Do not print account data when printing account contents."),
-            )
-            .arg(&max_genesis_archive_unpacked_size_arg)
-        ).subcommand(
+                .about("Print account stats and contents after processing the ledger")
+                .arg(&no_snapshot_arg)
+                .arg(&account_paths_arg)
+                .arg(&accounts_hash_cache_path_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&halt_at_slot_arg)
+                .arg(&hard_forks_arg)
+                .arg(&geyser_plugin_args)
+                .arg(&accounts_data_encoding_arg)
+                .arg(&use_snapshot_archives_at_startup)
+                .arg(
+                    Arg::with_name("include_sysvars")
+                        .long("include-sysvars")
+                        .takes_value(false)
+                        .help("Include sysvars too"),
+                )
+                .arg(
+                    Arg::with_name("no_account_contents")
+                        .long("no-account-contents")
+                        .takes_value(false)
+                        .help(
+                            "Do not print contents of each account, which is very slow with lots \
+                             of accounts.",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("no_account_data")
+                        .long("no-account-data")
+                        .takes_value(false)
+                        .help("Do not print account data when printing account contents."),
+                )
+                .arg(&max_genesis_archive_unpacked_size_arg),
+        )
+        .subcommand(
             SubCommand::with_name("capitalization")
-            .about("Print capitalization (aka, total supply) while checksumming it")
-            .arg(&no_snapshot_arg)
-            .arg(&account_paths_arg)
-            .arg(&accounts_hash_cache_path_arg)
-            .arg(&accounts_index_bins)
-            .arg(&accounts_index_limit)
-            .arg(&disable_disk_index)
-            .arg(&accountsdb_verify_refcounts)
-            .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
-            .arg(&accounts_db_skip_initial_hash_calc_arg)
-            .arg(&halt_at_slot_arg)
-            .arg(&hard_forks_arg)
-            .arg(&max_genesis_archive_unpacked_size_arg)
-            .arg(&geyser_plugin_args)
-            .arg(&use_snapshot_archives_at_startup)
-            .arg(
-                Arg::with_name("warp_epoch")
-                    .required(false)
-                    .long("warp-epoch")
-                    .takes_value(true)
-                    .value_name("WARP_EPOCH")
-                    .help("After loading the snapshot warp the ledger to WARP_EPOCH, \
-                           which could be an epoch in a galaxy far far away"),
-            )
-            .arg(
-                Arg::with_name("inflation")
-                    .required(false)
-                    .long("inflation")
-                    .takes_value(true)
-                    .possible_values(&["pico", "full", "none"])
-                    .help("Overwrite inflation when warping"),
-            )
-            .arg(
-                Arg::with_name("enable_credits_auto_rewind")
-                    .required(false)
-                    .long("enable-credits-auto-rewind")
-                    .takes_value(false)
-                    .help("Enable credits auto rewind"),
-            )
-            .arg(
-                Arg::with_name("recalculate_capitalization")
-                    .required(false)
-                    .long("recalculate-capitalization")
-                    .takes_value(false)
-                    .help("Recalculate capitalization before warping; circumvents \
-                          bank's out-of-sync capitalization"),
-            )
-            .arg(
-                Arg::with_name("csv_filename")
-                    .long("csv-filename")
-                    .value_name("FILENAME")
-                    .takes_value(true)
-                    .help("Output file in the csv format"),
-            )
-        ).subcommand(
+                .about("Print capitalization (aka, total supply) while checksumming it")
+                .arg(&no_snapshot_arg)
+                .arg(&account_paths_arg)
+                .arg(&accounts_hash_cache_path_arg)
+                .arg(&accounts_index_bins)
+                .arg(&accounts_index_limit)
+                .arg(&disable_disk_index)
+                .arg(&accountsdb_verify_refcounts)
+                .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash)
+                .arg(&accounts_db_skip_initial_hash_calc_arg)
+                .arg(&halt_at_slot_arg)
+                .arg(&hard_forks_arg)
+                .arg(&max_genesis_archive_unpacked_size_arg)
+                .arg(&geyser_plugin_args)
+                .arg(&use_snapshot_archives_at_startup)
+                .arg(
+                    Arg::with_name("warp_epoch")
+                        .required(false)
+                        .long("warp-epoch")
+                        .takes_value(true)
+                        .value_name("WARP_EPOCH")
+                        .help(
+                            "After loading the snapshot warp the ledger to WARP_EPOCH, which \
+                             could be an epoch in a galaxy far far away",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("inflation")
+                        .required(false)
+                        .long("inflation")
+                        .takes_value(true)
+                        .possible_values(&["pico", "full", "none"])
+                        .help("Overwrite inflation when warping"),
+                )
+                .arg(
+                    Arg::with_name("enable_credits_auto_rewind")
+                        .required(false)
+                        .long("enable-credits-auto-rewind")
+                        .takes_value(false)
+                        .help("Enable credits auto rewind"),
+                )
+                .arg(
+                    Arg::with_name("recalculate_capitalization")
+                        .required(false)
+                        .long("recalculate-capitalization")
+                        .takes_value(false)
+                        .help(
+                            "Recalculate capitalization before warping; circumvents bank's \
+                             out-of-sync capitalization",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("csv_filename")
+                        .long("csv-filename")
+                        .value_name("FILENAME")
+                        .takes_value(true)
+                        .help("Output file in the csv format"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("purge")
-            .about("Delete a range of slots from the ledger")
-            .arg(
-                Arg::with_name("start_slot")
-                    .index(1)
-                    .value_name("SLOT")
-                    .takes_value(true)
-                    .required(true)
-                    .help("Start slot to purge from (inclusive)"),
-            )
-            .arg(
-                Arg::with_name("end_slot")
-                    .index(2)
-                    .value_name("SLOT")
-                    .help("Ending slot to stop purging (inclusive) \
-                           [default: the highest slot in the ledger]"),
-            )
-            .arg(
-                Arg::with_name("batch_size")
-                    .long("batch-size")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .default_value("1000")
-                    .help("Removes at most BATCH_SIZE slots while purging in loop"),
-            )
-            .arg(
-                Arg::with_name("no_compaction")
-                    .long("no-compaction")
-                    .required(false)
-                    .takes_value(false)
-                    .help("--no-compaction is deprecated, ledger compaction \
-                           after purge is disabled by default")
-                    .conflicts_with("enable_compaction")
-                    .hidden(hidden_unless_forced())
-            )
-            .arg(
-                Arg::with_name("enable_compaction")
-                    .long("enable-compaction")
-                    .required(false)
-                    .takes_value(false)
-                    .help("Perform ledger compaction after purge. Compaction \
-                           will optimize storage space, but may take a long \
-                           time to complete.")
-                    .conflicts_with("no_compaction")
-            )
-            .arg(
-                Arg::with_name("dead_slots_only")
-                    .long("dead-slots-only")
-                    .required(false)
-                    .takes_value(false)
-                    .help("Limit purging to dead slots only")
-            )
+                .about("Delete a range of slots from the ledger")
+                .arg(
+                    Arg::with_name("start_slot")
+                        .index(1)
+                        .value_name("SLOT")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Start slot to purge from (inclusive)"),
+                )
+                .arg(Arg::with_name("end_slot").index(2).value_name("SLOT").help(
+                    "Ending slot to stop purging (inclusive) [default: the highest slot in the \
+                     ledger]",
+                ))
+                .arg(
+                    Arg::with_name("batch_size")
+                        .long("batch-size")
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .default_value("1000")
+                        .help("Removes at most BATCH_SIZE slots while purging in loop"),
+                )
+                .arg(
+                    Arg::with_name("no_compaction")
+                        .long("no-compaction")
+                        .required(false)
+                        .takes_value(false)
+                        .help(
+                            "--no-compaction is deprecated, ledger compaction after purge is \
+                             disabled by default",
+                        )
+                        .conflicts_with("enable_compaction")
+                        .hidden(hidden_unless_forced()),
+                )
+                .arg(
+                    Arg::with_name("enable_compaction")
+                        .long("enable-compaction")
+                        .required(false)
+                        .takes_value(false)
+                        .help(
+                            "Perform ledger compaction after purge. Compaction will optimize \
+                             storage space, but may take a long time to complete.",
+                        )
+                        .conflicts_with("no_compaction"),
+                )
+                .arg(
+                    Arg::with_name("dead_slots_only")
+                        .long("dead-slots-only")
+                        .required(false)
+                        .takes_value(false)
+                        .help("Limit purging to dead slots only"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("list-roots")
-            .about("Output up to last <num-roots> root hashes and their \
-                    heights starting at the given block height")
-            .arg(
-                Arg::with_name("max_height")
-                    .long("max-height")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .help("Maximum block height")
-            )
-            .arg(
-                Arg::with_name("start_root")
-                    .long("start-root")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .help("First root to start searching from")
-            )
-            .arg(
-                Arg::with_name("slot_list")
-                    .long("slot-list")
-                    .value_name("FILENAME")
-                    .required(false)
-                    .takes_value(true)
-                    .help("The location of the output YAML file. A list of \
-                           rollback slot heights and hashes will be written to the file")
-            )
-            .arg(
-                Arg::with_name("num_roots")
-                    .long("num-roots")
-                    .value_name("NUM")
-                    .takes_value(true)
-                    .default_value(DEFAULT_ROOT_COUNT)
-                    .required(false)
-                    .help("Number of roots in the output"),
-            )
+                .about(
+                    "Output up to last <num-roots> root hashes and their heights starting at the \
+                     given block height",
+                )
+                .arg(
+                    Arg::with_name("max_height")
+                        .long("max-height")
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .help("Maximum block height"),
+                )
+                .arg(
+                    Arg::with_name("start_root")
+                        .long("start-root")
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .help("First root to start searching from"),
+                )
+                .arg(
+                    Arg::with_name("slot_list")
+                        .long("slot-list")
+                        .value_name("FILENAME")
+                        .required(false)
+                        .takes_value(true)
+                        .help(
+                            "The location of the output YAML file. A list of rollback slot \
+                             heights and hashes will be written to the file",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("num_roots")
+                        .long("num-roots")
+                        .value_name("NUM")
+                        .takes_value(true)
+                        .default_value(DEFAULT_ROOT_COUNT)
+                        .required(false)
+                        .help("Number of roots in the output"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("latest-optimistic-slots")
-                .about("Output up to the most recent <num-slots> optimistic \
-                        slots with their hashes and timestamps.")
+                .about(
+                    "Output up to the most recent <num-slots> optimistic slots with their hashes \
+                     and timestamps.",
+                )
                 .arg(
                     Arg::with_name("num_slots")
                         .long("num-slots")
@@ -2108,25 +2186,27 @@ fn main() {
                         .long("exclude-vote-only-slots")
                         .required(false)
                         .help("Exclude slots that contain only votes from output"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("repair-roots")
-                .about("Traverses the AncestorIterator backward from a last known root \
-                        to restore missing roots to the Root column")
+                .about(
+                    "Traverses the AncestorIterator backward from a last known root to restore \
+                     missing roots to the Root column",
+                )
                 .arg(
                     Arg::with_name("start_root")
                         .long("before")
                         .value_name("NUM")
                         .takes_value(true)
-                        .help("Recent root after the range to repair")
+                        .help("Recent root after the range to repair"),
                 )
                 .arg(
                     Arg::with_name("end_root")
                         .long("until")
                         .value_name("NUM")
                         .takes_value(true)
-                        .help("Earliest slot to check for root repair")
+                        .help("Earliest slot to check for root repair"),
                 )
                 .arg(
                     Arg::with_name("max_slots")
@@ -2135,40 +2215,47 @@ fn main() {
                         .takes_value(true)
                         .default_value(DEFAULT_MAX_SLOTS_ROOT_REPAIR)
                         .required(true)
-                        .help("Override the maximum number of slots to check for root repair")
-                )
+                        .help("Override the maximum number of slots to check for root repair"),
+                ),
         )
-        .subcommand(
-            SubCommand::with_name("analyze-storage")
-                .about("Output statistics in JSON format about \
-                        all column families in the ledger rocksdb")
-        )
+        .subcommand(SubCommand::with_name("analyze-storage").about(
+            "Output statistics in JSON format about all column families in the ledger rocksdb",
+        ))
         .subcommand(
             SubCommand::with_name("compute-slot-cost")
-            .about("runs cost_model over the block at the given slots, \
-                   computes how expensive a block was based on cost_model")
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .multiple(true)
-                    .takes_value(true)
-                    .help("Slots that their blocks are computed for cost, default to all slots in ledger"),
-            )
+                .about(
+                    "runs cost_model over the block at the given slots, computes how expensive a \
+                     block was based on cost_model",
+                )
+                .arg(
+                    Arg::with_name("slots")
+                        .index(1)
+                        .value_name("SLOTS")
+                        .validator(is_slot)
+                        .multiple(true)
+                        .takes_value(true)
+                        .help(
+                            "Slots that their blocks are computed for cost, default to all slots \
+                             in ledger",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("print-file-metadata")
-            .about("Print the metadata of the specified ledger-store file. \
-                    If no file name is specified, it will print the metadata of all ledger files.")
-            .arg(
-                Arg::with_name("file_name")
-                    .long("file-name")
-                    .takes_value(true)
-                    .value_name("SST_FILE_NAME")
-                    .help("The ledger file name (e.g. 011080.sst.) \
-                           If no file name is specified, it will print the metadata of all ledger files.")
-            )
+                .about(
+                    "Print the metadata of the specified ledger-store file. If no file name is \
+                     specified, it will print the metadata of all ledger files.",
+                )
+                .arg(
+                    Arg::with_name("file_name")
+                        .long("file-name")
+                        .takes_value(true)
+                        .value_name("SST_FILE_NAME")
+                        .help(
+                            "The ledger file name (e.g. 011080.sst.) If no file name is \
+                             specified, it will print the metadata of all ledger files.",
+                        ),
+                ),
         )
         .program_subcommand()
         .get_matches();
@@ -2242,11 +2329,10 @@ fn main() {
                 let _ = get_shred_storage_type(
                     &target_db,
                     &format!(
-                        "No --target-db ledger at {:?} was detected, default \
-                        compaction (RocksLevel) will be used. Fifo compaction \
-                        can be enabled for a new ledger by manually creating \
-                        {BLOCKSTORE_DIRECTORY_ROCKS_FIFO} directory within \
-                        the specified --target_db directory.",
+                        "No --target-db ledger at {:?} was detected, default compaction \
+                         (RocksLevel) will be used. Fifo compaction can be enabled for a new \
+                         ledger by manually creating {BLOCKSTORE_DIRECTORY_ROCKS_FIFO} directory \
+                         within the specified --target_db directory.",
                         &target_db
                     ),
                 );
@@ -2803,8 +2889,8 @@ fn main() {
                 let minimum_stake_lamports = rent.minimum_balance(StakeStateV2::size_of());
                 if bootstrap_validator_stake_lamports < minimum_stake_lamports {
                     eprintln!(
-                        "Error: insufficient --bootstrap-validator-stake-lamports. \
-                           Minimum amount is {minimum_stake_lamports}"
+                        "Error: insufficient --bootstrap-validator-stake-lamports. Minimum amount \
+                         is {minimum_stake_lamports}"
                     );
                     exit(1);
                 }
@@ -2884,7 +2970,8 @@ fn main() {
                     .is_none()
                 {
                     eprintln!(
-                        "Error: snapshot slot {snapshot_slot} does not exist in blockstore or is not full.",
+                        "Error: snapshot slot {snapshot_slot} does not exist in blockstore or is \
+                         not full.",
                     );
                     exit(1);
                 }
@@ -2894,7 +2981,8 @@ fn main() {
                     let ending_slot = value_t_or_exit!(arg_matches, "ending_slot", Slot);
                     if ending_slot <= snapshot_slot {
                         eprintln!(
-                            "Error: ending_slot ({ending_slot}) must be greater than snapshot_slot ({snapshot_slot})"
+                            "Error: ending_slot ({ending_slot}) must be greater than \
+                             snapshot_slot ({snapshot_slot})"
                         );
                         exit(1);
                     }
@@ -3003,7 +3091,8 @@ fn main() {
                         for address in feature_gates_to_deactivate {
                             let mut account = bank.get_account(&address).unwrap_or_else(|| {
                                 eprintln!(
-                                    "Error: Feature-gate account does not exist, unable to deactivate it: {address}"
+                                    "Error: Feature-gate account does not exist, unable to \
+                                     deactivate it: {address}"
                                 );
                                 exit(1);
                             });
@@ -3133,7 +3222,8 @@ fn main() {
                             if let Some(warp_slot) = warp_slot {
                                 if warp_slot < minimum_warp_slot {
                                     eprintln!(
-                                        "Error: --warp-slot too close.  Must be >= {minimum_warp_slot}"
+                                        "Error: --warp-slot too close.  Must be >= \
+                                         {minimum_warp_slot}"
                                     );
                                     exit(1);
                                 }
@@ -3186,13 +3276,17 @@ fn main() {
 
                         if is_incremental {
                             if starting_snapshot_hashes.is_none() {
-                                eprintln!("Unable to create incremental snapshot without a base full snapshot");
+                                eprintln!(
+                                    "Unable to create incremental snapshot without a base full \
+                                     snapshot"
+                                );
                                 exit(1);
                             }
                             let full_snapshot_slot = starting_snapshot_hashes.unwrap().full.0 .0;
                             if bank.slot() <= full_snapshot_slot {
                                 eprintln!(
-                                    "Unable to create incremental snapshot: Slot must be greater than full snapshot slot. slot: {}, full snapshot slot: {}",
+                                    "Unable to create incremental snapshot: Slot must be greater \
+                                     than full snapshot slot. slot: {}, full snapshot slot: {}",
                                     bank.slot(),
                                     full_snapshot_slot,
                                 );
@@ -3217,7 +3311,8 @@ fn main() {
                                 });
 
                             println!(
-                                "Successfully created incremental snapshot for slot {}, hash {}, base slot: {}: {}",
+                                "Successfully created incremental snapshot for slot {}, hash {}, \
+                                 base slot: {}: {}",
                                 bank.slot(),
                                 bank.hash(),
                                 full_snapshot_slot,
@@ -3252,12 +3347,23 @@ fn main() {
                                 let ending_epoch =
                                     bank.epoch_schedule().get_epoch(ending_slot.unwrap());
                                 if starting_epoch != ending_epoch {
-                                    warn!("Minimized snapshot range crosses epoch boundary ({} to {}). Bank hashes after {} will not match replays from a full snapshot",
-                                        starting_epoch, ending_epoch, bank.epoch_schedule().get_last_slot_in_epoch(starting_epoch));
+                                    warn!(
+                                        "Minimized snapshot range crosses epoch boundary ({} to \
+                                         {}). Bank hashes after {} will not match replays from a \
+                                         full snapshot",
+                                        starting_epoch,
+                                        ending_epoch,
+                                        bank.epoch_schedule()
+                                            .get_last_slot_in_epoch(starting_epoch)
+                                    );
                                 }
 
                                 if minimize_snapshot_possibly_incomplete {
-                                    warn!("Minimized snapshot may be incomplete due to missing accounts from CPI'd address lookup table extensions. This may lead to mismatched bank hashes while replaying.");
+                                    warn!(
+                                        "Minimized snapshot may be incomplete due to missing \
+                                         accounts from CPI'd address lookup table extensions. \
+                                         This may lead to mismatched bank hashes while replaying."
+                                    );
                                 }
                             }
                         }
@@ -3510,8 +3616,9 @@ fn main() {
                                     let old_cap = base_bank.set_capitalization();
                                     let new_cap = base_bank.capitalization();
                                     warn!(
-                                        "Skewing capitalization a bit to enable credits_auto_rewind as \
-                                         requested: increasing {} from {} to {}",
+                                        "Skewing capitalization a bit to enable \
+                                         credits_auto_rewind as requested: increasing {} from {} \
+                                         to {}",
                                         feature_account_balance, old_cap, new_cap,
                                     );
                                     assert_eq!(
@@ -3945,13 +4052,14 @@ fn main() {
                     exit(1);
                 }
                 info!(
-                "Purging data from slots {} to {} ({} slots) (do compaction: {}) (dead slot only: {})",
-                start_slot,
-                end_slot,
-                end_slot - start_slot,
-                perform_compaction,
-                dead_slots_only,
-            );
+                    "Purging data from slots {} to {} ({} slots) (do compaction: {}) (dead slot \
+                     only: {})",
+                    start_slot,
+                    end_slot,
+                    end_slot - start_slot,
+                    perform_compaction,
+                    dead_slots_only,
+                );
                 let purge_from_blockstore = |start_slot, end_slot| {
                     blockstore.purge_from_next_slots(start_slot, end_slot);
                     if perform_compaction {
@@ -4084,9 +4192,8 @@ fn main() {
                 let num_slots = start_root - end_root - 1; // Adjust by one since start_root need not be checked
                 if arg_matches.is_present("end_root") && num_slots > max_slots {
                     eprintln!(
-                        "Requested range {num_slots} too large, max {max_slots}. \
-                    Either adjust `--until` value, or pass a larger `--repair-limit` \
-                    to override the limit",
+                        "Requested range {num_slots} too large, max {max_slots}. Either adjust \
+                         `--until` value, or pass a larger `--repair-limit` to override the limit",
                     );
                     exit(1);
                 }

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -143,8 +143,8 @@ impl ProgramSubCommand for App<'_, '_> {
     fn program_subcommand(self) -> Self {
         let program_arg = Arg::with_name("PROGRAM")
             .help(
-                "Program file to use. This is either an ELF shared-object file to be executed, \
-                 or an assembly file to be assembled and executed.",
+                "Program file to use. This is either an ELF shared-object file to be executed, or \
+                 an assembly file to be assembled and executed.",
             )
             .required(true)
             .index(1);

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -263,9 +263,8 @@ fn bank_forks_from_snapshot(
         )
         .unwrap_or_else(|err| {
             error!(
-                "Failed to load bank: {err} \
-                \nfull snapshot archive: {} \
-                \nincremental snapshot archive: {}",
+                "Failed to load bank: {err} \nfull snapshot archive: {} \nincremental snapshot \
+                 archive: {}",
                 full_snapshot_archive_info.path().display(),
                 incremental_snapshot_archive_info
                     .as_ref()
@@ -278,7 +277,8 @@ fn bank_forks_from_snapshot(
     } else {
         let Some(bank_snapshot) = latest_bank_snapshot else {
             error!(
-                "There is no local state to startup from. Ensure --{} is *not* set to \"{}\" and restart.",
+                "There is no local state to startup from. Ensure --{} is *not* set to \"{}\" and \
+                 restart.",
                 use_snapshot_archives_at_startup::cli::LONG_ARG,
                 UseSnapshotArchivesAtStartup::Never.to_string(),
             );
@@ -293,9 +293,9 @@ fn bank_forks_from_snapshot(
                 UseSnapshotArchivesAtStartup::Never,
             );
             warn!(
-                "Starting up from local state at slot {}, which is *older* than \
-                the latest snapshot archive at slot {}. If this is not desired, \
-                change the --{} CLI option to *not* \"{}\" and restart.",
+                "Starting up from local state at slot {}, which is *older* than the latest \
+                 snapshot archive at slot {}. If this is not desired, change the --{} CLI option \
+                 to *not* \"{}\" and restart.",
                 bank_snapshot.slot,
                 latest_snapshot_archive_slot,
                 use_snapshot_archives_at_startup::cli::LONG_ARG,
@@ -320,8 +320,7 @@ fn bank_forks_from_snapshot(
         )
         .unwrap_or_else(|err| {
             error!(
-                "Failed to load bank: {err} \
-                \nsnapshot: {}",
+                "Failed to load bank: {err} \nsnapshot: {}",
                 bank_snapshot.snapshot_path().display(),
             );
             process::exit(1);

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -429,9 +429,9 @@ impl Rocks {
             AccessType::Secondary => {
                 let secondary_path = path.join("solana-secondary");
                 info!(
-                    "Opening Rocks with secondary (read only) access at: {secondary_path:?}. \
-                    This secondary access could temporarily degrade other accesses, such as \
-                    by solana-validator"
+                    "Opening Rocks with secondary (read only) access at: {secondary_path:?}. This \
+                     secondary access could temporarily degrade other accesses, such as by \
+                     solana-validator"
                 );
                 DB::open_cf_descriptors_as_secondary(
                     &db_options,
@@ -2040,8 +2040,10 @@ fn new_cf_descriptor_fifo<C: 'static + Column + ColumnName>(
         )
     } else {
         panic!(
-            "{} cf_size must be greater than write buffer size {} when using ShredStorageType::RocksFifo.",
-            C::NAME, FIFO_WRITE_BUFFER_SIZE
+            "{} cf_size must be greater than write buffer size {} when using \
+             ShredStorageType::RocksFifo.",
+            C::NAME,
+            FIFO_WRITE_BUFFER_SIZE
         );
     }
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -610,7 +610,8 @@ fn process_entries(
                             (
                                 "error",
                                 format!(
-                                    "Lock accounts error, entry conflicts with itself, txs: {transactions:?}"
+                                    "Lock accounts error, entry conflicts with itself, txs: \
+                                     {transactions:?}"
                                 ),
                                 String
                             )
@@ -1249,8 +1250,8 @@ fn confirm_slot_entries(
         let tick_hash_count = &mut progress.tick_hash_count;
         verify_ticks(bank, &entries, slot_full, tick_hash_count).map_err(|err| {
             warn!(
-                "{:#?}, slot: {}, entry len: {}, tick_height: {}, last entry: {}, \
-                last_blockhash: {}, shred_index: {}, slot_full: {}",
+                "{:#?}, slot: {}, entry len: {}, tick_height: {}, last entry: {}, last_blockhash: \
+                 {}, shred_index: {}, slot_full: {}",
                 err,
                 slot,
                 num_entries,
@@ -1531,18 +1532,13 @@ fn load_frozen_forks(
                 let slots_per_sec = slots_processed as f32 / secs;
                 let txs_per_sec = txs as f32 / secs;
                 info!(
-                    "processing ledger: slot={slot}, \
-                    root_slot={root} \
-                    slots={slots_processed}, \
-                    slots/s={slots_per_sec}, \
-                    txs/s={txs_per_sec}"
+                    "processing ledger: slot={slot}, root_slot={root} slots={slots_processed}, \
+                     slots/s={slots_per_sec}, txs/s={txs_per_sec}"
                 );
                 debug!(
-                    "processing ledger timing: \
-                    set_root_us={set_root_us}, \
-                    root_retain_us={root_retain_us}, \
-                    process_single_slot_us:{process_single_slot_us}, \
-                    voting_us: {voting_us}"
+                    "processing ledger timing: set_root_us={set_root_us}, \
+                     root_retain_us={root_retain_us}, \
+                     process_single_slot_us:{process_single_slot_us}, voting_us: {voting_us}"
                 );
 
                 last_status_report = Instant::now();

--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -27,21 +27,17 @@ pub mod cli {
     pub const NAME: &str = "use_snapshot_archives_at_startup";
     pub const LONG_ARG: &str = "use-snapshot-archives-at-startup";
     pub const HELP: &str = "When should snapshot archives be used at startup?";
-    pub const LONG_HELP: &str = "At startup, when should snapshot archives be extracted \
-        versus using what is already on disk? \
-        \nSpecifying \"always\" will always startup by extracting snapshot archives \
-        and disregard any snapshot-related state already on disk. \
-        Note that starting up from snapshot archives will incur the runtime costs \
-        associated with extracting the archives and rebuilding the local state. \
-        \nSpecifying \"never\" will never startup from snapshot archives \
-        and will only use snapshot-related state already on disk. \
-        If there is no state already on disk, startup will fail. \
-        Note, this will use the latest state available, \
-        which may be newer than the latest snapshot archive. \
-        Specifying \"when-newest\" will use snapshot-related state \
-        already on disk unless there are snapshot archives newer than it. \
-        This can happen if a new snapshot archive is downloaded \
-        while the node is stopped.";
+    pub const LONG_HELP: &str =
+        "At startup, when should snapshot archives be extracted versus using what is already on \
+         disk? \nSpecifying \"always\" will always startup by extracting snapshot archives and \
+         disregard any snapshot-related state already on disk. Note that starting up from \
+         snapshot archives will incur the runtime costs associated with extracting the archives \
+         and rebuilding the local state. \nSpecifying \"never\" will never startup from snapshot \
+         archives and will only use snapshot-related state already on disk. If there is no state \
+         already on disk, startup will fail. Note, this will use the latest state available, \
+         which may be newer than the latest snapshot archive. Specifying \"when-newest\" will use \
+         snapshot-related state already on disk unless there are snapshot archives newer than it. \
+         This can happen if a new snapshot archive is downloaded while the node is stopped.";
 
     pub const POSSIBLE_VALUES: &[&str] = UseSnapshotArchivesAtStartup::VARIANTS;
 

--- a/local-cluster/src/local_cluster_snapshot_utils.rs
+++ b/local-cluster/src/local_cluster_snapshot_utils.rs
@@ -82,7 +82,8 @@ impl LocalCluster {
         // Wait for a snapshot for a bank >= last_slot to be made so we know that the snapshot
         // must include the transactions just pushed
         trace!(
-            "Waiting for {:?} snapshot archive to be generated with slot >= {}, max wait duration: {:?}",
+            "Waiting for {:?} snapshot archive to be generated with slot >= {}, max wait \
+             duration: {:?}",
             next_snapshot_type,
             last_slot,
             max_wait_duration,
@@ -118,7 +119,8 @@ impl LocalCluster {
             if let Some(max_wait_duration) = max_wait_duration {
                 assert!(
                     timer.elapsed() < max_wait_duration,
-                    "Waiting for next {next_snapshot_type:?} snapshot exceeded the {max_wait_duration:?} maximum wait duration!",
+                    "Waiting for next {next_snapshot_type:?} snapshot exceeded the \
+                     {max_wait_duration:?} maximum wait duration!",
                 );
             }
             sleep(Duration::from_secs(5));

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -619,12 +619,14 @@ fn test_incremental_snapshot_download() {
         .snapshot_config
         .incremental_snapshot_archives_dir;
 
-    debug!("snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}\n\taccounts hash interval: {}",
-           full_snapshot_interval,
-           incremental_snapshot_interval,
-           accounts_hash_interval);
     debug!(
-        "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
+        "snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: \
+         {}\n\taccounts hash interval: {}",
+        full_snapshot_interval, incremental_snapshot_interval, accounts_hash_interval
+    );
+    debug!(
+        "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: \
+         {}\n\tincremental snapshot archives dir: {}",
         leader_snapshot_test_config
             .bank_snapshots_dir
             .path()
@@ -639,7 +641,8 @@ fn test_incremental_snapshot_download() {
             .display(),
     );
     debug!(
-        "validator config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
+        "validator config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: \
+         {}\n\tincremental snapshot archives dir: {}",
         validator_snapshot_test_config
             .bank_snapshots_dir
             .path()
@@ -788,12 +791,14 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
     let mut cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
 
-    info!("snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: {}\n\taccounts hash interval: {}",
-           full_snapshot_interval,
-           incremental_snapshot_interval,
-           accounts_hash_interval);
+    info!(
+        "snapshot config:\n\tfull snapshot interval: {}\n\tincremental snapshot interval: \
+         {}\n\taccounts hash interval: {}",
+        full_snapshot_interval, incremental_snapshot_interval, accounts_hash_interval
+    );
     debug!(
-        "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
+        "leader config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: \
+         {}\n\tincremental snapshot archives dir: {}",
         leader_snapshot_test_config
             .bank_snapshots_dir
             .path()
@@ -808,7 +813,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .display(),
     );
     debug!(
-        "validator config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: {}\n\tincremental snapshot archives dir: {}",
+        "validator config:\n\tbank snapshots dir: {}\n\tfull snapshot archives dir: \
+         {}\n\tincremental snapshot archives dir: {}",
         validator_snapshot_test_config
             .bank_snapshots_dir
             .path()
@@ -1022,7 +1028,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     // that cross a full snapshot interval.
     let starting_slot = incremental_snapshot_archive.slot();
     let next_full_snapshot_slot = starting_slot + full_snapshot_interval;
-    info!("Waiting for the validator to see enough slots to cross a full snapshot interval ({next_full_snapshot_slot})...");
+    info!(
+        "Waiting for the validator to see enough slots to cross a full snapshot interval \
+         ({next_full_snapshot_slot})..."
+    );
     let timer = Instant::now();
     loop {
         let validator_current_slot = cluster
@@ -1041,7 +1050,9 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
         std::thread::yield_now();
     }
     info!(
-        "Waited {:?} for the validator to see enough slots to cross a full snapshot interval... DONE", timer.elapsed()
+        "Waited {:?} for the validator to see enough slots to cross a full snapshot interval... \
+         DONE",
+        timer.elapsed()
     );
 
     // Get the highest full snapshot archive info for the validator, now that it has crossed the
@@ -1081,7 +1092,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
         leader_full_snapshot.clone()
     };
-    info!("leader full snapshot archive for comparison: {leader_full_snapshot_archive_for_comparison:#?}");
+    info!(
+        "leader full snapshot archive for comparison: \
+         {leader_full_snapshot_archive_for_comparison:#?}"
+    );
 
     // Stop the validator before we reset its snapshots
     info!("Stopping the validator...");
@@ -1112,7 +1126,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
             .path(),
     );
     info!(
-        "Delete all the snapshots on the validator and restore the originals from the backup... DONE"
+        "Delete all the snapshots on the validator and restore the originals from the backup... \
+         DONE"
     );
 
     // Get the highest full snapshot slot *before* restarting, as a comparison
@@ -1142,7 +1157,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
     let validator_next_incremental_snapshot_slot =
         validator_next_full_snapshot_slot + incremental_snapshot_interval;
     info!("Waiting for validator next full snapshot slot: {validator_next_full_snapshot_slot}");
-    info!("Waiting for validator next incremental snapshot slot: {validator_next_incremental_snapshot_slot}");
+    info!(
+        "Waiting for validator next incremental snapshot slot: \
+         {validator_next_incremental_snapshot_slot}"
+    );
     let timer = Instant::now();
     loop {
         if let Some(full_snapshot_slot) = snapshot_utils::get_highest_full_snapshot_archive_slot(
@@ -1162,9 +1180,9 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
                     if incremental_snapshot_slot >= validator_next_incremental_snapshot_slot {
                         // specific incremental snapshot is not important, just that one was created
                         info!(
-                             "Validator made new snapshots, full snapshot slot: {}, incremental snapshot slot: {}",
-                             full_snapshot_slot,
-                             incremental_snapshot_slot,
+                            "Validator made new snapshots, full snapshot slot: {}, incremental \
+                             snapshot slot: {}",
+                            full_snapshot_slot, incremental_snapshot_slot,
                         );
                         break;
                     }
@@ -1174,7 +1192,8 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
 
         assert!(
             timer.elapsed() < Duration::from_secs(30),
-            "It should not take longer than 30 seconds to cross the next incremental snapshot interval."
+            "It should not take longer than 30 seconds to cross the next incremental snapshot \
+             interval."
         );
         std::thread::yield_now();
     }
@@ -1198,7 +1217,10 @@ fn test_incremental_snapshot_download_with_crossing_full_snapshot_interval_at_st
                 == leader_full_snapshot_archive_for_comparison.slot()
         })
         .expect("validator created an unexpected full snapshot");
-    info!("Validator full snapshot archive for comparison: {validator_full_snapshot_archive_for_comparison:#?}");
+    info!(
+        "Validator full snapshot archive for comparison: \
+         {validator_full_snapshot_archive_for_comparison:#?}"
+    );
     assert_eq!(
         validator_full_snapshot_archive_for_comparison.hash(),
         leader_full_snapshot_archive_for_comparison.hash(),
@@ -3382,9 +3404,15 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
             panic!("Violation expected because of removed persisted tower!");
         }
     } else if bad_vote_detected {
-        info!("THIS TEST expected violations. And indeed, there was some, because of removed persisted tower.");
+        info!(
+            "THIS TEST expected violations. And indeed, there was some, because of removed \
+             persisted tower."
+        );
     } else {
-        info!("THIS TEST expected no violation. And indeed, there was none, thanks to persisted tower.");
+        info!(
+            "THIS TEST expected no violation. And indeed, there was none, thanks to persisted \
+             tower."
+        );
     }
 }
 
@@ -3573,7 +3601,8 @@ fn test_fork_choice_refresh_old_votes() {
                         break;
                     } else {
                         info!(
-                            "Haven't seen vote on first slot in lighter partition, latest vote is: {}",
+                            "Haven't seen vote on first slot in lighter partition, latest vote \
+                             is: {}",
                             last_vote_slot
                         );
                     }
@@ -4821,7 +4850,10 @@ fn test_boot_from_local_state() {
             &validator1_config.incremental_snapshot_archives_dir,
             Some(Duration::from_secs(5 * 60)),
         );
-    debug!("snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: {incremental_snapshot_archive:?}");
+    debug!(
+        "snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: \
+         {incremental_snapshot_archive:?}"
+    );
     info!("Waiting for validator1 to create snapshots... DONE");
 
     info!("Copying snapshots to validator2...");
@@ -4904,7 +4936,10 @@ fn test_boot_from_local_state() {
             &validator2_config.incremental_snapshot_archives_dir,
             Some(Duration::from_secs(5 * 60)),
         );
-    debug!("snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: {incremental_snapshot_archive:?}");
+    debug!(
+        "snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: \
+         {incremental_snapshot_archive:?}"
+    );
     info!("Waiting for validator2 to create snapshots... DONE");
 
     info!("Copying snapshots to validator3...");
@@ -4946,7 +4981,10 @@ fn test_boot_from_local_state() {
             &validator3_config.incremental_snapshot_archives_dir,
             Some(Duration::from_secs(5 * 60)),
         );
-    debug!("snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: {incremental_snapshot_archive:?}");
+    debug!(
+        "snapshot archives:\n\tfull: {full_snapshot_archive:?}\n\tincr: \
+         {incremental_snapshot_archive:?}"
+    );
     info!("Waiting for validator3 to create snapshots... DONE");
 
     // ensure that all validators have the correct state by comparing snapshots

--- a/metrics/src/counter.rs
+++ b/metrics/src/counter.rs
@@ -178,8 +178,10 @@ impl Counter {
         let metricsrate = self.metricsrate.load(Ordering::Relaxed);
 
         if times % lograte == 0 && times > 0 && log_enabled!(level) {
-            log!(level,
-                "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"samples\": {},  \"now\": {}, \"events\": {}}}",
+            log!(
+                level,
+                "COUNTER:{{\"name\": \"{}\", \"counts\": {}, \"samples\": {},  \"now\": {}, \
+                 \"events\": {}}}",
                 self.name,
                 counts + events,
                 times,
@@ -322,7 +324,8 @@ mod tests {
         assert_eq!(
             Counter::default_log_rate(),
             DEFAULT_LOG_RATE,
-            "default_log_rate() is {}, expected {}, SOLANA_DEFAULT_LOG_RATE environment variable set?",
+            "default_log_rate() is {}, expected {}, SOLANA_DEFAULT_LOG_RATE environment variable \
+             set?",
             Counter::default_log_rate(),
             DEFAULT_LOG_RATE,
         );

--- a/net-shaper/src/main.rs
+++ b/net-shaper/src/main.rs
@@ -309,11 +309,12 @@ fn insert_tos_ifb_filter(class: &str, tos: &str) -> bool {
     run(
         "tc",
         &[
-            "filter", "add", "dev", "ifb0", "protocol", "ip", "parent", "1:", "prio", "1",
-            "u32", "match", "ip", "tos", tos, "0xff", "flowid", class,
+            "filter", "add", "dev", "ifb0", "protocol", "ip", "parent", "1:", "prio", "1", "u32",
+            "match", "ip", "tos", tos, "0xff", "flowid", class,
         ],
         "Failed to add tos filter",
-        "tc filter add dev ifb0 protocol ip parent 1: prio 1 u32 match ip tos <tos> 0xff flowid <class>",
+        "tc filter add dev ifb0 protocol ip parent 1: prio 1 u32 match ip tos <tos> 0xff flowid \
+         <class>",
         false,
     )
 }
@@ -584,7 +585,10 @@ fn main() {
                         .value_name("count")
                         .takes_value(true)
                         .required(false)
-                        .help("Maximum number of partitions. Used only with random configuration generation"),
+                        .help(
+                            "Maximum number of partitions. Used only with random configuration \
+                             generation",
+                        ),
                 )
                 .arg(
                     Arg::new("max-drop")
@@ -593,7 +597,10 @@ fn main() {
                         .value_name("percentage")
                         .takes_value(true)
                         .required(false)
-                        .help("Maximum amount of packet drop. Used only with random configuration generation"),
+                        .help(
+                            "Maximum amount of packet drop. Used only with random configuration \
+                             generation",
+                        ),
                 )
                 .arg(
                     Arg::new("max-delay")
@@ -602,7 +609,10 @@ fn main() {
                         .value_name("ms")
                         .takes_value(true)
                         .required(false)
-                        .help("Maximum amount of packet delay. Used only with random configuration generation"),
+                        .help(
+                            "Maximum amount of packet delay. Used only with random configuration \
+                             generation",
+                        ),
                 ),
         )
         .get_matches();

--- a/net-utils/src/lib.rs
+++ b/net-utils/src/lib.rs
@@ -76,14 +76,16 @@ fn ip_echo_server_request(
                     return Err(io::Error::new(
                         io::ErrorKind::Other,
                         format!(
-                            "Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP port: {http_response}"
+                            "Invalid gossip entrypoint. {ip_echo_server_addr} looks to be an HTTP \
+                             port: {http_response}"
                         ),
                     ));
                 }
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!(
-                        "Invalid gossip entrypoint. {ip_echo_server_addr} provided an invalid response header: '{response_header}'"
+                        "Invalid gossip entrypoint. {ip_echo_server_addr} provided an invalid \
+                         response header: '{response_header}'"
                     ),
                 ));
             }

--- a/perf/src/lib.rs
+++ b/perf/src/lib.rs
@@ -69,8 +69,9 @@ pub fn report_target_features() {
                 info!("AVX detected");
             } else {
                 error!(
-                "Incompatible CPU detected: missing AVX support. Please build from source on the target"
-            );
+                    "Incompatible CPU detected: missing AVX support. Please build from source on \
+                     the target"
+                );
                 std::process::abort();
             }
         }
@@ -84,7 +85,8 @@ pub fn report_target_features() {
                 info!("AVX2 detected");
             } else {
                 error!(
-                    "Incompatible CPU detected: missing AVX2 support. Please build from source on the target"
+                    "Incompatible CPU detected: missing AVX2 support. Please build from source on \
+                     the target"
                 );
                 std::process::abort();
             }

--- a/perf/src/thread.rs
+++ b/perf/src/thread.rs
@@ -81,9 +81,8 @@ where
         Ok(())
     } else {
         Err(String::from(
-            "niceness adjustment supported only on Linux; negative adjustment \
-             (priority increase) requires root or CAP_SYS_NICE (see `man 7 capabilities` \
-             for details)",
+            "niceness adjustment supported only on Linux; negative adjustment (priority increase) \
+             requires root or CAP_SYS_NICE (see `man 7 capabilities` for details)",
         ))
     }
 }

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -487,7 +487,8 @@ impl PohRecorder {
     /// leaders needed to be skipped).
     pub fn reached_leader_slot(&self) -> PohLeaderStatus {
         trace!(
-            "tick_height {}, start_tick_height {}, leader_first_tick_height_including_grace_ticks {:?}, grace_ticks {}, has_bank {}",
+            "tick_height {}, start_tick_height {}, leader_first_tick_height_including_grace_ticks \
+             {:?}, grace_ticks {}, has_bank {}",
             self.tick_height,
             self.start_tick_height,
             self.leader_first_tick_height_including_grace_ticks,

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -185,8 +185,19 @@ impl Stats {
             ("empty_entries", empty_entries, i64),
         );
         debug!(
-            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Insertions: {}, Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Expired: {}, Prunes-Environment: {}, Empty: {}",
-            hits, misses, evictions, insertions, replacements, one_hit_wonders, prunes_orphan, prunes_expired, prunes_environment, empty_entries
+            "Loaded Programs Cache Stats -- Hits: {}, Misses: {}, Evictions: {}, Insertions: {}, \
+             Replacements: {}, One-Hit-Wonders: {}, Prunes-Orphan: {}, Prunes-Expired: {}, \
+             Prunes-Environment: {}, Empty: {}",
+            hits,
+            misses,
+            evictions,
+            insertions,
+            replacements,
+            one_hit_wonders,
+            prunes_orphan,
+            prunes_expired,
+            prunes_environment,
+            empty_entries
         );
         if log_enabled!(log::Level::Trace) && !self.evictions.is_empty() {
             let mut evictions = self.evictions.iter().collect::<Vec<_>>();

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -479,10 +479,8 @@ impl Default for ProgramTest {
     ///
     fn default() -> Self {
         solana_logger::setup_with_default(
-            "solana_rbpf::vm=debug,\
-             solana_runtime::message_processor=debug,\
-             solana_runtime::system_instruction_processor=trace,\
-             solana_program_test=info",
+            "solana_rbpf::vm=debug,solana_runtime::message_processor=debug,\
+             solana_runtime::system_instruction_processor=trace,solana_program_test=info",
         );
         let prefer_bpf =
             std::env::var("BPF_OUT_DIR").is_ok() || std::env::var("SBF_OUT_DIR").is_ok();
@@ -678,8 +676,8 @@ impl ProgramTest {
             }
 
             warn!(
-                "Possible bogus program name. Ensure the program name ({}) \
-                matches one of the following recognizable program names:",
+                "Possible bogus program name. Ensure the program name ({}) matches one of the \
+                 following recognizable program names:",
                 program_name,
             );
             for name in valid_program_names {
@@ -788,7 +786,8 @@ impl ProgramTest {
                 match genesis_config.accounts.remove(deactivate_feature_pk) {
                     Some(_) => debug!("Feature for {:?} deactivated", deactivate_feature_pk),
                     None => warn!(
-                        "Feature {:?} set for deactivation not found in genesis_config account list, ignored.",
+                        "Feature {:?} set for deactivation not found in genesis_config account \
+                         list, ignored.",
                         deactivate_feature_pk
                     ),
                 }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1284,7 +1284,8 @@ fn process_loader_upgradeable_instruction(
             if new_len > MAX_PERMITTED_DATA_LENGTH as usize {
                 ic_logger_msg!(
                     log_collector,
-                    "Extended ProgramData length of {} bytes exceeds max account data length of {} bytes",
+                    "Extended ProgramData length of {} bytes exceeds max account data length of \
+                     {} bytes",
                     new_len,
                     MAX_PERMITTED_DATA_LENGTH
                 );

--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -117,7 +117,10 @@ pub enum SyscallError {
         num_accounts: u64,
         max_accounts: u64,
     },
-    #[error("Invoked an instruction with too many account info's ({num_account_infos} > {max_account_infos})")]
+    #[error(
+        "Invoked an instruction with too many account info's ({num_account_infos} > \
+         {max_account_infos})"
+    )]
     MaxInstructionAccountInfosExceeded {
         num_account_infos: u64,
         max_account_infos: u64,

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -156,7 +156,11 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
-    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
+    println!(
+        "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_interpreted_mips\", \"median\": \
+         {:?}, \"deviation\": 0 }}",
+        mips
+    );
 
     println!("JIT to native:");
     assert_eq!(SUCCESS, vm.execute_program(&executable, false).1.unwrap());
@@ -177,7 +181,11 @@ fn bench_program_alu(bencher: &mut Bencher) {
     assert!(0f64 != summary.median);
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
-    println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
+    println!(
+        "{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": \
+         {:?}, \"deviation\": 0 }}",
+        mips
+    );
 }
 
 #[bench]

--- a/programs/sbf/build.rs
+++ b/programs/sbf/build.rs
@@ -112,7 +112,10 @@ fn main() {
             "upgraded",
         ];
         for program in rust_programs.iter() {
-            println!("cargo:warning=(not a warning) Building Rust-based on-chain programs: solana_sbf_rust_{program}");
+            println!(
+                "cargo:warning=(not a warning) Building Rust-based on-chain programs: \
+                 solana_sbf_rust_{program}"
+            );
             assert!(Command::new("../../cargo-build-sbf")
                 .args([
                     "--manifest-path",

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1020,7 +1020,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction data len exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with data that is too large (10241 > 10240)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with data that is \
+                     too large (10241 > 10240)"
+                ),
             ]),
         );
 
@@ -1033,7 +1036,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max instruction accounts exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with too many accounts (256 > 255)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
+                     accounts (256 > 255)"
+                ),
             ]),
         );
 
@@ -1046,7 +1052,10 @@ fn test_program_sbf_invoke_sanity() {
                 format!("Program log: invoke {program_lang} program"),
                 "Program log: Test max account infos exceeded".into(),
                 "skip".into(), // don't compare compute consumption logs
-                format!("Program {invoke_program_id} failed: Invoked an instruction with too many account info's (129 > 128)"),
+                format!(
+                    "Program {invoke_program_id} failed: Invoked an instruction with too many \
+                     account info's (129 > 128)"
+                ),
             ]),
         );
 

--- a/programs/stake/src/lib.rs
+++ b/programs/stake/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 #[deprecated(
     since = "1.8.0",
-    note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` instead"
+    note = "Please use `solana_sdk::stake::program::id` or `solana_program::stake::program::id` \
+            instead"
 )]
 pub use solana_sdk::stake::program::{check_id, id};
 use solana_sdk::{

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -4473,7 +4473,10 @@ mod tests {
                     );
                     assert!(destination_stake.delegation.stake >= minimum_delegation,);
                 } else {
-                    panic!("destination state must be StakeStake::Stake after successful split when source is also StakeStateV2::Stake!");
+                    panic!(
+                        "destination state must be StakeStake::Stake after successful split when \
+                         source is also StakeStateV2::Stake!"
+                    );
                 }
             }
         }

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -308,7 +308,8 @@ fn check_update_vote_state_slots_are_valid(
                         root_to_check = None;
                     } else {
                         vote_state_update_index = vote_state_update_index.checked_add(1).expect(
-                            "`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when `proposed_vote_slot` is too old to be in SlotHashes history",
+                            "`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when \
+                             `proposed_vote_slot` is too old to be in SlotHashes history",
                         );
                     }
                     continue;
@@ -325,9 +326,10 @@ fn check_update_vote_state_slots_are_valid(
             }
             Ordering::Greater => {
                 // Decrement `slot_hashes_index` to find newer slots in the SlotHashes history
-                slot_hashes_index = slot_hashes_index
-                    .checked_sub(1)
-                    .expect("`slot_hashes_index` is positive when finding newer slots in SlotHashes history");
+                slot_hashes_index = slot_hashes_index.checked_sub(1).expect(
+                    "`slot_hashes_index` is positive when finding newer slots in SlotHashes \
+                     history",
+                );
                 continue;
             }
             Ordering::Equal => {
@@ -337,9 +339,10 @@ fn check_update_vote_state_slots_are_valid(
                 if root_to_check.is_some() {
                     root_to_check = None;
                 } else {
-                    vote_state_update_index = vote_state_update_index
-                        .checked_add(1)
-                        .expect("`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when match is found in SlotHashes history");
+                    vote_state_update_index = vote_state_update_index.checked_add(1).expect(
+                        "`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when match \
+                         is found in SlotHashes history",
+                    );
                     slot_hashes_index = slot_hashes_index.checked_sub(1).expect(
                         "`slot_hashes_index` is positive when match is found in SlotHashes history",
                     );
@@ -409,9 +412,10 @@ fn check_update_vote_state_slots_are_valid(
             true
         };
 
-        vote_state_update_index = vote_state_update_index
-            .checked_add(1)
-            .expect("`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when filtering out irrelevant votes");
+        vote_state_update_index = vote_state_update_index.checked_add(1).expect(
+            "`vote_state_update_index` is bounded by `MAX_LOCKOUT_HISTORY` when filtering out \
+             irrelevant votes",
+        );
         should_retain
     });
 
@@ -628,9 +632,10 @@ pub fn process_new_vote_state(
                         .checked_add(vote_state.credits_for_vote_at_index(current_vote_state_index))
                         .expect("`earned_credits` does not overflow");
                 }
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when processing new root");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when \
+                     processing new root",
+                );
                 continue;
             }
 
@@ -671,9 +676,10 @@ pub fn process_new_vote_state(
                 if current_vote.lockout.last_locked_out_slot() >= new_vote.slot() {
                     return Err(VoteError::LockoutConflict);
                 }
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is less than proposed");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     less than proposed",
+                );
             }
             Ordering::Equal => {
                 // The new vote state should never have less lockout than
@@ -685,17 +691,20 @@ pub fn process_new_vote_state(
                 // Copy the vote slot latency in from the current state to the new state
                 new_vote.latency = vote_state.votes[current_vote_state_index].latency;
 
-                current_vote_state_index = current_vote_state_index
-                    .checked_add(1)
-                    .expect("`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is equal to proposed");
-                new_vote_state_index = new_vote_state_index
-                    .checked_add(1)
-                    .expect("`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is equal to proposed");
+                current_vote_state_index = current_vote_state_index.checked_add(1).expect(
+                    "`current_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     equal to proposed",
+                );
+                new_vote_state_index = new_vote_state_index.checked_add(1).expect(
+                    "`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     equal to proposed",
+                );
             }
             Ordering::Greater => {
-                new_vote_state_index = new_vote_state_index
-                    .checked_add(1)
-                    .expect("`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is greater than proposed");
+                new_vote_state_index = new_vote_state_index.checked_add(1).expect(
+                    "`new_vote_state_index` is bounded by `MAX_LOCKOUT_HISTORY` when slot is \
+                     greater than proposed",
+                );
             }
         }
     }

--- a/pubsub-client/src/pubsub_client.rs
+++ b/pubsub-client/src/pubsub_client.rs
@@ -348,7 +348,8 @@ fn connect_with_retry(
 
                 connection_retries -= 1;
                 debug!(
-                    "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
+                    "Too many requests: server responded with {:?}, {} retries left, pausing for \
+                     {:?}",
                     response, connection_retries, duration
                 );
 

--- a/quic-client/src/nonblocking/quic_client.rs
+++ b/quic-client/src/nonblocking/quic_client.rs
@@ -306,7 +306,8 @@ impl QuicClient {
                             match conn {
                                 Ok(conn) => {
                                     info!(
-                                        "Made 0rtt connection to {} with id {} try_count {}, last_connection_id: {}, last_error: {:?}",
+                                        "Made 0rtt connection to {} with id {} try_count {}, \
+                                         last_connection_id: {}, last_error: {:?}",
                                         self.addr,
                                         conn.stable_id(),
                                         connection_try_count,
@@ -340,7 +341,8 @@ impl QuicClient {
                             Ok(conn) => {
                                 *conn_guard = Some(conn.clone());
                                 info!(
-                                    "Made connection to {} id {} try_count {}, from connection cache warming?: {}",
+                                    "Made connection to {} id {} try_count {}, from connection \
+                                     cache warming?: {}",
                                     self.addr,
                                     conn.connection.stable_id(),
                                     connection_try_count,
@@ -350,8 +352,13 @@ impl QuicClient {
                                 conn.connection.clone()
                             }
                             Err(err) => {
-                                info!("Cannot make connection to {}, error {:}, from connection cache warming?: {}",
-                                    self.addr, err, data.is_empty());
+                                info!(
+                                    "Cannot make connection to {}, error {:}, from connection \
+                                     cache warming?: {}",
+                                    self.addr,
+                                    err,
+                                    data.is_empty()
+                                );
                                 return Err(err);
                             }
                         }
@@ -406,7 +413,8 @@ impl QuicClient {
                         .prepare_connection_us
                         .fetch_add(measure_prepare_connection.as_us(), Ordering::Relaxed);
                     trace!(
-                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, send_packet_us: {} prepare_connection_us: {}",
+                        "Succcessfully sent to {} with id {}, thread: {:?}, data len: {}, \
+                         send_packet_us: {} prepare_connection_us: {}",
                         self.addr,
                         connection.stable_id(),
                         thread::current().id(),

--- a/rpc-client-api/src/custom_error.rs
+++ b/rpc-client-api/src/custom_error.rs
@@ -98,7 +98,8 @@ impl From<RpcCustomError> for Error {
             } => Self {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_BLOCK_CLEANED_UP),
                 message: format!(
-                    "Block {slot} cleaned up, does not exist on node. First available block: {first_available_block}",
+                    "Block {slot} cleaned up, does not exist on node. First available block: \
+                     {first_available_block}",
                 ),
                 data: None,
             },
@@ -161,8 +162,8 @@ impl From<RpcCustomError> for Error {
                     JSON_RPC_SERVER_ERROR_KEY_EXCLUDED_FROM_SECONDARY_INDEX,
                 ),
                 message: format!(
-                    "{index_key} excluded from account secondary indexes; \
-                    this RPC method unavailable for key"
+                    "{index_key} excluded from account secondary indexes; this RPC method \
+                     unavailable for key"
                 ),
                 data: None,
             },
@@ -194,8 +195,8 @@ impl From<RpcCustomError> for Error {
                 code: ErrorCode::ServerError(JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION),
                 message: format!(
                     "Transaction version ({version}) is not supported by the requesting client. \
-                    Please try the request again with the following configuration parameter: \
-                    \"maxSupportedTransactionVersion\": {version}"
+                     Please try the request again with the following configuration parameter: \
+                     \"maxSupportedTransactionVersion\": {version}"
                 ),
                 data: None,
             },

--- a/rpc-client-api/src/filter.rs
+++ b/rpc-client-api/src/filter.rs
@@ -147,8 +147,9 @@ pub struct Memcmp {
     /// Optional encoding specification
     #[deprecated(
         since = "1.11.2",
-        note = "Field has no server-side effect. Specify encoding with `MemcmpEncodedBytes` variant instead. \
-            Field will be made private in future. Please use a constructor method instead."
+        note = "Field has no server-side effect. Specify encoding with `MemcmpEncodedBytes` \
+                variant instead. Field will be made private in future. Please use a constructor \
+                method instead."
     )]
     pub encoding: Option<MemcmpEncoding>,
 }
@@ -310,8 +311,8 @@ pub fn maybe_map_filters(
                         memcmp.bytes = MemcmpEncodedBytes::Binary(string.clone());
                     }
                     MemcmpEncodedBytes::Base64(_) => {
-                        return Err("RPC node on old version does not support base64 \
-                            encoding for memcmp filters"
+                        return Err("RPC node on old version does not support base64 encoding \
+                                    for memcmp filters"
                             .to_string());
                     }
                     _ => {}

--- a/rpc-client/src/http_sender.rs
+++ b/rpc-client/src/http_sender.rs
@@ -159,9 +159,10 @@ impl RpcSender for HttpSender {
 
                     too_many_requests_retries -= 1;
                     debug!(
-                                "Too many requests: server responded with {:?}, {} retries left, pausing for {:?}",
-                                response, too_many_requests_retries, duration
-                            );
+                        "Too many requests: server responded with {:?}, {} retries left, pausing \
+                         for {:?}",
+                        response, too_many_requests_retries, duration
+                    );
 
                     sleep(duration).await;
                     stats_updater.add_rate_limited_time(duration);

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -709,9 +709,8 @@ impl RpcClient {
         }
 
         Err(RpcError::ForUser(
-            "unable to confirm transaction. \
-             This can happen in situations such as transaction expiration \
-             and insufficient fee-payer funds"
+            "unable to confirm transaction. This can happen in situations such as transaction \
+             expiration and insufficient fee-payer funds"
                 .to_string(),
         )
         .into())
@@ -1191,9 +1190,8 @@ impl RpcClient {
             }
         } else {
             return Err(RpcError::ForUser(
-                "unable to confirm transaction. \
-                                      This can happen in situations such as transaction expiration \
-                                      and insufficient fee-payer funds"
+                "unable to confirm transaction. This can happen in situations such as transaction \
+                 expiration and insufficient fee-payer funds"
                     .to_string(),
             )
             .into());
@@ -1224,11 +1222,12 @@ impl RpcClient {
                 .await
                 .unwrap_or(confirmations);
             if now.elapsed().as_secs() >= MAX_HASH_AGE_IN_SECONDS as u64 {
-                return Err(
-                    RpcError::ForUser("transaction not finalized. \
-                                      This can happen when a transaction lands in an abandoned fork. \
-                                      Please retry.".to_string()).into(),
-                );
+                return Err(RpcError::ForUser(
+                    "transaction not finalized. This can happen when a transaction lands in an \
+                     abandoned fork. Please retry."
+                        .to_string(),
+                )
+                .into());
             }
         }
     }
@@ -4566,7 +4565,8 @@ impl RpcClient {
 
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
+        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` \
+                instead"
     )]
     #[allow(deprecated)]
     pub async fn get_fees_with_commitment(
@@ -5064,8 +5064,7 @@ impl RpcClient {
         })
         .map_err(|_| {
             RpcError::ForUser(
-                "airdrop request failed. \
-                    This can happen when the rate limit is reached."
+                "airdrop request failed. This can happen when the rate limit is reached."
                     .to_string(),
             )
             .into()

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -3710,7 +3710,8 @@ impl RpcClient {
 
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` instead"
+        note = "Please use `get_latest_blockhash_with_commitment` and `get_fee_for_message` \
+                instead"
     )]
     #[allow(deprecated)]
     pub fn get_fees_with_commitment(&self, commitment_config: CommitmentConfig) -> RpcResult<Fees> {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -2309,7 +2309,10 @@ fn encode_account<T: ReadableAccount>(
     if (encoding == UiAccountEncoding::Binary || encoding == UiAccountEncoding::Base58)
         && account.data().len() > MAX_BASE58_BYTES
     {
-        let message = format!("Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please use Base64 encoding.");
+        let message = format!(
+            "Encoded binary (base 58) data should be less than {MAX_BASE58_BYTES} bytes, please \
+             use Base64 encoding."
+        );
         Err(error::Error {
             code: error::ErrorCode::InvalidRequest,
             message,
@@ -4440,7 +4443,8 @@ pub mod rpc_obsolete_v1_7 {
             }
             if end_slot - start_slot > MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE {
                 return Err(Error::invalid_params(format!(
-                    "Slot range too large; max {MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE}"
+                    "Slot range too large; max \
+                     {MAX_GET_CONFIRMED_SIGNATURES_FOR_ADDRESS_SLOT_RANGE}"
                 )));
             }
             Ok(meta
@@ -6827,9 +6831,9 @@ pub mod tests {
         let expected = (
             JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
             String::from(
-                "Transaction version (0) is not supported by the requesting client. \
-                Please try the request again with the following configuration parameter: \
-                \"maxSupportedTransactionVersion\": 0",
+                "Transaction version (0) is not supported by the requesting client. Please try \
+                 the request again with the following configuration parameter: \
+                 \"maxSupportedTransactionVersion\": 0",
             ),
         );
         assert_eq!(response, expected);
@@ -6856,7 +6860,8 @@ pub mod tests {
         {
             assert_eq!(
                 version, None,
-                "requests which don't set max_supported_transaction_version shouldn't receive a version"
+                "requests which don't set max_supported_transaction_version shouldn't receive a \
+                 version"
             );
             if let EncodedTransaction::Json(transaction) = transaction {
                 if transaction.signatures[0] == confirmed_block_signatures[0].to_string() {
@@ -6900,7 +6905,8 @@ pub mod tests {
         {
             assert_eq!(
                 version, None,
-                "requests which don't set max_supported_transaction_version shouldn't receive a version"
+                "requests which don't set max_supported_transaction_version shouldn't receive a \
+                 version"
             );
             if let EncodedTransaction::LegacyBinary(transaction) = transaction {
                 let decoded_transaction: Transaction =
@@ -8475,9 +8481,10 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base58 encoded solana_sdk::transaction::Transaction too large: {tx58_len} bytes (max: encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
-            )
-        ));
+                "base58 encoded solana_sdk::transaction::Transaction too large: {tx58_len} bytes \
+                 (max: encoded/raw {MAX_BASE58_SIZE}/{PACKET_DATA_SIZE})",
+            ))
+        );
 
         let tx64 = BASE64_STANDARD.encode(&tx_ser);
         let tx64_len = tx64.len();
@@ -8485,9 +8492,10 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "base64 encoded solana_sdk::transaction::Transaction too large: {tx64_len} bytes (max: encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
-            )
-        ));
+                "base64 encoded solana_sdk::transaction::Transaction too large: {tx64_len} bytes \
+                 (max: encoded/raw {MAX_BASE64_SIZE}/{PACKET_DATA_SIZE})",
+            ))
+        );
 
         let too_big = PACKET_DATA_SIZE + 1;
         let tx_ser = vec![0x00u8; too_big];
@@ -8496,7 +8504,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx58, TransactionBinaryEncoding::Base58)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {PACKET_DATA_SIZE} bytes)"
+                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: \
+                 {PACKET_DATA_SIZE} bytes)"
             ))
         );
 
@@ -8505,7 +8514,8 @@ pub mod tests {
             decode_and_deserialize::<Transaction>(tx64, TransactionBinaryEncoding::Base64)
                 .unwrap_err(),
             Error::invalid_params(format!(
-                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: {PACKET_DATA_SIZE} bytes)"
+                "decoded solana_sdk::transaction::Transaction too large: {too_big} bytes (max: \
+                 {PACKET_DATA_SIZE} bytes)"
             ))
         );
 
@@ -8516,7 +8526,7 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(
                 "failed to deserialize solana_sdk::transaction::Transaction: invalid value: \
-                continue signal on byte-three, expected a terminal signal on or before byte-three"
+                 continue signal on byte-three, expected a terminal signal on or before byte-three"
                     .to_string()
             )
         );
@@ -8534,7 +8544,7 @@ pub mod tests {
                 .unwrap_err(),
             Error::invalid_params(
                 "failed to deserialize solana_sdk::transaction::Transaction: invalid value: \
-                continue signal on byte-three, expected a terminal signal on or before byte-three"
+                 continue signal on byte-three, expected a terminal signal on or before byte-three"
                     .to_string()
             )
         );

--- a/rpc/src/rpc_health.rs
+++ b/rpc/src/rpc_health.rs
@@ -104,9 +104,9 @@ impl RpcHealth {
             let num_slots = cluster_latest_optimistically_confirmed_slot
                 .saturating_sub(my_latest_optimistically_confirmed_slot);
             warn!(
-                "health check: behind by {num_slots} \
-                slots: me={my_latest_optimistically_confirmed_slot}, \
-                latest cluster={cluster_latest_optimistically_confirmed_slot}",
+                "health check: behind by {num_slots} slots: \
+                 me={my_latest_optimistically_confirmed_slot}, latest \
+                 cluster={cluster_latest_optimistically_confirmed_slot}",
             );
             RpcHealthStatus::Behind { num_slots }
         }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -535,8 +535,8 @@ impl JsonRpcService {
 
                 if let Err(e) = server {
                     warn!(
-                        "JSON RPC service unavailable error: {:?}. \n\
-                           Also, check that port {} is not already in use by another application",
+                        "JSON RPC service unavailable error: {:?}. \nAlso, check that port {} is \
+                         not already in use by another application",
                         e,
                         rpc_addr.port()
                     );

--- a/rpc/src/rpc_subscriptions.rs
+++ b/rpc/src/rpc_subscriptions.rs
@@ -1151,7 +1151,8 @@ impl RpcSubscriptions {
         let total_ms = total_time.as_ms();
         if total_notified > 0 || total_ms > 10 {
             debug!(
-                "notified({}): accounts: {} / {} logs: {} / {} programs: {} / {} signatures: {} / {}",
+                "notified({}): accounts: {} / {} logs: {} / {} programs: {} / {} signatures: {} / \
+                 {}",
                 source,
                 num_accounts_found.load(Ordering::Relaxed),
                 num_accounts_notified.load(Ordering::Relaxed),

--- a/runtime/src/accounts_background_service.rs
+++ b/runtime/src/accounts_background_service.rs
@@ -422,7 +422,10 @@ impl SnapshotRequestHandler {
                         accounts_hash_for_testing,
                     )
                 }
-                AccountsPackageKind::EpochAccountsHash => panic!("Illegal account package type: EpochAccountsHash packages must be from an EpochAccountsHash request!"),
+                AccountsPackageKind::EpochAccountsHash => panic!(
+                    "Illegal account package type: EpochAccountsHash packages must be from an \
+                     EpochAccountsHash request!"
+                ),
             },
             SnapshotRequestKind::EpochAccountsHash => {
                 // skip the bank snapshot, just make an accounts package to send to AHV
@@ -691,7 +694,10 @@ impl AccountsBackgroundService {
                                 last_cleaned_block_height = snapshot_block_height;
                             }
                             Err(err) => {
-                                error!("Stopping AccountsBackgroundService! Fatal error while handling snapshot requests: {err}");
+                                error!(
+                                    "Stopping AccountsBackgroundService! Fatal error while \
+                                     handling snapshot requests: {err}"
+                                );
                                 exit.store(true, Ordering::Relaxed);
                                 break;
                             }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1897,8 +1897,8 @@ impl Bank {
             Some(account)
         })
         .expect(
-            "Stakes cache is inconsistent with accounts-db. This can indicate \
-            a corrupted snapshot or bugs in cached accounts or accounts-db.",
+            "Stakes cache is inconsistent with accounts-db. This can indicate a corrupted \
+             snapshot or bugs in cached accounts or accounts-db.",
         );
         let stakes_accounts_load_duration = now.elapsed();
         let mut bank = Self {
@@ -1978,8 +1978,8 @@ impl Bank {
         // from the passed in genesis_config instead (as new()/new_with_paths() already do)
         assert_eq!(
             bank.genesis_creation_time, genesis_config.creation_time,
-            "Bank snapshot genesis creation time does not match genesis.bin creation time.\
-             The snapshot and genesis.bin might pertain to different clusters"
+            "Bank snapshot genesis creation time does not match genesis.bin creation time.The \
+             snapshot and genesis.bin might pertain to different clusters"
         );
         assert_eq!(bank.ticks_per_slot, genesis_config.ticks_per_slot);
         assert_eq!(
@@ -3445,8 +3445,13 @@ impl Bank {
                 if let Some(curr_stake_account) = self.get_account_with_fixed_root(&stake_pubkey) {
                     let pre_lamport = curr_stake_account.lamports();
                     let post_lamport = post_stake_account.lamports();
-                    assert_eq!(pre_lamport + u64::try_from(reward_amount).unwrap(), post_lamport,
-                        "stake account balance has changed since the reward calculation! account: {stake_pubkey}, pre balance: {pre_lamport}, post balance: {post_lamport}, rewards: {reward_amount}");
+                    assert_eq!(
+                        pre_lamport + u64::try_from(reward_amount).unwrap(),
+                        post_lamport,
+                        "stake account balance has changed since the reward calculation! account: \
+                         {stake_pubkey}, pre balance: {pre_lamport}, post balance: \
+                         {post_lamport}, rewards: {reward_amount}"
+                    );
                 }
             }
         }
@@ -3995,8 +4000,9 @@ impl Bank {
 
         assert!(
             !self.freeze_started(),
-            "Can't change frozen bank by adding not-existing new builtin program ({name}, {program_id}). \
-            Maybe, inconsistent program activation is detected on snapshot restore?"
+            "Can't change frozen bank by adding not-existing new builtin program ({name}, \
+             {program_id}). Maybe, inconsistent program activation is detected on snapshot \
+             restore?"
         );
 
         // Add a bogus executable builtin account, which will be loaded and ignored.
@@ -4026,8 +4032,9 @@ impl Bank {
 
         assert!(
             !self.freeze_started(),
-            "Can't change frozen bank by adding not-existing new precompiled program ({program_id}). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+            "Can't change frozen bank by adding not-existing new precompiled program \
+             ({program_id}). Maybe, inconsistent program activation is detected on snapshot \
+             restore?"
         );
 
         // Add a bogus executable account, which will be loaded and ignored.
@@ -5645,7 +5652,8 @@ impl Bank {
     ) -> TransactionResults {
         assert!(
             !self.freeze_started(),
-            "commit_transactions() working on a bank that is already frozen or is undergoing freezing!"
+            "commit_transactions() working on a bank that is already frozen or is undergoing \
+             freezing!"
         );
 
         let CommitTransactionCounts {
@@ -5997,8 +6005,8 @@ impl Bank {
                                 ("partition_from_pubkey", partition_from_pubkey, i64)
                             );
                             warn!(
-                                "Collecting rent from unexpected pubkey: {}, slot: {}, parent_slot: {:?}, \
-                                partition_index: {}, partition_from_pubkey: {}",
+                                "Collecting rent from unexpected pubkey: {}, slot: {}, \
+                                 parent_slot: {:?}, partition_index: {}, partition_from_pubkey: {}",
                                 pubkey,
                                 self.slot(),
                                 self.parent().map(|bank| bank.slot()),
@@ -6764,14 +6772,14 @@ impl Bank {
         let bank_frozen = *lock != Hash::default();
         if new_hard_fork_slot < bank_slot {
             warn!(
-                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is older \
-                than the bank at slot {bank_slot} that attempted to register it."
+                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is older than the \
+                 bank at slot {bank_slot} that attempted to register it."
             );
         } else if (new_hard_fork_slot == bank_slot) && bank_frozen {
             warn!(
-                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is the same \
-                slot as the bank at slot {bank_slot} that attempted to register it, but that \
-                bank is already frozen."
+                "Hard fork at slot {new_hard_fork_slot} ignored, the hard fork is the same slot \
+                 as the bank at slot {bank_slot} that attempted to register it, but that bank is \
+                 already frozen."
             );
         } else {
             self.hard_forks
@@ -7076,7 +7084,8 @@ impl Bank {
             .get_bank_hash_stats(slot)
             .expect("No bank hash stats were found for this bank, that should not be possible");
         info!(
-            "bank frozen: {slot} hash: {hash} accounts_delta: {} signature_count: {} last_blockhash: {} capitalization: {}{}, stats: {bank_hash_stats:?}",
+            "bank frozen: {slot} hash: {hash} accounts_delta: {} signature_count: {} \
+             last_blockhash: {} capitalization: {}{}, stats: {bank_hash_stats:?}",
             accounts_delta_hash.0,
             self.signature_count(),
             self.last_blockhash(),
@@ -7168,7 +7177,12 @@ impl Bank {
                 .is_alive_root(self.slot())
         {
             if let Some(parent) = self.parent() {
-                info!("{} is not a root, so attempting to verify bank hash on parent bank at slot: {}", self.slot(), parent.slot());
+                info!(
+                    "{} is not a root, so attempting to verify bank hash on parent bank at slot: \
+                     {}",
+                    self.slot(),
+                    parent.slot()
+                );
                 return parent.verify_accounts_hash(base, config);
             } else {
                 // this will result in mismatch errors
@@ -7430,7 +7444,11 @@ impl Bank {
         let incremental_accounts_hash = self.get_incremental_accounts_hash();
 
         let accounts_hash = match (accounts_hash, incremental_accounts_hash) {
-            (Some(_), Some(_)) => panic!("Both full and incremental accounts hashes are present for slot {}; it is ambiguous which one to use for the snapshot hash!", self.slot()),
+            (Some(_), Some(_)) => panic!(
+                "Both full and incremental accounts hashes are present for slot {}; it is \
+                 ambiguous which one to use for the snapshot hash!",
+                self.slot()
+            ),
             (Some(accounts_hash), None) => accounts_hash.into(),
             (None, Some(incremental_accounts_hash)) => incremental_accounts_hash.into(),
             (None, None) => panic!("accounts hash is required to get snapshot hash"),

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -263,7 +263,10 @@ impl Bank {
 
         if !self.should_collect_rent() {
             if total_rent_collected != 0 {
-                warn!("Rent fees collection is disabled, yet total rent collected was non zero! Total rent collected: {total_rent_collected}");
+                warn!(
+                    "Rent fees collection is disabled, yet total rent collected was non zero! \
+                     Total rent collected: {total_rent_collected}"
+                );
             }
             return;
         }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -222,7 +222,9 @@ mod tests {
                 assert_eq!(
                     size,
                     expected,
-                    "(reserialize_accounts_hash, incremental_snapshot_persistence, update_accounts_hash, initial_epoch_accounts_hash): {:?}, previous_len: {previous_len}",
+                    "(reserialize_accounts_hash, incremental_snapshot_persistence, \
+                     update_accounts_hash, initial_epoch_accounts_hash): {:?}, previous_len: \
+                     {previous_len}",
                     (
                         reserialize_accounts_hash,
                         incremental_snapshot_persistence,
@@ -293,14 +295,19 @@ mod tests {
         }
         assert!(bank2 == dbank);
         assert_eq!(dbank.incremental_snapshot_persistence, incremental);
-        assert_eq!(dbank.get_epoch_accounts_hash_to_serialize().map(|epoch_accounts_hash| *epoch_accounts_hash.as_ref()), expected_epoch_accounts_hash,
-                   "(reserialize_accounts_hash, incremental_snapshot_persistence, update_accounts_hash, initial_epoch_accounts_hash): {:?}",
-                   (
-                       reserialize_accounts_hash,
-                       incremental_snapshot_persistence,
-                       update_accounts_hash,
-                       initial_epoch_accounts_hash,
-                   )
+        assert_eq!(
+            dbank
+                .get_epoch_accounts_hash_to_serialize()
+                .map(|epoch_accounts_hash| *epoch_accounts_hash.as_ref()),
+            expected_epoch_accounts_hash,
+            "(reserialize_accounts_hash, incremental_snapshot_persistence, update_accounts_hash, \
+             initial_epoch_accounts_hash): {:?}",
+            (
+                reserialize_accounts_hash,
+                incremental_snapshot_persistence,
+                update_accounts_hash,
+                initial_epoch_accounts_hash,
+            )
         );
     }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4834,7 +4834,9 @@ fn test_banks_leak() {
     let pid = std::process::id();
     #[cfg(not(target_os = "linux"))]
     error!(
-        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= -p {})/$REPLY));done", pid
+        "\nYou can run this to watch RAM:\n   while read -p 'banks: '; do echo $(( $(ps -o vsize= \
+         -p {})/$REPLY));done",
+        pid
     );
     loop {
         num_banks += 1;
@@ -6890,9 +6892,9 @@ fn test_add_builtin_account_squatted_while_not_replacing() {
 
 #[test]
 #[should_panic(
-    expected = "Can't change frozen bank by adding not-existing new builtin \
-                program (mock_program, CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+    expected = "Can't change frozen bank by adding not-existing new builtin program \
+                (mock_program, CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). Maybe, inconsistent \
+                program activation is detected on snapshot restore?"
 )]
 fn test_add_builtin_account_after_frozen() {
     let slot = 123;
@@ -7042,9 +7044,9 @@ fn test_add_precompiled_account_squatted_while_not_replacing() {
 
 #[test]
 #[should_panic(
-    expected = "Can't change frozen bank by adding not-existing new precompiled \
-                program (CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). \
-                Maybe, inconsistent program activation is detected on snapshot restore?"
+    expected = "Can't change frozen bank by adding not-existing new precompiled program \
+                (CiXgo2KHKSDmDnV1F6B69eWFgNAPiSBjjYvfB4cvRNre). Maybe, inconsistent program \
+                activation is detected on snapshot restore?"
 )]
 fn test_add_precompiled_account_after_frozen() {
     let slot = 123;

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -196,7 +196,11 @@ impl SyncClient for BankClient {
         min_confirmed_blocks: usize,
     ) -> Result<usize> {
         // https://github.com/solana-labs/solana/issues/7199
-        assert_eq!(min_confirmed_blocks, 1, "BankClient cannot observe the passage of multiple blocks, so min_confirmed_blocks must be 1");
+        assert_eq!(
+            min_confirmed_blocks, 1,
+            "BankClient cannot observe the passage of multiple blocks, so min_confirmed_blocks \
+             must be 1"
+        );
         let now = Instant::now();
         let confirmed_blocks;
         loop {

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -344,7 +344,8 @@ impl BankForks {
             .collect();
         assert!(
             eah_banks.len() <= 1,
-            "At most one bank should request an epoch accounts hash calculation! num banks: {}, bank slots: {:?}",
+            "At most one bank should request an epoch accounts hash calculation! num banks: {}, \
+             bank slots: {:?}",
             eah_banks.len(),
             eah_banks.iter().map(|bank| bank.slot()).collect::<Vec<_>>(),
         );
@@ -414,7 +415,11 @@ impl BankForks {
                         );
                     }
                 } else {
-                    info!("Not sending snapshot request for bank: {}, startup verification is incomplete", bank_slot);
+                    info!(
+                        "Not sending snapshot request for bank: {}, startup verification is \
+                         incomplete",
+                        bank_slot
+                    );
                 }
             }
             snapshot_time.stop();

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -365,7 +365,8 @@ impl BankWithSchedulerInner {
     fn drop_scheduler(&self) {
         if std::thread::panicking() {
             error!(
-                "BankWithSchedulerInner::drop_scheduler(): slot: {} skipping due to already panicking...",
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} skipping due to already \
+                 panicking...",
                 self.bank.slot(),
             );
             return;
@@ -377,7 +378,8 @@ impl BankWithSchedulerInner {
             .map(|(result, _timings)| result)
         {
             warn!(
-                "BankWithSchedulerInner::drop_scheduler(): slot: {} discarding error from scheduler: {:?}",
+                "BankWithSchedulerInner::drop_scheduler(): slot: {} discarding error from \
+                 scheduler: {:?}",
                 self.bank.slot(),
                 err,
             );

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -332,7 +332,10 @@ impl PrioritizationFeeCache {
                 // It should be rare that optimistically confirmed bank had no prioritized
                 // transactions, but duplicated and unconfirmed bank had.
                 if pre_purge_bank_count > 0 && post_purge_bank_count == 0 {
-                    warn!("Finalized bank has empty prioritization fee cache. slot {slot} bank id {bank_id}");
+                    warn!(
+                        "Finalized bank has empty prioritization fee cache. slot {slot} bank id \
+                         {bank_id}"
+                    );
                 }
 
                 let mut block_prioritization_fee = slot_prioritization_fee

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -171,8 +171,14 @@ impl<T> SnapshotAccountsDbFields<T> {
                 // There must not be any overlap in the slots of storages between the full snapshot and the incremental snapshot
                 incremental_snapshot_storages
                     .iter()
-                    .all(|storage_entry| !full_snapshot_storages.contains_key(storage_entry.0)).then_some(()).ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Snapshots are incompatible: There are storages for the same slot in both the full snapshot and the incremental snapshot!")
+                    .all(|storage_entry| !full_snapshot_storages.contains_key(storage_entry.0))
+                    .then_some(())
+                    .ok_or_else(|| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "Snapshots are incompatible: There are storages for the same slot in \
+                             both the full snapshot and the incremental snapshot!",
+                        )
                     })?;
 
                 let mut combined_storages = full_snapshot_storages;
@@ -787,7 +793,8 @@ where
                 );
             assert!(
                 old_incremental_accounts_hash.is_none(),
-                "There should not already be an IncrementalAccountsHash at slot {slot}: {old_incremental_accounts_hash:?}",
+                "There should not already be an IncrementalAccountsHash at slot {slot}: \
+                 {old_incremental_accounts_hash:?}",
             );
         } else {
             // Otherwise, we've booted from a snapshot archive, or from local state that was *not*
@@ -820,17 +827,20 @@ where
                 let full_accounts_hash = &full_bank_hash_info.accounts_hash;
                 assert_eq!(
                     incremental_snapshot_persistence.full_slot, *full_slot,
-                    "The incremental snapshot's base slot ({}) must match the full snapshot's slot ({full_slot})!",
+                    "The incremental snapshot's base slot ({}) must match the full snapshot's \
+                     slot ({full_slot})!",
                     incremental_snapshot_persistence.full_slot,
                 );
                 assert_eq!(
                     &incremental_snapshot_persistence.full_hash, full_accounts_hash,
-                    "The incremental snapshot's base accounts hash ({}) must match the full snapshot's accounts hash ({})!",
+                    "The incremental snapshot's base accounts hash ({}) must match the full \
+                     snapshot's accounts hash ({})!",
                     &incremental_snapshot_persistence.full_hash.0, full_accounts_hash.0,
                 );
                 assert_eq!(
                     incremental_snapshot_persistence.full_capitalization, capitalizations.0,
-                    "The incremental snapshot's base capitalization ({}) must match the full snapshot's capitalization ({})!",
+                    "The incremental snapshot's base capitalization ({}) must match the full \
+                     snapshot's capitalization ({})!",
                     incremental_snapshot_persistence.full_capitalization, capitalizations.0,
                 );
                 let old_incremental_accounts_hash = accounts_db
@@ -841,7 +851,8 @@ where
                     );
                 assert!(
                     old_incremental_accounts_hash.is_none(),
-                    "There should not already be an IncrementalAccountsHash at slot {slot}: {old_incremental_accounts_hash:?}",
+                    "There should not already be an IncrementalAccountsHash at slot {slot}: \
+                     {old_incremental_accounts_hash:?}",
                 );
             } else {
                 // ..and without a BankIncrementalSnapshotPersistence then the Incremental Accounts
@@ -855,7 +866,8 @@ where
                 );
                 assert!(
                     old_accounts_hash.is_none(),
-                    "There should not already be an AccountsHash at slot {slot}: {old_accounts_hash:?}",
+                    "There should not already be an AccountsHash at slot {slot}: \
+                     {old_accounts_hash:?}",
                 );
             };
         }
@@ -900,8 +912,9 @@ where
     );
     assert!(
         old_accounts_delta_hash.is_none(),
-        "There should not already be an AccountsDeltaHash at slot {snapshot_slot}: {old_accounts_delta_hash:?}",
-        );
+        "There should not already be an AccountsDeltaHash at slot {snapshot_slot}: \
+         {old_accounts_delta_hash:?}",
+    );
     let old_stats = accounts_db
         .update_bank_hash_stats_from_snapshot(snapshot_slot, snapshot_bank_hash_info.stats);
     assert!(

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -93,7 +93,8 @@ impl<'a> SnapshotMinimizer<'a> {
         let added_accounts = total_accounts_len - initial_accounts_len;
 
         info!(
-            "Added {added_accounts} {name} for total of {total_accounts_len} accounts. get {measure}"
+            "Added {added_accounts} {name} for total of {total_accounts_len} accounts. get \
+             {measure}"
         );
     }
 

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -269,8 +269,11 @@ impl SnapshotPackage {
             SnapshotKind::IncrementalSnapshot(incremental_snapshot_base_slot) => {
                 snapshot_storages.retain(|storage| storage.slot() > incremental_snapshot_base_slot);
                 assert!(
-                    snapshot_storages.iter().all(|storage| storage.slot() > incremental_snapshot_base_slot),
-                    "Incremental snapshot package must only contain storage entries where slot > incremental snapshot base slot (i.e. full snapshot slot)!"
+                    snapshot_storages
+                        .iter()
+                        .all(|storage| storage.slot() > incremental_snapshot_base_slot),
+                    "Incremental snapshot package must only contain storage entries where slot > \
+                     incremental snapshot base slot (i.e. full snapshot slot)!"
                 );
                 snapshot_utils::build_incremental_snapshot_archive_path(
                     snapshot_info.incremental_snapshot_archives_dir,

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -322,7 +322,10 @@ pub enum SnapshotError {
     #[error("could not parse snapshot archive's file name: {0}")]
     ParseSnapshotArchiveFileNameError(String),
 
-    #[error("snapshots are incompatible: full snapshot slot ({0}) and incremental snapshot base slot ({1}) do not match")]
+    #[error(
+        "snapshots are incompatible: full snapshot slot ({0}) and incremental snapshot base slot \
+         ({1}) do not match"
+    )]
     MismatchedBaseSlot(Slot, Slot),
 
     #[error("no snapshot archives to load from")]
@@ -996,7 +999,8 @@ where
     let consumed_size = data_file_stream.stream_position()?;
     if consumed_size > maximum_file_size {
         let error_message = format!(
-            "too large snapshot data file to serialize: {data_file_path:?} has {consumed_size} bytes"
+            "too large snapshot data file to serialize: {data_file_path:?} has {consumed_size} \
+             bytes"
         );
         return Err(get_io_error(&error_message));
     }

--- a/runtime/src/status_cache.rs
+++ b/runtime/src/status_cache.rs
@@ -101,7 +101,8 @@ impl<T: Serialize + Clone> StatusCache<T> {
                             }
                         } else {
                             panic!(
-                                "Map for key must exist if key exists in self.slot_deltas, slot: {slot}"
+                                "Map for key must exist if key exists in self.slot_deltas, slot: \
+                                 {slot}"
                             )
                         }
                     }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 imports_granularity = "One"
 group_imports = "One"
+format_strings = true

--- a/sdk/cargo-build-sbf/src/main.rs
+++ b/sdk/cargo-build-sbf/src/main.rs
@@ -130,7 +130,11 @@ pub fn is_version_string(arg: &str) -> Result<(), String> {
     if semver_re.is_match(arg) {
         return Ok(());
     }
-    Err("a version string starts with 'v' and contains major and minor version numbers separated by a dot, e.g. v1.32".to_string())
+    Err(
+        "a version string starts with 'v' and contains major and minor version numbers separated \
+         by a dot, e.g. v1.32"
+            .to_string(),
+    )
 }
 
 fn find_installed_platform_tools() -> Vec<String> {
@@ -658,7 +662,8 @@ fn build_solana_package(
     // this by removing RUSTC from the child process environment.
     if env::var("RUSTC").is_ok() {
         warn!(
-            "Removed RUSTC from cargo environment, because it overrides +solana cargo command line option."
+            "Removed RUSTC from cargo environment, because it overrides +solana cargo command \
+             line option."
         );
         env::remove_var("RUSTC")
     }
@@ -799,12 +804,17 @@ fn build_solana_package(
             let dump_script = config.sbf_sdk.join("scripts").join("dump.sh");
             #[cfg(windows)]
             {
-                error!("Using Bash scripts from within a program is not supported on Windows, skipping `--dump`.");
                 error!(
-                    "Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this command to see the processed program dump.",
+                    "Using Bash scripts from within a program is not supported on Windows, \
+                     skipping `--dump`."
+                );
+                error!(
+                    "Please run \"{} {} {}\" from a Bash-supporting shell, then re-run this \
+                     command to see the processed program dump.",
                     &dump_script.display(),
                     &program_unstripped_so.display(),
-                    &program_dump.display());
+                    &program_dump.display()
+                );
             }
             #[cfg(not(windows))]
             {

--- a/sdk/gen-headers/src/main.rs
+++ b/sdk/gen-headers/src/main.rs
@@ -82,7 +82,11 @@ fn transform(inc: &PathBuf) {
         let ty = &caps[1].to_string();
         let func = &caps[2].to_string();
         let args = &caps[3].to_string();
-        let warn = format!("/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE {} AND RUN `cargo run --bin gen-headers` */", inc.display());
+        let warn = format!(
+            "/* DO NOT MODIFY THIS GENERATED FILE. INSTEAD CHANGE {} AND RUN `cargo run --bin \
+             gen-headers` */",
+            inc.display()
+        );
         let ifndef = format!("#ifndef SOL_SBFV2\n{ty} {func}({args});");
         let hash = sys_hash(func);
         let typedef_statement = format!("typedef {ty}(*{func}_pointer_type)({args});");
@@ -99,9 +103,8 @@ fn transform(inc: &PathBuf) {
             arg_list = format!("{arg_list} arg{arg}");
         }
         let function_signature = format!("static {ty} {func}({arg_list})");
-        let pointer_assignment = format!(
-            "{func}_pointer_type {func}_pointer = ({func}_pointer_type) {hash};"
-        );
+        let pointer_assignment =
+            format!("{func}_pointer_type {func}_pointer = ({func}_pointer_type) {hash};");
         if !args.is_empty() {
             arg_list = "arg1".to_string();
             for a in 2..arg + 1 {
@@ -114,7 +117,8 @@ fn transform(inc: &PathBuf) {
             format!("return {func}_pointer({arg_list});")
         };
         format!(
-            "{warn}\n{ifndef}\n#else\n{typedef_statement}\n{function_signature} {{\n  {pointer_assignment}\n  {return_statement}\n}}\n#endif",
+            "{warn}\n{ifndef}\n#else\n{typedef_statement}\n{function_signature} {{\n  \
+             {pointer_assignment}\n  {return_statement}\n}}\n#endif",
         )
     });
     write!(output_writer, "{output_content}").unwrap();

--- a/sdk/program/src/account_info.rs
+++ b/sdk/program/src/account_info.rs
@@ -454,16 +454,8 @@ mod tests {
         assert_eq!(
             format!("{info:?}"),
             format!(
-                "AccountInfo {{ \
-                key: {}, \
-                owner: {}, \
-                is_signer: {}, \
-                is_writable: {}, \
-                executable: {}, \
-                rent_epoch: {}, \
-                lamports: {}, \
-                data.len: {}, \
-                data: {}, .. }}",
+                "AccountInfo {{ key: {}, owner: {}, is_signer: {}, is_writable: {}, executable: \
+                 {}, rent_epoch: {}, lamports: {}, data.len: {}, data: {}, .. }}",
                 key,
                 key,
                 false,
@@ -482,16 +474,8 @@ mod tests {
         assert_eq!(
             format!("{info:?}"),
             format!(
-                "AccountInfo {{ \
-                key: {}, \
-                owner: {}, \
-                is_signer: {}, \
-                is_writable: {}, \
-                executable: {}, \
-                rent_epoch: {}, \
-                lamports: {}, \
-                data.len: {}, \
-                data: {}, .. }}",
+                "AccountInfo {{ key: {}, owner: {}, is_signer: {}, is_writable: {}, executable: \
+                 {}, rent_epoch: {}, lamports: {}, data.len: {}, data: {}, .. }}",
                 key,
                 key,
                 false,
@@ -509,15 +493,8 @@ mod tests {
         assert_eq!(
             format!("{info:?}"),
             format!(
-                "AccountInfo {{ \
-                key: {}, \
-                owner: {}, \
-                is_signer: {}, \
-                is_writable: {}, \
-                executable: {}, \
-                rent_epoch: {}, \
-                lamports: {}, \
-                data.len: {}, .. }}",
+                "AccountInfo {{ key: {}, owner: {}, is_signer: {}, is_writable: {}, executable: \
+                 {}, rent_epoch: {}, lamports: {}, data.len: {}, .. }}",
                 key,
                 key,
                 false,

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -505,7 +505,8 @@ impl Instruction {
 
     #[deprecated(
         since = "1.6.0",
-        note = "Please use another Instruction constructor instead, such as `Instruction::new_with_borsh`"
+        note = "Please use another Instruction constructor instead, such as \
+                `Instruction::new_with_borsh`"
     )]
     pub fn new<T: Serialize>(program_id: Pubkey, data: &T, accounts: Vec<AccountMeta>) -> Self {
         Self::new_with_bincode(program_id, data, accounts)

--- a/sdk/program/src/program_option.rs
+++ b/sdk/program/src/program_option.rs
@@ -63,8 +63,8 @@ impl<T> COption<T> {
     /// ```
     ///
     /// [`COption::None`]: #variant.COption::None
-    #[must_use = "if you intended to assert that this doesn't have a value, consider \
-                  `.and_then(|| panic!(\"`COption` had a value when expected `COption::None`\"))` instead"]
+    #[must_use = "if you intended to assert that this doesn't have a value, consider `.and_then(|| \
+                  panic!(\"`COption` had a value when expected `COption::None`\"))` instead"]
     #[inline]
     pub fn is_none(&self) -> bool {
         !self.is_some()

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -775,8 +775,7 @@ mod tests {
         assert!(Pubkey::create_with_seed(
             &Pubkey::new_unique(),
             "\
-             \u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\
-             ",
+             \u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}",
             &Pubkey::new_unique()
         )
         .is_ok());
@@ -785,8 +784,7 @@ mod tests {
             Pubkey::create_with_seed(
                 &Pubkey::new_unique(),
                 "\
-                 x\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\
-                 ",
+                 x\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}\u{10FFFF}",
                 &Pubkey::new_unique()
             ),
             Err(PubkeyError::MaxSeedLengthExceeded)

--- a/sdk/program/src/stake/config.rs
+++ b/sdk/program/src/stake/config.rs
@@ -3,7 +3,8 @@
 
 #[deprecated(
     since = "1.16.7",
-    note = "Please use `solana_sdk::stake::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
+    note = "Please use `solana_sdk::stake::state::{DEFAULT_SLASH_PENALTY, \
+            DEFAULT_WARMUP_COOLDOWN_RATE}` instead"
 )]
 pub use super::state::{DEFAULT_SLASH_PENALTY, DEFAULT_WARMUP_COOLDOWN_RATE};
 use serde_derive::{Deserialize, Serialize};

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -38,7 +38,10 @@ pub fn warmup_cooldown_rate(current_epoch: Epoch, new_rate_activation_epoch: Opt
 #[allow(clippy::large_enum_variant)]
 #[deprecated(
     since = "1.17.0",
-    note = "Please use `StakeStateV2` instead, and match the third `StakeFlags` field when matching `StakeStateV2::Stake` to resolve any breakage. For example, `if let StakeState::Stake(meta, stake)` becomes `if let StakeStateV2::Stake(meta, stake, _stake_flags)`."
+    note = "Please use `StakeStateV2` instead, and match the third `StakeFlags` field when \
+            matching `StakeStateV2::Stake` to resolve any breakage. For example, `if let \
+            StakeState::Stake(meta, stake)` becomes `if let StakeStateV2::Stake(meta, stake, \
+            _stake_flags)`."
 )]
 pub enum StakeState {
     #[default]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -149,7 +149,8 @@ fn serialize_instructions(instructions: &[BorrowedInstruction]) -> Vec<u8> {
 /// `data` is the instructions sysvar account data.
 #[deprecated(
     since = "1.8.0",
-    note = "Unsafe because the sysvar accounts address is not checked, please use `load_current_index_checked` instead"
+    note = "Unsafe because the sysvar accounts address is not checked, please use \
+            `load_current_index_checked` instead"
 )]
 pub fn load_current_index(data: &[u8]) -> u16 {
     let mut instr_fixed_data = [0u8; 2];
@@ -234,7 +235,8 @@ fn deserialize_instruction(index: usize, data: &[u8]) -> Result<Instruction, San
 /// `data` is the instructions sysvar account data.
 #[deprecated(
     since = "1.8.0",
-    note = "Unsafe because the sysvar accounts address is not checked, please use `load_instruction_at_checked` instead"
+    note = "Unsafe because the sysvar accounts address is not checked, please use \
+            `load_instruction_at_checked` instead"
 )]
 pub fn load_instruction_at(index: usize, data: &[u8]) -> Result<Instruction, SanitizeError> {
     deserialize_instruction(index, data)

--- a/sdk/program/src/vote/error.rs
+++ b/sdk/program/src/vote/error.rs
@@ -102,7 +102,8 @@ mod tests {
             }
         }
         assert_eq!(
-            "Custom(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes history",
+            "Custom(0): VoteError::VoteTooOld - vote already recorded or not in slot hashes \
+             history",
             pretty_err::<VoteError>(VoteError::VoteTooOld.into())
         )
     }

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -668,9 +668,11 @@ impl VoteState {
         for (i, v) in self.votes.iter_mut().enumerate() {
             // Don't increase the lockout for this vote until we get more confirmations
             // than the max number of confirmations this vote has seen
-            if stack_depth >
-                i.checked_add(v.confirmation_count() as usize)
-                    .expect("`confirmation_count` and tower_size should be bounded by `MAX_LOCKOUT_HISTORY`")
+            if stack_depth
+                > i.checked_add(v.confirmation_count() as usize).expect(
+                    "`confirmation_count` and tower_size should be bounded by \
+                     `MAX_LOCKOUT_HISTORY`",
+                )
             {
                 v.lockout.increase_confirmation_count(1);
             }

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -89,7 +89,8 @@ pub trait SyncClient {
     /// Get recent blockhash. Uses explicit commitment configuration.
     #[deprecated(
         since = "1.9.0",
-        note = "Please use `get_latest_blockhash_with_commitment` and `get_latest_blockhash_with_commitment` instead"
+        note = "Please use `get_latest_blockhash_with_commitment` and \
+                `get_latest_blockhash_with_commitment` instead"
     )]
     fn get_recent_blockhash_with_commitment(
         &self,

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -256,23 +256,10 @@ impl fmt::Display for GenesisConfig {
         write!(
             f,
             "\
-             Creation time: {}\n\
-             Cluster type: {:?}\n\
-             Genesis hash: {}\n\
-             Shred version: {}\n\
-             Ticks per slot: {:?}\n\
-             Hashes per tick: {:?}\n\
-             Target tick duration: {:?}\n\
-             Slots per epoch: {}\n\
-             Warmup epochs: {}abled\n\
-             Slots per year: {}\n\
-             {:?}\n\
-             {:?}\n\
-             {:?}\n\
-             Capitalization: {} SOL in {} accounts\n\
-             Native instruction processors: {:#?}\n\
-             Rewards pool: {:#?}\n\
-             ",
+             Creation time: {}\nCluster type: {:?}\nGenesis hash: {}\nShred version: {}\nTicks per \
+             slot: {:?}\nHashes per tick: {:?}\nTarget tick duration: {:?}\nSlots per epoch: \
+             {}\nWarmup epochs: {}abled\nSlots per year: {}\n{:?}\n{:?}\n{:?}\nCapitalization: {} \
+             SOL in {} accounts\nNative instruction processors: {:#?}\nRewards pool: {:#?}\n",
             Utc.timestamp_opt(self.creation_time, 0)
                 .unwrap()
                 .to_rfc3339(),

--- a/sdk/src/hash.rs
+++ b/sdk/src/hash.rs
@@ -8,7 +8,8 @@ pub use solana_program::hash::*;
 /// Random hash value for tests and benchmarks.
 #[deprecated(
     since = "1.17.0",
-    note = "Please use `Hash::new_unique()` for testing, or fill 32 bytes with any source of randomness"
+    note = "Please use `Hash::new_unique()` for testing, or fill 32 bytes with any source of \
+            randomness"
 )]
 #[cfg(feature = "full")]
 pub fn new_rand<R: ?Sized>(rng: &mut R) -> Hash

--- a/sdk/src/transaction/error.rs
+++ b/sdk/src/transaction/error.rs
@@ -163,7 +163,10 @@ pub enum TransactionError {
     ResanitizationNeeded,
 
     /// Program execution is temporarily restricted on an account.
-    #[error("Execution of the program referenced by account at index {account_index} is temporarily restricted.")]
+    #[error(
+        "Execution of the program referenced by account at index {account_index} is temporarily \
+         restricted."
+    )]
     ProgramExecutionTemporarilyRestricted { account_index: u8 },
 
     /// The total balance before the transaction does not equal the total balance after the transaction

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -1111,10 +1111,9 @@ impl LedgerStorage {
                     }
                     Some(Ok(fetched_tx_info)) => {
                         warn!(
-                            "skipped tx row {} because the bigtable entry ({:?}) did not match to {:?}",
-                            signature,
-                            fetched_tx_info,
-                            &expected_tx_info,
+                            "skipped tx row {} because the bigtable entry ({:?}) did not match to \
+                             {:?}",
+                            signature, fetched_tx_info, &expected_tx_info,
                         );
                     }
                     Some(Err(err)) => {
@@ -1165,12 +1164,13 @@ impl LedgerStorage {
         }
 
         info!(
-            "{}deleted ledger data for slot {}: {} transaction rows, {} address slot rows, {} entry row",
+            "{}deleted ledger data for slot {}: {} transaction rows, {} address slot rows, {} \
+             entry row",
             if dry_run { "[dry run] " } else { "" },
             slot,
             tx_deletion_rows.len(),
             address_slot_rows.len(),
-            if entries_exist { "with" } else {"WITHOUT"}
+            if entries_exist { "with" } else { "WITHOUT" }
         );
 
         Ok(())

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -327,7 +327,8 @@ fn handle_and_cache_new_connection(
         let remote_addr = connection.remote_address();
 
         debug!(
-            "Peer type: {:?}, stake {}, total stake {}, max streams {} receive_window {:?} from peer {}",
+            "Peer type: {:?}, stake {}, total stake {}, max streams {} receive_window {:?} from \
+             peer {}",
             connection_table_l.peer_type,
             params.stake,
             params.total_stake,

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -795,7 +795,8 @@ impl TestValidator {
                 match genesis_config.accounts.remove(deactivate_feature_pk) {
                     Some(_) => info!("Feature for {:?} deactivated", deactivate_feature_pk),
                     None => warn!(
-                        "Feature {:?} set for deactivation not found in genesis_config account list, ignored.",
+                        "Feature {:?} set for deactivation not found in genesis_config account \
+                         list, ignored.",
                         deactivate_feature_pk
                     ),
                 }

--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -44,8 +44,8 @@ where
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .subcommand(
@@ -58,9 +58,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -121,9 +121,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -192,9 +192,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(
@@ -290,9 +290,9 @@ where
                         .takes_value(true)
                         .value_name("FILE")
                         .help(
-                            "Location for storing distribution database. \
-                            The database is used for tracking transactions as they are finalized \
-                            and preventing double spends.",
+                            "Location for storing distribution database. The database is used for \
+                             tracking transactions as they are finalized and preventing double \
+                             spends.",
                         ),
                 )
                 .arg(

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -142,7 +142,8 @@ pub fn update_finalized_transaction(
     if opt_transaction_status.is_none() {
         if finalized_block_height > last_valid_block_height {
             eprintln!(
-                "Signature not found {signature} and blockhash expired. Transaction either dropped or the validator purged the transaction status."
+                "Signature not found {signature} and blockhash expired. Transaction either \
+                 dropped or the validator purged the transaction status."
             );
             eprintln!();
 

--- a/transaction-dos/src/main.rs
+++ b/transaction-dos/src/main.rs
@@ -69,14 +69,16 @@ pub fn airdrop_lamports(
                     }
                     if tries >= 5 {
                         panic!(
-                            "Error requesting airdrop: to addr: {faucet_addr:?} amount: {airdrop_amount} {result:?}"
+                            "Error requesting airdrop: to addr: {faucet_addr:?} amount: \
+                             {airdrop_amount} {result:?}"
                         )
                     }
                 }
             }
             Err(err) => {
                 panic!(
-                    "Error requesting airdrop: {err:?} to addr: {faucet_addr:?} amount: {airdrop_amount}"
+                    "Error requesting airdrop: {err:?} to addr: {faucet_addr:?} amount: \
+                     {airdrop_amount}"
                 );
             }
         };
@@ -471,14 +473,17 @@ fn main() {
                 .takes_value(true)
                 .multiple(true)
                 .value_name("FILE")
-                .help("One or more keypairs to create accounts owned by the program and which the program will write to."),
+                .help(
+                    "One or more keypairs to create accounts owned by the program and which the \
+                     program will write to.",
+                ),
         )
         .arg(
             Arg::with_name("account_groups")
-            .long("account_groups")
-            .takes_value(true)
-            .value_name("NUM")
-            .help("Number of groups of accounts to split the accounts into")
+                .long("account_groups")
+                .takes_value(true)
+                .value_name("NUM")
+                .help("Number of groups of accounts to split the accounts into"),
         )
         .arg(
             Arg::with_name("batch_size")
@@ -513,7 +518,10 @@ fn main() {
                 .long("batch-sleep-ms")
                 .takes_value(true)
                 .value_name("NUM")
-                .help("Sleep for this long the num outstanding transctions is greater than the batch size."),
+                .help(
+                    "Sleep for this long the num outstanding transctions is greater than the \
+                     batch size.",
+                ),
         )
         .arg(
             Arg::with_name("check_gossip")

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -1447,47 +1447,21 @@ mod test {
             assert_eq!(reserialized_value, expected_json_output_value);
         }
 
-        let json_input = "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6]\
-        }";
-        let expected_json_output = "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null\
-        }";
+        let json_input = "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,\
+                          2,3],\"postBalances\":[4,5,6]}";
+        let expected_json_output =
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}";
         test_serde::<UiTransactionStatusMeta>(json_input, expected_json_output);
 
-        let json_input = "{\
-            \"accountIndex\":5,\
-            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
-            \"uiTokenAmount\": {
-                \"amount\": \"1\",\
-                \"decimals\": 0,\
-                \"uiAmount\": 1.0,\
-                \"uiAmountString\": \"1\"\
-            }\
-        }";
-        let expected_json_output = "{\
-            \"accountIndex\":5,\
-            \"mint\":\"DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\
-            \"uiTokenAmount\": {
-                \"amount\": \"1\",\
-                \"decimals\": 0,\
-                \"uiAmount\": 1.0,\
-                \"uiAmountString\": \"1\"\
-            }\
-        }";
+        let json_input = "{\"accountIndex\":5,\"mint\":\"\
+                          DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"uiTokenAmount\": {
+                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
+        let expected_json_output = "{\"accountIndex\":5,\"mint\":\"\
+                                    DXM2yVSouSg1twmQgHLKoSReqXhtUroehWxrTgPmmfWi\",\"\
+                                    uiTokenAmount\": {
+                \"amount\": \"1\",\"decimals\": 0,\"uiAmount\": 1.0,\"uiAmountString\": \"1\"}}";
         test_serde::<UiTransactionTokenBalance>(json_input, expected_json_output);
     }
 
@@ -1511,22 +1485,10 @@ mod test {
             compute_units_consumed: None,
         };
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null,\
-            \"loadedAddresses\":{\
-                \"readonly\": [],\
-                \"writable\": []\
-            }\
-        }",
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null,\"\
+             loadedAddresses\":{\"readonly\": [],\"writable\": []}}",
         )
         .unwrap();
         let ui_meta_from: UiTransactionStatusMeta = meta.clone().into();
@@ -1536,18 +1498,9 @@ mod test {
         );
 
         let expected_json_output_value: serde_json::Value = serde_json::from_str(
-            "{\
-            \"err\":null,\
-            \"status\":{\"Ok\":null},\
-            \"fee\":1234,\
-            \"preBalances\":[1,2,3],\
-            \"postBalances\":[4,5,6],\
-            \"innerInstructions\":null,\
-            \"logMessages\":null,\
-            \"preTokenBalances\":null,\
-            \"postTokenBalances\":null,\
-            \"rewards\":null\
-        }",
+            "{\"err\":null,\"status\":{\"Ok\":null},\"fee\":1234,\"preBalances\":[1,2,3],\"\
+             postBalances\":[4,5,6],\"innerInstructions\":null,\"logMessages\":null,\"\
+             preTokenBalances\":null,\"postTokenBalances\":null,\"rewards\":null}",
         )
         .unwrap();
         let ui_meta_parse_with_rewards = UiTransactionStatusMeta::parse(meta.clone(), &[], true);

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -335,7 +335,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                 {
                     if cluster_partition.contains(node.pubkey()) {
                         info!(
-                            "Not broadcasting original shred index {}, slot {} to partition node {}",
+                            "Not broadcasting original shred index {}, slot {} to partition node \
+                             {}",
                             shred.index(),
                             shred.slot(),
                             node.pubkey(),
@@ -357,7 +358,8 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                             .iter()
                             .filter_map(|pubkey| {
                                 info!(
-                                    "Broadcasting partition shred index {}, slot {} to partition node {}",
+                                    "Broadcasting partition shred index {}, slot {} to partition \
+                                     node {}",
                                     shred.index(),
                                     shred.slot(),
                                     pubkey,

--- a/upload-perf/src/upload-perf.rs
+++ b/upload-perf/src/upload-perf.rs
@@ -89,7 +89,8 @@ fn main() {
 
     if let Some(commit) = last_commit {
         println!(
-            "Comparing current commits: {trimmed_hash} against baseline {commit} on {branch} branch"
+            "Comparing current commits: {trimmed_hash} against baseline {commit} on {branch} \
+             branch"
         );
         println!("bench_name, median, last_median, deviation, last_deviation");
         for (entry, values) in results {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -582,10 +582,9 @@ impl AdminRpc for AdminRpcImpl {
                 .tpu(Protocol::UDP)
                 .map_err(|err| {
                     error!(
-                        "The public TPU address isn't being published. \
-                        The node is likely in repair mode. \
-                        See help for --restricted-repair-only-mode for more information. \
-                        {err}"
+                        "The public TPU address isn't being published. The node is likely in \
+                         repair mode. See help for --restricted-repair-only-mode for more \
+                         information. {err}"
                     );
                     jsonrpc_core::error::Error::internal_error()
                 })?;
@@ -620,10 +619,9 @@ impl AdminRpc for AdminRpcImpl {
                 .tpu_forwards(Protocol::UDP)
                 .map_err(|err| {
                     error!(
-                        "The public TPU Forwards address isn't being published. \
-                        The node is likely in repair mode. \
-                        See help for --restricted-repair-only-mode for more information. \
-                        {err}"
+                        "The public TPU Forwards address isn't being published. The node is \
+                         likely in repair mode. See help for --restricted-repair-only-mode for \
+                         more information. {err}"
                     );
                     jsonrpc_core::error::Error::internal_error()
                 })?;

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -285,17 +285,20 @@ fn main() {
     let warp_slot = if matches.is_present("warp_slot") {
         Some(match matches.value_of("warp_slot") {
             Some(_) => value_t_or_exit!(matches, "warp_slot", Slot),
-            None => {
-                cluster_rpc_client.as_ref().unwrap_or_else(|_| {
-                        println!("The --url argument must be provided if --warp-slot/-w is used without an explicit slot");
-                        exit(1);
-
-                }).get_slot()
-                    .unwrap_or_else(|err| {
-                        println!("Unable to get current cluster slot: {err}");
-                        exit(1);
-                    })
-            }
+            None => cluster_rpc_client
+                .as_ref()
+                .unwrap_or_else(|_| {
+                    println!(
+                        "The --url argument must be provided if --warp-slot/-w is used without an \
+                         explicit slot"
+                    );
+                    exit(1);
+                })
+                .get_slot()
+                .unwrap_or_else(|err| {
+                    println!("Unable to get current cluster slot: {err}");
+                    exit(1);
+                }),
         })
     } else {
         None

--- a/validator/src/bootstrap.rs
+++ b/validator/src/bootstrap.rs
@@ -237,7 +237,10 @@ fn get_rpc_peers(
         })
         .count();
 
-    info!("Total {rpc_peers_total} RPC nodes found. {rpc_known_peers} known, {rpc_peers_blacklisted} blacklisted");
+    info!(
+        "Total {rpc_peers_total} RPC nodes found. {rpc_known_peers} known, \
+         {rpc_peers_blacklisted} blacklisted"
+    );
 
     if rpc_peers_blacklisted == rpc_peers_total {
         *retry_reason = if !blacklisted_rpc_nodes.is_empty()
@@ -487,9 +490,9 @@ fn get_vetted_rpc_nodes(
             Ok(rpc_node_details) => rpc_node_details,
             Err(err) => {
                 error!(
-                    "Failed to get RPC nodes: {err}. Consider checking system \
-                    clock, removing `--no-port-check`, or adjusting \
-                    `--known-validator ...` arguments as applicable"
+                    "Failed to get RPC nodes: {err}. Consider checking system clock, removing \
+                     `--no-port-check`, or adjusting `--known-validator ...` arguments as \
+                     applicable"
                 );
                 exit(1);
             }
@@ -905,9 +908,8 @@ fn get_snapshot_hashes_from_known_validators(
         get_snapshot_hashes_for_node,
     ) {
         debug!(
-            "Snapshot hashes have not been discovered from known validators. \
-            This likely means the gossip tables are not fully populated. \
-            We will sleep and retry..."
+            "Snapshot hashes have not been discovered from known validators. This likely means \
+             the gossip tables are not fully populated. We will sleep and retry..."
         );
         return KnownSnapshotHashes::default();
     }
@@ -981,8 +983,8 @@ fn build_known_snapshot_hashes<'a>(
         // hashes.  So if it happens, keep the first and ignore the rest.
         if is_any_same_slot_and_different_hash(&full_snapshot_hash, known_snapshot_hashes.keys()) {
             warn!(
-                "Ignoring all snapshot hashes from node {node} since we've seen a different full snapshot hash with this slot.\
-                \nfull snapshot hash: {full_snapshot_hash:?}"
+                "Ignoring all snapshot hashes from node {node} since we've seen a different full \
+                 snapshot hash with this slot.\nfull snapshot hash: {full_snapshot_hash:?}"
             );
             debug!(
                 "known full snapshot hashes: {:#?}",
@@ -1007,9 +1009,10 @@ fn build_known_snapshot_hashes<'a>(
                 known_incremental_snapshot_hashes.iter(),
             ) {
                 warn!(
-                    "Ignoring incremental snapshot hash from node {node} since we've seen a different incremental snapshot hash with this slot.\
-                    \nfull snapshot hash: {full_snapshot_hash:?}\
-                    \nincremental snapshot hash: {incremental_snapshot_hash:?}"
+                    "Ignoring incremental snapshot hash from node {node} since we've seen a \
+                     different incremental snapshot hash with this slot.\nfull snapshot hash: \
+                     {full_snapshot_hash:?}\nincremental snapshot hash: \
+                     {incremental_snapshot_hash:?}"
                 );
                 debug!(
                     "known incremental snapshot hashes based on this slot: {:#?}",
@@ -1112,7 +1115,10 @@ fn retain_peer_snapshot_hashes_with_highest_incremental_snapshot_slot(
         peer_snapshot_hash.snapshot_hash.incr == highest_incremental_snapshot_hash
     });
 
-    trace!("retain peer snapshot hashes with highest incremental snapshot slot: {peer_snapshot_hashes:?}");
+    trace!(
+        "retain peer snapshot hashes with highest incremental snapshot slot: \
+         {peer_snapshot_hashes:?}"
+    );
 }
 
 /// Check to see if we can use our local snapshots, otherwise download newer ones.
@@ -1192,7 +1198,8 @@ fn download_snapshots(
                 })
             {
                 info!(
-                    "Incremental snapshot archive already exists locally. Skipping download. slot: {}, hash: {}",
+                    "Incremental snapshot archive already exists locally. Skipping download. \
+                     slot: {}, hash: {}",
                     incremental_snapshot_hash.0, incremental_snapshot_hash.1
                 );
             } else {
@@ -1272,9 +1279,9 @@ fn download_snapshot(
                     {
                         warn!(
                             "The snapshot download is too slow, throughput: {} < min speed {} \
-                            bytes/sec, but will NOT abort and try a different node as it is the \
-                            only known validator and the --only-known-rpc flag is set. \
-                            Abort count: {}, Progress detail: {:?}",
+                             bytes/sec, but will NOT abort and try a different node as it is the \
+                             only known validator and the --only-known-rpc flag is set. Abort \
+                             count: {}, Progress detail: {:?}",
                             download_progress.last_throughput,
                             minimal_snapshot_download_speed,
                             download_abort_count,
@@ -1284,9 +1291,8 @@ fn download_snapshot(
                     }
                 }
                 warn!(
-                    "The snapshot download is too slow, throughput: {} < min speed {} \
-                    bytes/sec, will abort and try a different node. \
-                    Abort count: {}, Progress detail: {:?}",
+                    "The snapshot download is too slow, throughput: {} < min speed {} bytes/sec, \
+                     will abort and try a different node. Abort count: {}, Progress detail: {:?}",
                     download_progress.last_throughput,
                     minimal_snapshot_download_speed,
                     download_abort_count,
@@ -1321,17 +1327,26 @@ fn should_use_local_snapshot(
         incremental_snapshot_fetch,
     ) {
         None => {
-            info!("Downloading a snapshot for slot {cluster_snapshot_slot} since there is not a local snapshot.");
+            info!(
+                "Downloading a snapshot for slot {cluster_snapshot_slot} since there is not a \
+                 local snapshot."
+            );
             false
         }
         Some((local_snapshot_slot, _)) => {
             if local_snapshot_slot
                 >= cluster_snapshot_slot.saturating_sub(maximum_local_snapshot_age)
             {
-                info!("Reusing local snapshot at slot {local_snapshot_slot} instead of downloading a snapshot for slot {cluster_snapshot_slot}.");
+                info!(
+                    "Reusing local snapshot at slot {local_snapshot_slot} instead of downloading \
+                     a snapshot for slot {cluster_snapshot_slot}."
+                );
                 true
             } else {
-                info!("Local snapshot from slot {local_snapshot_slot} is too old. Downloading a newer snapshot for slot {cluster_snapshot_slot}.");
+                info!(
+                    "Local snapshot from slot {local_snapshot_slot} is too old. Downloading a \
+                     newer snapshot for slot {cluster_snapshot_slot}."
+                );
                 false
             }
         }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -61,7 +61,8 @@ const MAX_SNAPSHOT_DOWNLOAD_ABORT: u32 = 5;
 const MINIMUM_TICKS_PER_SLOT: u64 = 2;
 
 pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
-    return App::new(crate_name!()).about(crate_description!())
+    return App::new(crate_name!())
+        .about(crate_description!())
         .version(version)
         .setting(AppSettings::VersionlessSubcommands)
         .setting(AppSettings::InferSubcommands)
@@ -87,9 +88,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .validator(is_keypair_or_ask_keyword)
                 .requires("vote_account")
                 .multiple(true)
-                .help("Include an additional authorized voter keypair. \
-                       May be specified multiple times. \
-                       [default: the --identity keypair]"),
+                .help(
+                    "Include an additional authorized voter keypair. May be specified multiple \
+                     times. [default: the --identity keypair]",
+                ),
         )
         .arg(
             Arg::with_name("vote_account")
@@ -98,18 +100,21 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_pubkey_or_keypair)
                 .requires("identity")
-                .help("Validator vote account public key.  \
-                       If unspecified voting will be disabled. \
-                       The authorized voter for the account must either be the \
-                       --identity keypair or with the --authorized-voter argument")
+                .help(
+                    "Validator vote account public key.  If unspecified voting will be disabled. \
+                     The authorized voter for the account must either be the --identity keypair \
+                     or with the --authorized-voter argument",
+                ),
         )
         .arg(
             Arg::with_name("init_complete_file")
                 .long("init-complete-file")
                 .value_name("FILE")
                 .takes_value(true)
-                .help("Create this file if it doesn't already exist \
-                       once validator initialization is complete"),
+                .help(
+                    "Create this file if it doesn't already exist once validator initialization \
+                     is complete",
+                ),
         )
         .arg(
             Arg::with_name("ledger_path")
@@ -135,8 +140,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("no_snapshot_fetch")
                 .long("no-snapshot-fetch")
                 .takes_value(false)
-                .help("Do not attempt to fetch a snapshot from the cluster, \
-                      start from a local snapshot if present"),
+                .help(
+                    "Do not attempt to fetch a snapshot from the cluster, start from a local \
+                     snapshot if present",
+                ),
         )
         .arg(
             Arg::with_name("no_genesis_fetch")
@@ -157,18 +164,21 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("RPC_URL")
                 .requires("entrypoint")
                 .conflicts_with_all(&["no_check_vote_account", "no_voting"])
-                .help("Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL must expose `--full-rpc-api`")
+                .help(
+                    "Sanity check vote account state at startup. The JSON RPC endpoint at RPC_URL \
+                     must expose `--full-rpc-api`",
+                ),
         )
         .arg(
             Arg::with_name("restricted_repair_only_mode")
                 .long("restricted-repair-only-mode")
                 .takes_value(false)
-                .help("Do not publish the Gossip, TPU, TVU or Repair Service ports causing \
-                       the validator to operate in a limited capacity that reduces its \
-                       exposure to the rest of the cluster. \
-                       \
-                       The --no-voting flag is implicit when this flag is enabled \
-                      "),
+                .help(
+                    "Do not publish the Gossip, TPU, TVU or Repair Service ports causing the \
+                     validator to operate in a limited capacity that reduces its exposure to the \
+                     rest of the cluster. The --no-voting flag is implicit when this flag is \
+                     enabled ",
+                ),
         )
         .arg(
             Arg::with_name("dev_halt_at_slot")
@@ -203,30 +213,33 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("private_rpc")
                 .long("private-rpc")
                 .takes_value(false)
-                .help("Do not publish the RPC port for use by others")
+                .help("Do not publish the RPC port for use by others"),
         )
         .arg(
             Arg::with_name("no_port_check")
                 .long("no-port-check")
                 .takes_value(false)
                 .hidden(hidden_unless_forced())
-                .help("Do not perform TCP/UDP reachable port checks at start-up")
+                .help("Do not perform TCP/UDP reachable port checks at start-up"),
         )
         .arg(
             Arg::with_name("enable_rpc_transaction_history")
                 .long("enable-rpc-transaction-history")
                 .takes_value(false)
-                .help("Enable historical transaction info over JSON RPC, \
-                       including the 'getConfirmedBlock' API.  \
-                       This will cause an increase in disk usage and IOPS"),
+                .help(
+                    "Enable historical transaction info over JSON RPC, including the \
+                     'getConfirmedBlock' API.  This will cause an increase in disk usage and IOPS",
+                ),
         )
         .arg(
             Arg::with_name("enable_rpc_bigtable_ledger_storage")
                 .long("enable-rpc-bigtable-ledger-storage")
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
-                .help("Fetch historical transaction info from a BigTable instance \
-                       as a fallback to local ledger data"),
+                .help(
+                    "Fetch historical transaction info from a BigTable instance as a fallback to \
+                     local ledger data",
+                ),
         )
         .arg(
             Arg::with_name("enable_bigtable_ledger_upload")
@@ -240,8 +253,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("enable-extended-tx-metadata-storage")
                 .requires("enable_rpc_transaction_history")
                 .takes_value(false)
-                .help("Include CPI inner instructions, logs, and return data in \
-                       the historical transaction info stored"),
+                .help(
+                    "Include CPI inner instructions, logs, and return data in the historical \
+                     transaction info stored",
+                ),
         )
         .arg(
             Arg::with_name("rpc_max_multiple_accounts")
@@ -249,8 +264,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MAX ACCOUNTS")
                 .takes_value(true)
                 .default_value(&default_args.rpc_max_multiple_accounts)
-                .help("Override the default maximum accounts accepted by \
-                       the getMultipleAccounts JSON RPC method")
+                .help(
+                    "Override the default maximum accounts accepted by the getMultipleAccounts \
+                     JSON RPC method",
+                ),
         )
         .arg(
             Arg::with_name("health_check_slot_distance")
@@ -258,9 +275,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("SLOT_DISTANCE")
                 .takes_value(true)
                 .default_value(&default_args.health_check_slot_distance)
-                .help("Report this validator healthy if its latest optimistically confirmed slot \
-                       that has been replayed is no further behind than this number of slots from \
-                       the cluster latest optimistically confirmed slot")
+                .help(
+                    "Report this validator healthy if its latest optimistically confirmed slot \
+                     that has been replayed is no further behind than this number of slots from \
+                     the cluster latest optimistically confirmed slot",
+                ),
         )
         .arg(
             Arg::with_name("rpc_faucet_addr")
@@ -291,7 +310,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("accounts-hash-cache-path")
                 .value_name("PATH")
                 .takes_value(true)
-                .help("Use PATH as accounts hash cache location [default: <LEDGER>/accounts_hash_cache]"),
+                .help(
+                    "Use PATH as accounts hash cache location [default: \
+                     <LEDGER>/accounts_hash_cache]",
+                ),
         )
         .arg(
             Arg::with_name("snapshots")
@@ -307,7 +329,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .possible_values(use_snapshot_archives_at_startup::cli::POSSIBLE_VALUES)
                 .default_value(use_snapshot_archives_at_startup::cli::default_value())
                 .help(use_snapshot_archives_at_startup::cli::HELP)
-                .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP)
+                .long_help(use_snapshot_archives_at_startup::cli::LONG_HELP),
         )
         .arg(
             Arg::with_name("incremental_snapshot_archive_path")
@@ -315,7 +337,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .conflicts_with("no-incremental-snapshots")
                 .value_name("DIR")
                 .takes_value(true)
-                .help("Use DIR as separate location for incremental snapshot archives [default: --snapshots value]"),
+                .help(
+                    "Use DIR as separate location for incremental snapshot archives [default: \
+                     --snapshots value]",
+                ),
         )
         .arg(
             Arg::with_name("tower")
@@ -340,7 +365,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .multiple(true)
                 .validator(solana_net_utils::is_host_port)
-                .help("etcd gRPC endpoint to connect with")
+                .help("etcd gRPC endpoint to connect with"),
         )
         .arg(
             Arg::with_name("etcd_domain_name")
@@ -349,7 +374,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("DOMAIN")
                 .default_value(&default_args.etcd_domain_name)
                 .takes_value(true)
-                .help("domain name against which to verify the etcd server’s TLS certificate")
+                .help("domain name against which to verify the etcd server’s TLS certificate"),
         )
         .arg(
             Arg::with_name("etcd_cacert_file")
@@ -357,7 +382,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .required_if("tower_storage", "etcd")
                 .value_name("FILE")
                 .takes_value(true)
-                .help("verify the TLS certificate of the etcd endpoint using this CA bundle")
+                .help("verify the TLS certificate of the etcd endpoint using this CA bundle"),
         )
         .arg(
             Arg::with_name("etcd_key_file")
@@ -365,7 +390,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .required_if("tower_storage", "etcd")
                 .value_name("FILE")
                 .takes_value(true)
-                .help("TLS key file to use when establishing a connection to the etcd endpoint")
+                .help("TLS key file to use when establishing a connection to the etcd endpoint"),
         )
         .arg(
             Arg::with_name("etcd_cert_file")
@@ -373,7 +398,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .required_if("tower_storage", "etcd")
                 .value_name("FILE")
                 .takes_value(true)
-                .help("TLS certificate to use when establishing a connection to the etcd endpoint")
+                .help("TLS certificate to use when establishing a connection to the etcd endpoint"),
         )
         .arg(
             Arg::with_name("gossip_port")
@@ -388,8 +413,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .help("Gossip DNS name or IP address for the validator to advertise in gossip \
-                       [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]"),
+                .help(
+                    "Gossip DNS name or IP address for the validator to advertise in gossip \
+                     [default: ask --entrypoint, or 127.0.0.1 when --entrypoint is not provided]",
+                ),
         )
         .arg(
             Arg::with_name("public_tpu_addr")
@@ -398,8 +425,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host_port)
-                .help("Specify TPU address to advertise in gossip [default: ask --entrypoint or localhost\
-                    when --entrypoint is not provided]"),
+                .help(
+                    "Specify TPU address to advertise in gossip [default: ask --entrypoint or \
+                     localhostwhen --entrypoint is not provided]",
+                ),
         )
         .arg(
             Arg::with_name("public_tpu_forwards_addr")
@@ -407,8 +436,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("HOST:PORT")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host_port)
-                .help("Specify TPU Forwards address to advertise in gossip [default: ask --entrypoint or localhost\
-                    when --entrypoint is not provided]"),
+                .help(
+                    "Specify TPU Forwards address to advertise in gossip [default: ask \
+                     --entrypoint or localhostwhen --entrypoint is not provided]",
+                ),
         )
         .arg(
             Arg::with_name("public_rpc_addr")
@@ -417,9 +448,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .conflicts_with("private_rpc")
                 .validator(solana_net_utils::is_host_port)
-                .help("RPC address for the validator to advertise publicly in gossip. \
-                      Useful for validators running behind a load balancer or proxy \
-                      [default: use --rpc-bind-address / --rpc-port]"),
+                .help(
+                    "RPC address for the validator to advertise publicly in gossip. Useful for \
+                     validators running behind a load balancer or proxy [default: use \
+                     --rpc-bind-address / --rpc-port]",
+                ),
         )
         .arg(
             Arg::with_name("dynamic_port_range")
@@ -436,19 +469,21 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER_OF_SLOTS")
                 .takes_value(true)
                 .default_value(&default_args.maximum_local_snapshot_age)
-                .help("Reuse a local snapshot if it's less than this many \
-                       slots behind the highest snapshot available for \
-                       download from other validators"),
+                .help(
+                    "Reuse a local snapshot if it's less than this many slots behind the highest \
+                     snapshot available for download from other validators",
+                ),
         )
         .arg(
             Arg::with_name("no_incremental_snapshots")
                 .long("no-incremental-snapshots")
                 .takes_value(false)
                 .help("Disable incremental snapshots")
-                .long_help("Disable incremental snapshots by setting this flag. \
-                   When enabled, --snapshot-interval-slots will set the \
-                   incremental snapshot interval. To set the full snapshot \
-                   interval, use --full-snapshot-interval-slots.")
+                .long_help(
+                    "Disable incremental snapshots by setting this flag. When enabled, \
+                     --snapshot-interval-slots will set the incremental snapshot interval. To set \
+                     the full snapshot interval, use --full-snapshot-interval-slots.",
+                ),
         )
         .arg(
             Arg::with_name("incremental_snapshot_interval_slots")
@@ -457,8 +492,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.incremental_snapshot_archive_interval_slots)
-                .help("Number of slots between generating snapshots, \
-                      0 to disable snapshots"),
+                .help("Number of slots between generating snapshots, 0 to disable snapshots"),
         )
         .arg(
             Arg::with_name("full_snapshot_interval_slots")
@@ -466,8 +500,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.full_snapshot_archive_interval_slots)
-                .help("Number of slots between generating full snapshots. \
-                    Must be a multiple of the incremental snapshot interval.")
+                .help(
+                    "Number of slots between generating full snapshots. Must be a multiple of the \
+                     incremental snapshot interval.",
+                ),
         )
         .arg(
             Arg::with_name("maximum_full_snapshots_to_retain")
@@ -477,7 +513,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .default_value(&default_args.maximum_full_snapshot_archives_to_retain)
                 .validator(validate_maximum_full_snapshot_archives_to_retain)
-                .help("The maximum number of full snapshot archives to hold on to when purging older snapshots.")
+                .help(
+                    "The maximum number of full snapshot archives to hold on to when purging \
+                     older snapshots.",
+                ),
         )
         .arg(
             Arg::with_name("maximum_incremental_snapshots_to_retain")
@@ -486,7 +525,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .default_value(&default_args.maximum_incremental_snapshot_archives_to_retain)
                 .validator(validate_maximum_incremental_snapshot_archives_to_retain)
-                .help("The maximum number of incremental snapshot archives to hold on to when purging older snapshots.")
+                .help(
+                    "The maximum number of incremental snapshot archives to hold on to when \
+                     purging older snapshots.",
+                ),
         )
         .arg(
             Arg::with_name("snapshot_packager_niceness_adj")
@@ -495,8 +537,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(solana_perf::thread::is_niceness_adjustment_valid)
                 .default_value(&default_args.snapshot_packager_niceness_adjustment)
-                .help("Add this value to niceness of snapshot packager thread. Negative value \
-                      increases priority, positive value decreases priority.")
+                .help(
+                    "Add this value to niceness of snapshot packager thread. Negative value \
+                     increases priority, positive value decreases priority.",
+                ),
         )
         .arg(
             Arg::with_name("minimal_snapshot_download_speed")
@@ -504,9 +548,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MINIMAL_SNAPSHOT_DOWNLOAD_SPEED")
                 .takes_value(true)
                 .default_value(&default_args.min_snapshot_download_speed)
-                .help("The minimal speed of snapshot downloads measured in bytes/second. \
-                      If the initial download speed falls below this threshold, the system will \
-                      retry the download against a different rpc node."),
+                .help(
+                    "The minimal speed of snapshot downloads measured in bytes/second. If the \
+                     initial download speed falls below this threshold, the system will retry the \
+                     download against a different rpc node.",
+                ),
         )
         .arg(
             Arg::with_name("maximum_snapshot_download_abort")
@@ -514,8 +560,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MAXIMUM_SNAPSHOT_DOWNLOAD_ABORT")
                 .takes_value(true)
                 .default_value(&default_args.max_snapshot_download_abort)
-                .help("The maximum number of times to abort and retry when encountering a \
-                      slow snapshot download."),
+                .help(
+                    "The maximum number of times to abort and retry when encountering a slow \
+                     snapshot download.",
+                ),
         )
         .arg(
             Arg::with_name("contact_debug_interval")
@@ -535,31 +583,31 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("no_os_network_limits_test")
                 .hidden(hidden_unless_forced())
                 .long("no-os-network-limits-test")
-                .help("Skip checks for OS network limits.")
+                .help("Skip checks for OS network limits."),
         )
         .arg(
             Arg::with_name("no_os_memory_stats_reporting")
                 .long("no-os-memory-stats-reporting")
                 .hidden(hidden_unless_forced())
-                .help("Disable reporting of OS memory statistics.")
+                .help("Disable reporting of OS memory statistics."),
         )
         .arg(
             Arg::with_name("no_os_network_stats_reporting")
                 .long("no-os-network-stats-reporting")
                 .hidden(hidden_unless_forced())
-                .help("Disable reporting of OS network statistics.")
+                .help("Disable reporting of OS network statistics."),
         )
         .arg(
             Arg::with_name("no_os_cpu_stats_reporting")
                 .long("no-os-cpu-stats-reporting")
                 .hidden(hidden_unless_forced())
-                .help("Disable reporting of OS CPU statistics.")
+                .help("Disable reporting of OS CPU statistics."),
         )
         .arg(
             Arg::with_name("no_os_disk_stats_reporting")
                 .long("no-os-disk-stats-reporting")
                 .hidden(hidden_unless_forced())
-                .help("Disable reporting of OS disk statistics.")
+                .help("Disable reporting of OS disk statistics."),
         )
         .arg(
             Arg::with_name("snapshot_version")
@@ -587,12 +635,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .possible_values(&["level", "fifo"])
                 .default_value(&default_args.rocksdb_shred_compaction)
-                .help("Controls how RocksDB compacts shreds. \
-                       *WARNING*: You will lose your ledger data when you switch between options. \
-                       Possible values are: \
-                       'level': stores shreds using RocksDB's default (level) compaction. \
-                       'fifo': stores shreds under RocksDB's FIFO compaction. \
-                           This option is more efficient on disk-write-bytes of the ledger store."),
+                .help(
+                    "Controls how RocksDB compacts shreds. *WARNING*: You will lose your ledger \
+                     data when you switch between options. Possible values are: 'level': stores \
+                     shreds using RocksDB's default (level) compaction. 'fifo': stores shreds \
+                     under RocksDB's FIFO compaction. This option is more efficient on \
+                     disk-write-bytes of the ledger store.",
+                ),
         )
         .arg(
             Arg::with_name("rocksdb_fifo_shred_storage_size")
@@ -600,13 +649,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("SHRED_STORAGE_SIZE_BYTES")
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
-                .help("The shred storage size in bytes. \
-                       The suggested value is at least 50% of your ledger storage size. \
-                       If this argument is unspecified, we will assign a proper \
-                       value based on --limit-ledger-size.  If --limit-ledger-size \
-                       is not presented, it means there is no limitation on the ledger \
-                       size and thus rocksdb_fifo_shred_storage_size will also be \
-                       unbounded."),
+                .help(
+                    "The shred storage size in bytes. The suggested value is at least 50% of your \
+                     ledger storage size. If this argument is unspecified, we will assign a \
+                     proper value based on --limit-ledger-size.  If --limit-ledger-size is not \
+                     presented, it means there is no limitation on the ledger size and thus \
+                     rocksdb_fifo_shred_storage_size will also be unbounded.",
+                ),
         )
         .arg(
             Arg::with_name("rocksdb_ledger_compression")
@@ -616,9 +665,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .possible_values(&["none", "lz4", "snappy", "zlib"])
                 .default_value(&default_args.rocksdb_ledger_compression)
-                .help("The compression algorithm that is used to compress \
-                       transaction status data.  \
-                       Turning on compression can save ~10% of the ledger size."),
+                .help(
+                    "The compression algorithm that is used to compress transaction status data.  \
+                     Turning on compression can save ~10% of the ledger size.",
+                ),
         )
         .arg(
             Arg::with_name("rocksdb_perf_sample_interval")
@@ -628,8 +678,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .default_value(&default_args.rocksdb_perf_sample_interval)
-                .help("Controls how often RocksDB read/write performance sample is collected. \
-                       Reads/writes perf samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL sampling rate."),
+                .help(
+                    "Controls how often RocksDB read/write performance sample is collected. \
+                     Reads/writes perf samples are collected in 1 / ROCKS_PERF_SAMPLE_INTERVAL \
+                     sampling rate.",
+                ),
         )
         .arg(
             Arg::with_name("skip_startup_ledger_verification")
@@ -679,9 +732,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("log")
                 .value_name("FILE")
                 .takes_value(true)
-                .help("Redirect logging to the specified file, '-' for standard error. \
-                       Sending the SIGUSR1 signal to the validator process will cause it \
-                       to re-open the log file"),
+                .help(
+                    "Redirect logging to the specified file, '-' for standard error. Sending the \
+                     SIGUSR1 signal to the validator process will cause it to re-open the log file",
+                ),
         )
         .arg(
             Arg::with_name("wait_for_supermajority")
@@ -689,16 +743,20 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .requires("expected_bank_hash")
                 .value_name("SLOT")
                 .validator(is_slot)
-                .help("After processing the ledger and the next slot is SLOT, wait until a \
-                       supermajority of stake is visible on gossip before starting PoH"),
+                .help(
+                    "After processing the ledger and the next slot is SLOT, wait until a \
+                     supermajority of stake is visible on gossip before starting PoH",
+                ),
         )
         .arg(
             Arg::with_name("no_wait_for_vote_to_start_leader")
                 .hidden(hidden_unless_forced())
                 .long("no-wait-for-vote-to-start-leader")
-                .help("If the validator starts up with no ledger, it will wait to start block
+                .help(
+                    "If the validator starts up with no ledger, it will wait to start block
                       production until it sees a vote land in a rooted slot. This prevents
-                      double signing. Turn off to risk double signing a block."),
+                      double signing. Turn off to risk double signing a block.",
+                ),
         )
         .arg(
             Arg::with_name("hard_forks")
@@ -717,8 +775,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("VALIDATOR IDENTITY")
                 .multiple(true)
                 .takes_value(true)
-                .help("A snapshot hash must be published in gossip by this validator to be accepted. \
-                       May be specified multiple times. If unspecified any snapshot hash will be accepted"),
+                .help(
+                    "A snapshot hash must be published in gossip by this validator to be \
+                     accepted. May be specified multiple times. If unspecified any snapshot hash \
+                     will be accepted",
+                ),
         )
         .arg(
             Arg::with_name("debug_key")
@@ -735,7 +796,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("only-known-rpc")
                 .takes_value(false)
                 .requires("known_validators")
-                .help("Use the RPC service of known validators only")
+                .help("Use the RPC service of known validators only"),
         )
         .arg(
             Arg::with_name("repair_validators")
@@ -744,8 +805,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("VALIDATOR IDENTITY")
                 .multiple(true)
                 .takes_value(true)
-                .help("A list of validators to request repairs from. If specified, repair will not \
-                       request from validators outside this set [default: all validators]")
+                .help(
+                    "A list of validators to request repairs from. If specified, repair will not \
+                     request from validators outside this set [default: all validators]",
+                ),
         )
         .arg(
             Arg::with_name("repair_whitelist")
@@ -755,9 +818,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("VALIDATOR IDENTITY")
                 .multiple(true)
                 .takes_value(true)
-                .help("A list of validators to prioritize repairs from. If specified, repair requests \
-                       from validators in the list will be prioritized over requests from other validators. \
-                       [default: all validators]")
+                .help(
+                    "A list of validators to prioritize repairs from. If specified, repair \
+                     requests from validators in the list will be prioritized over requests from \
+                     other validators. [default: all validators]",
+                ),
         )
         .arg(
             Arg::with_name("gossip_validators")
@@ -766,9 +831,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("VALIDATOR IDENTITY")
                 .multiple(true)
                 .takes_value(true)
-                .help("A list of validators to gossip with.  If specified, gossip \
-                      will not push/pull from from validators outside this set. \
-                      [default: all validators]")
+                .help(
+                    "A list of validators to gossip with.  If specified, gossip will not \
+                     push/pull from from validators outside this set. [default: all validators]",
+                ),
         )
         .arg(
             Arg::with_name("tpu_coalesce_ms")
@@ -811,11 +877,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .long("staked-nodes-overrides")
                 .value_name("PATH")
                 .takes_value(true)
-                .help("Provide path to a yaml file with custom overrides for stakes of specific
+                .help(
+                    "Provide path to a yaml file with custom overrides for stakes of specific
                             identities. Overriding the amount of stake this validator considers
-                            as valid for other peers in network. The stake amount is used for calculating
-                            number of QUIC streams permitted from the peer and vote packet sender stage.
-                            Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}"),
+                            as valid for other peers in network. The stake amount is used for \
+                     calculating
+                            number of QUIC streams permitted from the peer and vote packet sender \
+                     stage.
+                            Format of the file: `staked_map_id: {<pubkey>: <SOL stake amount>}",
+                ),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -832,7 +902,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("HOST")
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
-                .help("IP address to bind the RPC port [default: 127.0.0.1 if --private-rpc is present, otherwise use --bind-address]"),
+                .help(
+                    "IP address to bind the RPC port [default: 127.0.0.1 if --private-rpc is \
+                     present, otherwise use --bind-address]",
+                ),
         )
         .arg(
             Arg::with_name("rpc_threads")
@@ -850,8 +923,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(solana_perf::thread::is_niceness_adjustment_valid)
                 .default_value(&default_args.rpc_niceness_adjustment)
-                .help("Add this value to niceness of RPC threads. Negative value \
-                      increases priority, positive value decreases priority.")
+                .help(
+                    "Add this value to niceness of RPC threads. Negative value increases \
+                     priority, positive value decreases priority.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_bigtable_timeout")
@@ -868,7 +943,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .value_name("INSTANCE_NAME")
                 .default_value(&default_args.rpc_bigtable_instance_name)
-                .help("Name of the Bigtable instance to upload to")
+                .help("Name of the Bigtable instance to upload to"),
         )
         .arg(
             Arg::with_name("rpc_bigtable_app_profile_id")
@@ -876,7 +951,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .value_name("APP_PROFILE_ID")
                 .default_value(&default_args.rpc_bigtable_app_profile_id)
-                .help("Bigtable application profile id to use in requests")
+                .help("Bigtable application profile id to use in requests"),
         )
         .arg(
             Arg::with_name("rpc_pubsub_worker_threads")
@@ -907,9 +982,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .hidden(hidden_unless_forced())
-                .help("The maximum number of connections that RPC PubSub will support. \
-                       This is a hard limit and no new connections beyond this limit can \
-                       be made until an old connection is dropped. (Obsolete)"),
+                .help(
+                    "The maximum number of connections that RPC PubSub will support. This is a \
+                     hard limit and no new connections beyond this limit can be made until an old \
+                     connection is dropped. (Obsolete)",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_max_fragment_size")
@@ -918,8 +995,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .hidden(hidden_unless_forced())
-                .help("The maximum length in bytes of acceptable incoming frames. Messages longer \
-                       than this will be rejected. (Obsolete)"),
+                .help(
+                    "The maximum length in bytes of acceptable incoming frames. Messages longer \
+                     than this will be rejected. (Obsolete)",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_max_in_buffer_capacity")
@@ -928,8 +1007,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .hidden(hidden_unless_forced())
-                .help("The maximum size in bytes to which the incoming websocket buffer can grow. \
-                      (Obsolete)"),
+                .help(
+                    "The maximum size in bytes to which the incoming websocket buffer can grow. \
+                     (Obsolete)",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_max_out_buffer_capacity")
@@ -938,8 +1019,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .hidden(hidden_unless_forced())
-                .help("The maximum size in bytes to which the outgoing websocket buffer can grow. \
-                       (Obsolete)"),
+                .help(
+                    "The maximum size in bytes to which the outgoing websocket buffer can grow. \
+                     (Obsolete)",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_max_active_subscriptions")
@@ -948,8 +1031,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .validator(is_parsable::<usize>)
                 .default_value(&default_args.rpc_pubsub_max_active_subscriptions)
-                .help("The maximum number of active subscriptions that RPC PubSub will accept \
-                       across all connections."),
+                .help(
+                    "The maximum number of active subscriptions that RPC PubSub will accept \
+                     across all connections.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_queue_capacity_items")
@@ -958,8 +1043,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .validator(is_parsable::<usize>)
                 .default_value(&default_args.rpc_pubsub_queue_capacity_items)
-                .help("The maximum number of notifications that RPC PubSub will store \
-                       across all connections."),
+                .help(
+                    "The maximum number of notifications that RPC PubSub will store across all \
+                     connections.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_queue_capacity_bytes")
@@ -968,8 +1055,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("BYTES")
                 .validator(is_parsable::<usize>)
                 .default_value(&default_args.rpc_pubsub_queue_capacity_bytes)
-                .help("The maximum total size of notifications that RPC PubSub will store \
-                       across all connections."),
+                .help(
+                    "The maximum total size of notifications that RPC PubSub will store across \
+                     all connections.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_pubsub_notification_threads")
@@ -978,8 +1067,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .value_name("NUM_THREADS")
                 .validator(is_parsable::<usize>)
-                .help("The maximum number of threads that RPC PubSub will use \
-                       for generating notifications. 0 will disable RPC PubSub notifications"),
+                .help(
+                    "The maximum number of threads that RPC PubSub will use for generating \
+                     notifications. 0 will disable RPC PubSub notifications",
+                ),
         )
         .arg(
             Arg::with_name("rpc_send_transaction_retry_ms")
@@ -1007,7 +1098,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<u64>)
                 .default_value(&default_args.rpc_send_transaction_leader_forward_count)
-                .help("The number of upcoming leaders to which to forward transactions sent via rpc service."),
+                .help(
+                    "The number of upcoming leaders to which to forward transactions sent via rpc \
+                     service.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_send_transaction_default_max_retries")
@@ -1015,7 +1109,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
-                .help("The maximum number of transaction broadcast retries when unspecified by the request, otherwise retried until expiration."),
+                .help(
+                    "The maximum number of transaction broadcast retries when unspecified by the \
+                     request, otherwise retried until expiration.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_send_transaction_service_max_retries")
@@ -1024,7 +1121,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .default_value(&default_args.rpc_send_transaction_service_max_retries)
-                .help("The maximum number of transaction broadcast retries, regardless of requested value."),
+                .help(
+                    "The maximum number of transaction broadcast retries, regardless of requested \
+                     value.",
+                ),
         )
         .arg(
             Arg::with_name("rpc_send_transaction_batch_size")
@@ -1066,7 +1166,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(solana_net_utils::is_host)
                 .hidden(hidden_unless_forced())
-                .help("IP address to bind the AccountsDb Replication port [default: use --bind-address]"),
+                .help(
+                    "IP address to bind the AccountsDb Replication port [default: use \
+                     --bind-address]",
+                ),
         )
         .arg(
             Arg::with_name("accountsdb_repl_port")
@@ -1112,9 +1215,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("NUMBER")
                 .takes_value(true)
                 .default_value(&default_args.genesis_archive_unpacked_size)
-                .help(
-                    "maximum total uncompressed file size of downloaded genesis archive",
-                ),
+                .help("maximum total uncompressed file size of downloaded genesis archive"),
         )
         .arg(
             Arg::with_name("wal_recovery_mode")
@@ -1125,10 +1226,9 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     "tolerate_corrupted_tail_records",
                     "absolute_consistency",
                     "point_in_time",
-                    "skip_any_corrupted_record"])
-                .help(
-                    "Mode to recovery the ledger db write ahead log."
-                ),
+                    "skip_any_corrupted_record",
+                ])
+                .help("Mode to recovery the ledger db write ahead log."),
         )
         .arg(
             Arg::with_name("poh_pinned_cpu_core")
@@ -1138,7 +1238,9 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("CPU_CORE_INDEX")
                 .validator(|s| {
                     let core_index = usize::from_str(&s).map_err(|e| e.to_string())?;
-                    let max_index = core_affinity::get_core_ids().map(|cids| cids.len() - 1).unwrap_or(0);
+                    let max_index = core_affinity::get_core_ids()
+                        .map(|cids| cids.len() - 1)
+                        .unwrap_or(0);
                     if core_index > max_index {
                         return Err(format!("core index must be in the range [0, {max_index}]"));
                     }
@@ -1158,7 +1260,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("process_ledger_before_services")
                 .long("process-ledger-before-services")
                 .hidden(hidden_unless_forced())
-                .help("Process the local ledger fully before starting networking services")
+                .help("Process the local ledger fully before starting networking services"),
         )
         .arg(
             Arg::with_name("account_indexes")
@@ -1186,40 +1288,52 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .conflicts_with("account_index_exclude_key")
                 .multiple(true)
                 .value_name("KEY")
-                .help("When account indexes are enabled, only include specific keys in the index. This overrides --account-index-exclude-key."),
+                .help(
+                    "When account indexes are enabled, only include specific keys in the index. \
+                     This overrides --account-index-exclude-key.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_db_verify_refcounts")
                 .long("accounts-db-verify-refcounts")
-                .help("Debug option to scan all append vecs and verify account index refcounts prior to clean")
-                .hidden(hidden_unless_forced())
+                .help(
+                    "Debug option to scan all append vecs and verify account index refcounts \
+                     prior to clean",
+                )
+                .hidden(hidden_unless_forced()),
         )
         .arg(
             Arg::with_name("accounts_db_test_skip_rewrites")
                 .long("accounts-db-test-skip-rewrites")
-                .help("Debug option to skip rewrites for rent-exempt accounts but still add them in bank delta hash calculation")
-                .hidden(hidden_unless_forced())
+                .help(
+                    "Debug option to skip rewrites for rent-exempt accounts but still add them in \
+                     bank delta hash calculation",
+                )
+                .hidden(hidden_unless_forced()),
         )
         .arg(
             Arg::with_name("no_skip_initial_accounts_db_clean")
                 .long("no-skip-initial-accounts-db-clean")
                 .help("Do not skip the initial cleaning of accounts when verifying snapshot bank")
                 .hidden(hidden_unless_forced())
-                .conflicts_with("accounts_db_skip_shrink")
+                .conflicts_with("accounts_db_skip_shrink"),
         )
         .arg(
             Arg::with_name("accounts_db_create_ancient_storage_packed")
                 .long("accounts-db-create-ancient-storage-packed")
                 .help("Create ancient storages in one shot instead of appending.")
                 .hidden(hidden_unless_forced()),
-            )
+        )
         .arg(
             Arg::with_name("accounts_db_ancient_append_vecs")
                 .long("accounts-db-ancient-append-vecs")
                 .value_name("SLOT-OFFSET")
                 .validator(is_parsable::<i64>)
                 .takes_value(true)
-                .help("AppendVecs that are older than (slots_per_epoch - SLOT-OFFSET) are squashed together.")
+                .help(
+                    "AppendVecs that are older than (slots_per_epoch - SLOT-OFFSET) are squashed \
+                     together.",
+                )
                 .hidden(hidden_unless_forced()),
         )
         .arg(
@@ -1228,7 +1342,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MEGABYTES")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
-                .help("How large the write cache for account data can become. If this is exceeded, the cache is flushed more aggressively."),
+                .help(
+                    "How large the write cache for account data can become. If this is exceeded, \
+                     the cache is flushed more aggressively.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_index_scan_results_limit_mb")
@@ -1236,7 +1353,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MEGABYTES")
                 .validator(is_parsable::<usize>)
                 .takes_value(true)
-                .help("How large accumulated results from an accounts index scan can become. If this is exceeded, the scan aborts."),
+                .help(
+                    "How large accumulated results from an accounts index scan can become. If \
+                     this is exceeded, the scan aborts.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_index_memory_limit_mb")
@@ -1244,7 +1364,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("MEGABYTES")
                 .validator(is_parsable::<usize>)
                 .takes_value(true)
-                .help("How much memory the accounts index can consume. If this is exceeded, some account index entries will be stored on disk."),
+                .help(
+                    "How much memory the accounts index can consume. If this is exceeded, some \
+                     account index entries will be stored on disk.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_index_bins")
@@ -1258,16 +1381,24 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("partitioned_epoch_rewards_compare_calculation")
                 .long("partitioned-epoch-rewards-compare-calculation")
                 .takes_value(false)
-                .help("Do normal epoch rewards distribution, but also calculate rewards using the partitioned rewards code path and compare the resulting vote and stake accounts")
-                .hidden(hidden_unless_forced())
+                .help(
+                    "Do normal epoch rewards distribution, but also calculate rewards using the \
+                     partitioned rewards code path and compare the resulting vote and stake \
+                     accounts",
+                )
+                .hidden(hidden_unless_forced()),
         )
         .arg(
             Arg::with_name("partitioned_epoch_rewards_force_enable_single_slot")
                 .long("partitioned-epoch-rewards-force-enable-single-slot")
                 .takes_value(false)
-                .help("Force the partitioned rewards distribution, but distribute all rewards in the first slot in the epoch. This should match consensus with the normal rewards distribution.")
+                .help(
+                    "Force the partitioned rewards distribution, but distribute all rewards in \
+                     the first slot in the epoch. This should match consensus with the normal \
+                     rewards distribution.",
+                )
                 .conflicts_with("partitioned_epoch_rewards_compare_calculation")
-                .hidden(hidden_unless_forced())
+                .hidden(hidden_unless_forced()),
         )
         .arg(
             Arg::with_name("accounts_index_path")
@@ -1275,15 +1406,18 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("PATH")
                 .takes_value(true)
                 .multiple(true)
-                .help("Persistent accounts-index location. \
-                       May be specified multiple times. \
-                       [default: [ledger]/accounts_index]"),
+                .help(
+                    "Persistent accounts-index location. May be specified multiple times. \
+                     [default: [ledger]/accounts_index]",
+                ),
         )
         .arg(
             Arg::with_name("accounts_db_test_hash_calculation")
                 .long("accounts-db-test-hash-calculation")
-                .help("Enables testing of hash calculation using stores in \
-                      AccountsHashVerifier. This has a computational cost."),
+                .help(
+                    "Enables testing of hash calculation using stores in AccountsHashVerifier. \
+                     This has a computational cost.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_shrink_optimize_total_space")
@@ -1291,10 +1425,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .value_name("BOOLEAN")
                 .default_value(&default_args.accounts_shrink_optimize_total_space)
-                .help("When this is set to true, the system will shrink the most \
-                       sparse accounts and when the overall shrink ratio is above \
-                       the specified accounts-shrink-ratio, the shrink will stop and \
-                       it will skip all other less sparse accounts."),
+                .help(
+                    "When this is set to true, the system will shrink the most sparse accounts \
+                     and when the overall shrink ratio is above the specified \
+                     accounts-shrink-ratio, the shrink will stop and it will skip all other less \
+                     sparse accounts.",
+                ),
         )
         .arg(
             Arg::with_name("accounts_shrink_ratio")
@@ -1302,11 +1438,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .value_name("RATIO")
                 .default_value(&default_args.accounts_shrink_ratio)
-                .help("Specifies the shrink ratio for the accounts to be shrunk. \
-                       The shrink ratio is defined as the ratio of the bytes alive over the  \
-                       total bytes used. If the account's shrink ratio is less than this ratio \
-                       it becomes a candidate for shrinking. The value must between 0. and 1.0 \
-                       inclusive."),
+                .help(
+                    "Specifies the shrink ratio for the accounts to be shrunk. The shrink ratio \
+                     is defined as the ratio of the bytes alive over the  total bytes used. If \
+                     the account's shrink ratio is less than this ratio it becomes a candidate \
+                     for shrinking. The value must between 0. and 1.0 inclusive.",
+                ),
         )
         .arg(
             Arg::with_name("allow_private_addr")
@@ -1321,12 +1458,12 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .validator(is_parsable::<usize>)
                 .value_name("BYTES")
-                .help("Maximum number of bytes written to the program log before truncation")
+                .help("Maximum number of bytes written to the program log before truncation"),
         )
         .arg(
             Arg::with_name("replay_slots_concurrently")
                 .long("replay-slots-concurrently")
-                .help("Allow concurrent replay of slots on different forks")
+                .help("Allow concurrent replay of slots on different forks"),
         )
         .arg(
             Arg::with_name("banking_trace_dir_byte_limit")
@@ -1342,17 +1479,19 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 // explicitly given, similar to --limit-ledger-size.
                 // see configure_banking_trace_dir_byte_limit() for this.
                 .default_value(&default_args.banking_trace_dir_byte_limit)
-                .help("Enables the banking trace explicitly, which is enabled by default and \
-                       writes trace files for simulate-leader-blocks, retaining up to the default \
-                       or specified total bytes in the ledger. This flag can be used to override \
-                       its byte limit.")
+                .help(
+                    "Enables the banking trace explicitly, which is enabled by default and writes \
+                     trace files for simulate-leader-blocks, retaining up to the default or \
+                     specified total bytes in the ledger. This flag can be used to override its \
+                     byte limit.",
+                ),
         )
         .arg(
             Arg::with_name("disable_banking_trace")
                 .long("disable-banking-trace")
                 .conflicts_with("banking_trace_dir_byte_limit")
                 .takes_value(false)
-                .help("Disables the banking trace")
+                .help("Disables the banking trace"),
         )
         .arg(
             Arg::with_name("block_verification_method")
@@ -1361,7 +1500,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockVerificationMethod::cli_names())
-                .help(BlockVerificationMethod::cli_message())
+                .help(BlockVerificationMethod::cli_message()),
         )
         .arg(
             Arg::with_name("block_production_method")
@@ -1370,7 +1509,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockProductionMethod::cli_names())
-                .help(BlockProductionMethod::cli_message())
+                .help(BlockProductionMethod::cli_message()),
         )
         .arg(
             Arg::with_name("wen_restart")
@@ -1399,7 +1538,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
 
                     If wen_restart fails, refer to the progress file (in proto3 format) for
                     further debugging.
-                ")
+                ",
+                ),
         )
         .args(&get_deprecated_arguments())
         .after_help("The default subcommand is run")
@@ -1411,14 +1551,17 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .short("f")
                         .long("force")
                         .takes_value(false)
-                        .help("Request the validator exit immediately instead of waiting for a restart window")
+                        .help(
+                            "Request the validator exit immediately instead of waiting for a \
+                             restart window",
+                        ),
                 )
                 .arg(
                     Arg::with_name("monitor")
                         .short("m")
                         .long("monitor")
                         .takes_value(false)
-                        .help("Monitor the validator after sending the exit request")
+                        .help("Monitor the validator after sending the exit request"),
                 )
                 .arg(
                     Arg::with_name("min_idle_time")
@@ -1427,7 +1570,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .validator(is_parsable::<usize>)
                         .value_name("MINUTES")
                         .default_value(&default_args.exit_min_idle_time)
-                        .help("Minimum time that the validator should not be leader before restarting")
+                        .help(
+                            "Minimum time that the validator should not be leader before \
+                             restarting",
+                        ),
                 )
                 .arg(
                     Arg::with_name("max_delinquent_stake")
@@ -1436,18 +1582,18 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .validator(is_valid_percentage)
                         .default_value(&default_args.exit_max_delinquent_stake)
                         .value_name("PERCENT")
-                        .help("The maximum delinquent stake % permitted for an exit")
+                        .help("The maximum delinquent stake % permitted for an exit"),
                 )
                 .arg(
                     Arg::with_name("skip_new_snapshot_check")
                         .long("skip-new-snapshot-check")
-                        .help("Skip check for a new snapshot")
+                        .help("Skip check for a new snapshot"),
                 )
                 .arg(
                     Arg::with_name("skip_health_check")
                         .long("skip-health-check")
-                        .help("Skip health check")
-                )
+                        .help("Skip health check"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("authorized-voter")
@@ -1464,18 +1610,24 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                                 .required(false)
                                 .takes_value(true)
                                 .validator(is_keypair)
-                                .help("Path to keypair of the authorized voter to add \
-                               [default: read JSON keypair from stdin]"),
+                                .help(
+                                    "Path to keypair of the authorized voter to add [default: \
+                                     read JSON keypair from stdin]",
+                                ),
                         )
-                        .after_help("Note: the new authorized voter only applies to the \
-                             currently running validator instance")
+                        .after_help(
+                            "Note: the new authorized voter only applies to the currently running \
+                             validator instance",
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("remove-all")
                         .about("Remove all authorized voters")
-                        .after_help("Note: the removal only applies to the \
-                             currently running validator instance")
-                )
+                        .after_help(
+                            "Note: the removal only applies to the currently running validator \
+                             instance",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("contact-info")
@@ -1486,8 +1638,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .takes_value(true)
                         .value_name("MODE")
                         .possible_values(&["json", "json-compact"])
-                        .help("Output display mode")
-                )
+                        .help("Output display mode"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("repair-whitelist")
@@ -1503,8 +1655,8 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                                 .takes_value(true)
                                 .value_name("MODE")
                                 .possible_values(&["json", "json-compact"])
-                                .help("Output display mode")
-                        )
+                                .help("Output display mode"),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("set")
@@ -1512,76 +1664,65 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .setting(AppSettings::ArgRequiredElseHelp)
                         .arg(
                             Arg::with_name("whitelist")
-                            .long("whitelist")
-                            .validator(is_pubkey)
-                            .value_name("VALIDATOR IDENTITY")
-                            .multiple(true)
-                            .takes_value(true)
-                            .help("Set the validator's repair protocol whitelist")
+                                .long("whitelist")
+                                .validator(is_pubkey)
+                                .value_name("VALIDATOR IDENTITY")
+                                .multiple(true)
+                                .takes_value(true)
+                                .help("Set the validator's repair protocol whitelist"),
                         )
-                        .after_help("Note: repair protocol whitelist changes only apply to the currently \
-                                    running validator instance")
+                        .after_help(
+                            "Note: repair protocol whitelist changes only apply to the currently \
+                             running validator instance",
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("remove-all")
                         .about("Clear the validator's repair protocol whitelist")
-                        .after_help("Note: repair protocol whitelist changes only apply to the currently \
-                                    running validator instance")
-                )
+                        .after_help(
+                            "Note: repair protocol whitelist changes only apply to the currently \
+                             running validator instance",
+                        ),
+                ),
         )
         .subcommand(
-            SubCommand::with_name("init")
-                .about("Initialize the ledger directory then exit")
+            SubCommand::with_name("init").about("Initialize the ledger directory then exit"),
         )
-        .subcommand(
-            SubCommand::with_name("monitor")
-                .about("Monitor the validator")
-        )
-        .subcommand(
-            SubCommand::with_name("run")
-                .about("Run the validator")
-        )
+        .subcommand(SubCommand::with_name("monitor").about("Monitor the validator"))
+        .subcommand(SubCommand::with_name("run").about("Run the validator"))
         .subcommand(
             SubCommand::with_name("plugin")
                 .about("Manage and view geyser plugins")
                 .setting(AppSettings::SubcommandRequiredElseHelp)
                 .setting(AppSettings::InferSubcommands)
                 .subcommand(
-                    SubCommand::with_name("list")
-                        .about("List all current running gesyer plugins")
+                    SubCommand::with_name("list").about("List all current running gesyer plugins"),
                 )
                 .subcommand(
                     SubCommand::with_name("unload")
-                        .about("Unload a particular gesyer plugin. You must specify the gesyer plugin name")
-                        .arg(
-                            Arg::with_name("name")
-                                .required(true)
-                                .takes_value(true)
+                        .about(
+                            "Unload a particular gesyer plugin. You must specify the gesyer \
+                             plugin name",
                         )
+                        .arg(Arg::with_name("name").required(true).takes_value(true)),
                 )
                 .subcommand(
                     SubCommand::with_name("reload")
-                        .about("Reload a particular gesyer plugin. You must specify the gesyer plugin name and the new config path")
-                        .arg(
-                            Arg::with_name("name")
-                                .required(true)
-                                .takes_value(true)
+                        .about(
+                            "Reload a particular gesyer plugin. You must specify the gesyer \
+                             plugin name and the new config path",
                         )
-                        .arg(
-                            Arg::with_name("config")
-                                .required(true)
-                                .takes_value(true)
-                        )
+                        .arg(Arg::with_name("name").required(true).takes_value(true))
+                        .arg(Arg::with_name("config").required(true).takes_value(true)),
                 )
                 .subcommand(
                     SubCommand::with_name("load")
-                        .about("Load a new gesyer plugin. You must specify the config path. Fails if overwriting (use reload)")
-                        .arg(
-                            Arg::with_name("config")
-                                .required(true)
-                                .takes_value(true)
+                        .about(
+                            "Load a new gesyer plugin. You must specify the config path. Fails if \
+                             overwriting (use reload)",
                         )
-                )
+                        .arg(Arg::with_name("config").required(true).takes_value(true)),
+                ),
         )
         .subcommand(
             SubCommand::with_name("set-identity")
@@ -1593,28 +1734,36 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .required(false)
                         .takes_value(true)
                         .validator(is_keypair)
-                        .help("Path to validator identity keypair \
-                           [default: read JSON keypair from stdin]")
+                        .help(
+                            "Path to validator identity keypair [default: read JSON keypair from \
+                             stdin]",
+                        ),
                 )
                 .arg(
                     clap::Arg::with_name("require_tower")
                         .long("require-tower")
                         .takes_value(false)
-                        .help("Refuse to set the validator identity if saved tower state is not found"),
+                        .help(
+                            "Refuse to set the validator identity if saved tower state is not \
+                             found",
+                        ),
                 )
-                .after_help("Note: the new identity only applies to the \
-                         currently running validator instance")
+                .after_help(
+                    "Note: the new identity only applies to the currently running validator \
+                     instance",
+                ),
         )
         .subcommand(
             SubCommand::with_name("set-log-filter")
                 .about("Adjust the validator log filter")
                 .arg(
-                    Arg::with_name("filter")
-                        .takes_value(true)
-                        .index(1)
-                        .help("New filter using the same format as the RUST_LOG environment variable")
+                    Arg::with_name("filter").takes_value(true).index(1).help(
+                        "New filter using the same format as the RUST_LOG environment variable",
+                    ),
                 )
-                .after_help("Note: the new filter only applies to the currently running validator instance")
+                .after_help(
+                    "Note: the new filter only applies to the currently running validator instance",
+                ),
         )
         .subcommand(
             SubCommand::with_name("staked-nodes-overrides")
@@ -1624,10 +1773,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .value_name("PATH")
                         .takes_value(true)
                         .required(true)
-                        .help("Provide path to a file with custom overrides for stakes of specific validator identities."),
+                        .help(
+                            "Provide path to a file with custom overrides for stakes of specific \
+                             validator identities.",
+                        ),
                 )
-                .after_help("Note: the new staked nodes overrides only applies to the \
-                         currently running validator instance")
+                .after_help(
+                    "Note: the new staked nodes overrides only applies to the currently running \
+                     validator instance",
+                ),
         )
         .subcommand(
             SubCommand::with_name("wait-for-restart-window")
@@ -1639,7 +1793,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .validator(is_parsable::<usize>)
                         .value_name("MINUTES")
                         .default_value(&default_args.wait_for_restart_window_min_idle_time)
-                        .help("Minimum time that the validator should not be leader before restarting")
+                        .help(
+                            "Minimum time that the validator should not be leader before \
+                             restarting",
+                        ),
                 )
                 .arg(
                     Arg::with_name("identity")
@@ -1647,7 +1804,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .value_name("ADDRESS")
                         .takes_value(true)
                         .validator(is_pubkey_or_keypair)
-                        .help("Validator identity to monitor [default: your validator]")
+                        .help("Validator identity to monitor [default: your validator]"),
                 )
                 .arg(
                     Arg::with_name("max_delinquent_stake")
@@ -1656,22 +1813,24 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .validator(is_valid_percentage)
                         .default_value(&default_args.wait_for_restart_window_max_delinquent_stake)
                         .value_name("PERCENT")
-                        .help("The maximum delinquent stake % permitted for a restart")
+                        .help("The maximum delinquent stake % permitted for a restart"),
                 )
                 .arg(
                     Arg::with_name("skip_new_snapshot_check")
                         .long("skip-new-snapshot-check")
-                        .help("Skip check for a new snapshot")
+                        .help("Skip check for a new snapshot"),
                 )
                 .arg(
                     Arg::with_name("skip_health_check")
                         .long("skip-health-check")
-                        .help("Skip health check")
+                        .help("Skip health check"),
                 )
-                .after_help("Note: If this command exits with a non-zero status \
-                         then this not a good time for a restart")
-        ).
-        subcommand(
+                .after_help(
+                    "Note: If this command exits with a non-zero status then this not a good time \
+                     for a restart",
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("set-public-address")
                 .about("Specify addresses to advertise in gossip")
                 .arg(
@@ -1680,7 +1839,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .value_name("HOST:PORT")
                         .takes_value(true)
                         .validator(solana_net_utils::is_host_port)
-                        .help("TPU address to advertise in gossip")
+                        .help("TPU address to advertise in gossip"),
                 )
                 .arg(
                     Arg::with_name("tpu_forwards_addr")
@@ -1688,13 +1847,13 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                         .value_name("HOST:PORT")
                         .takes_value(true)
                         .validator(solana_net_utils::is_host_port)
-                        .help("TPU Forwards address to advertise in gossip")
+                        .help("TPU Forwards address to advertise in gossip"),
                 )
                 .group(
                     ArgGroup::with_name("set_public_address_details")
                         .args(&["tpu_addr", "tpu_forwards_addr"])
                         .required(true)
-                        .multiple(true)
+                        .multiple(true),
                 )
                 .after_help("Note: At least one arg must be used. Using multiple is ok"),
         );
@@ -1804,7 +1963,10 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
             .long("halt-on-known-validators-accounts-hash-mismatch")
             .requires("known_validators")
             .takes_value(false)
-            .help("Abort the validator if a bank hash mismatch is detected within known validator set"),
+            .help(
+                "Abort the validator if a bank hash mismatch is detected within known validator \
+                 set"
+            ),
     );
     add_arg!(Arg::with_name("incremental_snapshots")
         .long("incremental-snapshots")
@@ -1813,7 +1975,7 @@ fn deprecated_arguments() -> Vec<DeprecatedArg> {
         .help("Enable incremental snapshots")
         .long_help(
             "Enable incremental snapshots by setting this flag.  When enabled, \
-                 --snapshot-interval-slots will set the incremental snapshot interval. To set the
+             --snapshot-interval-slots will set the incremental snapshot interval. To set the
                  full snapshot interval, use --full-snapshot-interval-slots.",
         ));
     add_arg!(Arg::with_name("minimal_rpc_api")
@@ -2108,8 +2270,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                   [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -2119,9 +2281,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(is_pubkey)
                 .takes_value(true)
                 .help(
-                    "Address of the mint account that will receive tokens \
-                       created at genesis.  If the ledger already exists then \
-                       this parameter is silently ignored [default: client keypair]",
+                    "Address of the mint account that will receive tokens created at genesis.  If \
+                     the ledger already exists then this parameter is silently ignored [default: \
+                     client keypair]",
                 ),
         )
         .arg(
@@ -2140,8 +2302,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .long("reset")
                 .takes_value(false)
                 .help(
-                    "Reset the ledger to genesis if it exists. \
-                       By default the validator will resume an existing ledger (if present)",
+                    "Reset the ledger to genesis if it exists. By default the validator will \
+                     resume an existing ledger (if present)",
                 ),
         )
         .arg(
@@ -2191,8 +2353,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .long("enable-rpc-bigtable-ledger-storage")
                 .takes_value(false)
                 .hidden(hidden_unless_forced())
-                .help("Fetch historical transaction info from a BigTable instance \
-                       as a fallback to local ledger data"),
+                .help(
+                    "Fetch historical transaction info from a BigTable instance as a fallback to \
+                     local ledger data",
+                ),
         )
         .arg(
             Arg::with_name("rpc_bigtable_instance")
@@ -2210,7 +2374,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .hidden(hidden_unless_forced())
                 .default_value(solana_storage_bigtable::DEFAULT_APP_PROFILE_ID)
-                .help("Application profile id to use in Bigtable requests")
+                .help("Application profile id to use in Bigtable requests"),
         )
         .arg(
             Arg::with_name("rpc_pubsub_enable_vote_subscription")
@@ -2232,9 +2396,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .number_of_values(2)
                 .multiple(true)
                 .help(
-                    "Add a SBF program to the genesis configuration with upgrades disabled. \
-                       If the ledger already exists then this parameter is silently ignored. \
-                       First argument can be a pubkey string or path to a keypair",
+                    "Add a SBF program to the genesis configuration with upgrades disabled. If \
+                     the ledger already exists then this parameter is silently ignored. First \
+                     argument can be a pubkey string or path to a keypair",
                 ),
         )
         .arg(
@@ -2245,10 +2409,10 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .number_of_values(3)
                 .multiple(true)
                 .help(
-                    "Add an upgradeable SBF program to the genesis configuration. \
-                       If the ledger already exists then this parameter is silently ignored. \
-                       First and third arguments can be a pubkey string or path to a keypair. \
-                       Upgrade authority set to \"none\" disables upgrades",
+                    "Add an upgradeable SBF program to the genesis configuration. If the ledger \
+                     already exists then this parameter is silently ignored. First and third \
+                     arguments can be a pubkey string or path to a keypair. Upgrade authority set \
+                     to \"none\" disables upgrades",
                 ),
         )
         .arg(
@@ -2260,10 +2424,11 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .allow_hyphen_values(true)
                 .multiple(true)
                 .help(
-                    "Load an account from the provided JSON file (see `solana account --help` on how to dump \
-                        an account to file). Files are searched for relatively to CWD and tests/fixtures. \
-                        If ADDRESS is omitted via the `-` placeholder, the one in the file will be used. \
-                        If the ledger already exists then this parameter is silently ignored",
+                    "Load an account from the provided JSON file (see `solana account --help` on \
+                     how to dump an account to file). Files are searched for relatively to CWD \
+                     and tests/fixtures. If ADDRESS is omitted via the `-` placeholder, the one \
+                     in the file will be used. If the ledger already exists then this parameter \
+                     is silently ignored",
                 ),
         )
         .arg(
@@ -2278,7 +2443,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                             if path.exists() && path.is_dir() {
                                 Ok(())
                             } else {
-                                Err(format!("path does not exist or is not a directory: {value}"))
+                                Err(format!(
+                                    "path does not exist or is not a directory: {value}"
+                                ))
                             }
                         })
                 })
@@ -2286,8 +2453,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .multiple(true)
                 .help(
                     "Load all the accounts from the JSON files found in the specified DIRECTORY \
-                        (see also the `--account` flag). \
-                        If the ledger already exists then this parameter is silently ignored",
+                     (see also the `--account` flag). If the ledger already exists then this \
+                     parameter is silently ignored",
                 ),
         )
         .arg(
@@ -2327,8 +2494,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 })
                 .takes_value(true)
                 .help(
-                    "Override the number of slots in an epoch. \
-                       If the ledger already exists then this parameter is silently ignored",
+                    "Override the number of slots in an epoch. If the ledger already exists then \
+                     this parameter is silently ignored",
                 ),
         )
         .arg(
@@ -2346,7 +2513,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .validator(solana_net_utils::is_host)
                 .help(
                     "Gossip DNS name or IP address for the validator to advertise in gossip \
-                       [default: 127.0.0.1]",
+                     [default: 127.0.0.1]",
                 ),
         )
         .arg(
@@ -2355,10 +2522,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("MIN_PORT-MAX_PORT")
                 .takes_value(true)
                 .validator(port_range_validator)
-                .help(
-                    "Range to use for dynamically assigned ports \
-                    [default: 1024-65535]",
-                ),
+                .help("Range to use for dynamically assigned ports [default: 1024-65535]"),
         )
         .arg(
             Arg::with_name("bind_address")
@@ -2380,8 +2544,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .requires("json_rpc_url")
                 .help(
                     "Copy an account from the cluster referenced by the --url argument the \
-                     genesis configuration. \
-                     If the ledger already exists then this parameter is silently ignored",
+                     genesis configuration. If the ledger already exists then this parameter is \
+                     silently ignored",
                 ),
         )
         .arg(
@@ -2393,9 +2557,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .multiple(true)
                 .requires("json_rpc_url")
                 .help(
-                    "Copy an account from the cluster referenced by the --url argument, \
-                     skipping it if it doesn't exist. \
-                     If the ledger already exists then this parameter is silently ignored",
+                    "Copy an account from the cluster referenced by the --url argument, skipping \
+                     it if it doesn't exist. If the ledger already exists then this parameter is \
+                     silently ignored",
                 ),
         )
         .arg(
@@ -2408,8 +2572,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .requires("json_rpc_url")
                 .help(
                     "Copy an upgradeable program and its executable data from the cluster \
-                     referenced by the --url argument the genesis configuration. \
-                     If the ledger already exists then this parameter is silently ignored",
+                     referenced by the --url argument the genesis configuration. If the ledger \
+                     already exists then this parameter is silently ignored",
                 ),
         )
         .arg(
@@ -2423,9 +2587,9 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .min_values(0)
                 .max_values(1)
                 .help(
-                    "Warp the ledger to WARP_SLOT after starting the validator. \
-                        If no slot is provided then the current slot of the cluster \
-                        referenced by the --url argument will be used",
+                    "Warp the ledger to WARP_SLOT after starting the validator. If no slot is \
+                     provided then the current slot of the cluster referenced by the --url \
+                     argument will be used",
                 ),
         )
         .arg(
@@ -2443,8 +2607,8 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("SOL")
                 .default_value(default_args.faucet_sol.as_str())
                 .help(
-                    "Give the faucet address this much SOL in genesis. \
-                     If the ledger already exists then this parameter is silently ignored",
+                    "Give the faucet address this much SOL in genesis. If the ledger already \
+                     exists then this parameter is silently ignored",
                 ),
         )
         .arg(
@@ -2453,9 +2617,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .takes_value(true)
                 .value_name("SECS")
                 .default_value(default_args.faucet_time_slice_secs.as_str())
-                .help(
-                    "Time slice (in secs) over which to limit faucet requests",
-                ),
+                .help("Time slice (in secs) over which to limit faucet requests"),
         )
         .arg(
             Arg::with_name("faucet_per_time_sol_cap")
@@ -2464,9 +2626,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("SOL")
                 .min_values(0)
                 .max_values(1)
-                .help(
-                    "Per-time slice limit for faucet requests, in SOL",
-                ),
+                .help("Per-time slice limit for faucet requests, in SOL"),
         )
         .arg(
             Arg::with_name("faucet_per_request_sol_cap")
@@ -2475,9 +2635,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("SOL")
                 .min_values(0)
                 .max_values(1)
-                .help(
-                    "Per-request limit for faucet requests, in SOL",
-                ),
+                .help("Per-request limit for faucet requests, in SOL"),
         )
         .arg(
             Arg::with_name("geyser_plugin_config")
@@ -2495,7 +2653,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("FEATURE_PUBKEY")
                 .validator(is_pubkey)
                 .multiple(true)
-                .help("deactivate this feature in genesis.")
+                .help("deactivate this feature in genesis."),
         )
         .arg(
             Arg::with_name("compute_unit_limit")
@@ -2504,7 +2662,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("COMPUTE_UNITS")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
-                .help("Override the runtime's compute unit limit per transaction")
+                .help("Override the runtime's compute unit limit per transaction"),
         )
         .arg(
             Arg::with_name("log_messages_bytes_limit")
@@ -2512,7 +2670,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("BYTES")
                 .validator(is_parsable::<usize>)
                 .takes_value(true)
-                .help("Maximum number of bytes written to the program log before truncation")
+                .help("Maximum number of bytes written to the program log before truncation"),
         )
         .arg(
             Arg::with_name("transaction_account_lock_limit")
@@ -2520,7 +2678,7 @@ pub fn test_app<'a>(version: &'a str, default_args: &'a DefaultTestArgs) -> App<
                 .value_name("NUM_ACCOUNTS")
                 .validator(is_parsable::<u64>)
                 .takes_value(true)
-                .help("Override the runtime's account lock limit per transaction")
+                .help("Override the runtime's account lock limit per transaction"),
         );
 }
 
@@ -2568,8 +2726,8 @@ mod test {
 
             assert!(
                 curr_name != next_name,
-                "Arguments in `deprecated_arguments()` should be distinct.\n\
-                 Arguments {} and {} use the same name: {}",
+                "Arguments in `deprecated_arguments()` should be distinct.\nArguments {} and {} \
+                 use the same name: {}",
                 i,
                 i + 1,
                 curr_name,
@@ -2578,10 +2736,8 @@ mod test {
             assert!(
                 curr_name < next_name,
                 "To generate better diffs and for readability purposes, `deprecated_arguments()` \
-                 should list arguments in alphabetical order.\n\
-                 Arguments {} and {} are not.\n\
-                 Argument {} name: {}\n\
-                 Argument {} name: {}",
+                 should list arguments in alphabetical order.\nArguments {} and {} are \
+                 not.\nArgument {} name: {}\nArgument {} name: {}",
                 i,
                 i + 1,
                 i,

--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -154,10 +154,9 @@ impl Dashboard {
                         };
 
                         progress_bar.set_message(format!(
-                            "{}{}| \
-                                    Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: {} | \
-                                    Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
-                                    Transactions: {} | {}",
+                            "{}{}| Processed Slot: {} | Confirmed Slot: {} | Finalized Slot: {} | \
+                             Full Snapshot Slot: {} | Incremental Snapshot Slot: {} | \
+                             Transactions: {} | {}",
                             uptime,
                             if health == "ok" {
                                 "".to_string()

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -220,7 +220,8 @@ fn wait_for_restart_window(
                 }
                 if !leader_schedule.is_empty() && upcoming_idle_windows.is_empty() {
                     return Err(format!(
-                        "Validator has no idle window of at least {} slots. Largest idle window for epoch {} is {} slots",
+                        "Validator has no idle window of at least {} slots. Largest idle window \
+                         for epoch {} is {} slots",
                         min_idle_slots, epoch_info.epoch, max_idle_window
                     )
                     .into());
@@ -274,7 +275,8 @@ fn wait_for_restart_window(
                                         )
                                     }
                                     None => format!(
-                                        "Validator will be leader soon. Next leader slot is {next_leader_slot}"
+                                        "Validator will be leader soon. Next leader slot is \
+                                         {next_leader_slot}"
                                     ),
                                 })
                             }
@@ -849,11 +851,14 @@ pub fn main() {
         ("set-public-address", Some(subcommand_matches)) => {
             let parse_arg_addr = |arg_name: &str, arg_long: &str| -> Option<SocketAddr> {
                 subcommand_matches.value_of(arg_name).map(|host_port| {
-                        solana_net_utils::parse_host_port(host_port).unwrap_or_else(|err| {
-                            eprintln!("Failed to parse --{arg_long} address. It must be in the HOST:PORT format. {err}");
-                            exit(1);
-                        })
+                    solana_net_utils::parse_host_port(host_port).unwrap_or_else(|err| {
+                        eprintln!(
+                            "Failed to parse --{arg_long} address. It must be in the HOST:PORT \
+                             format. {err}"
+                        );
+                        exit(1);
                     })
+                })
             };
             let tpu_addr = parse_arg_addr("tpu_addr", "tpu");
             let tpu_forwards_addr = parse_arg_addr("tpu_forwards_addr", "tpu-forwards");
@@ -1059,7 +1064,8 @@ pub fn main() {
     let shrink_ratio = value_t_or_exit!(matches, "accounts_shrink_ratio", f64);
     if !(0.0..=1.0).contains(&shrink_ratio) {
         eprintln!(
-            "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0 inclusive: {shrink_ratio}"
+            "The specified account-shrink-ratio is invalid, it must be between 0. and 1.0 \
+             inclusive: {shrink_ratio}"
         );
         exit(1);
     }
@@ -1242,7 +1248,8 @@ pub fn main() {
 
     if rpc_send_batch_send_rate_ms > rpc_send_retry_rate_ms {
         eprintln!(
-            "The specified rpc-send-batch-ms ({rpc_send_batch_send_rate_ms}) is invalid, it must be <= rpc-send-retry-ms ({rpc_send_retry_rate_ms})"
+            "The specified rpc-send-batch-ms ({rpc_send_batch_send_rate_ms}) is invalid, it must \
+             be <= rpc-send-retry-ms ({rpc_send_retry_rate_ms})"
         );
         exit(1);
     }
@@ -1251,7 +1258,7 @@ pub fn main() {
     if tps > send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND {
         eprintln!(
             "Either the specified rpc-send-batch-size ({}) or rpc-send-batch-ms ({}) is invalid, \
-            'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
+             'rpc-send-batch-size * 1000 / rpc-send-batch-ms' must be smaller than ({}) .",
             rpc_send_batch_size,
             rpc_send_batch_send_rate_ms,
             send_transaction_service::MAX_TRANSACTION_SENDS_PER_SECOND
@@ -1587,14 +1594,22 @@ pub fn main() {
         &validator_config.snapshot_config,
         validator_config.accounts_hash_interval_slots,
     ) {
-        eprintln!("Invalid snapshot configuration provided: snapshot intervals are incompatible. \
-            \n\t- full snapshot interval MUST be a multiple of incremental snapshot interval (if enabled) \
-            \n\t- full snapshot interval MUST be larger than incremental snapshot interval (if enabled) \
-            \nSnapshot configuration values: \
-            \n\tfull snapshot interval: {} \
-            \n\tincremental snapshot interval: {}",
-            if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { full_snapshot_archive_interval_slots.to_string() },
-            if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL { "disabled".to_string() } else { incremental_snapshot_archive_interval_slots.to_string() },
+        eprintln!(
+            "Invalid snapshot configuration provided: snapshot intervals are incompatible. \n\t- \
+             full snapshot interval MUST be a multiple of incremental snapshot interval (if \
+             enabled) \n\t- full snapshot interval MUST be larger than incremental snapshot \
+             interval (if enabled) \nSnapshot configuration values: \n\tfull snapshot interval: \
+             {} \n\tincremental snapshot interval: {}",
+            if full_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
+                "disabled".to_string()
+            } else {
+                full_snapshot_archive_interval_slots.to_string()
+            },
+            if incremental_snapshot_archive_interval_slots == DISABLED_SNAPSHOT_ARCHIVE_INTERVAL {
+                "disabled".to_string()
+            } else {
+                incremental_snapshot_archive_interval_slots.to_string()
+            },
         );
         exit(1);
     }
@@ -1606,7 +1621,8 @@ pub fn main() {
         };
         if limit_ledger_size < DEFAULT_MIN_MAX_LEDGER_SHREDS {
             eprintln!(
-                "The provided --limit-ledger-size value was too small, the minimum value is {DEFAULT_MIN_MAX_LEDGER_SHREDS}"
+                "The provided --limit-ledger-size value was too small, the minimum value is \
+                 {DEFAULT_MIN_MAX_LEDGER_SHREDS}"
             );
             exit(1);
         }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -45,7 +45,8 @@ fn get_config() -> Config {
     let matches = App::new(crate_name!())
         .about(crate_description!())
         .version(solana_version::version!())
-        .after_help("ADDITIONAL HELP:
+        .after_help(
+            "ADDITIONAL HELP:
         To receive a Slack, Discord, PagerDuty and/or Telegram notification on sanity failure,
         define environment variables before running `solana-watchtower`:
 
@@ -57,7 +58,8 @@ fn get_config() -> Config {
         export TELEGRAM_BOT_TOKEN=...
         export TELEGRAM_CHAT_ID=...
 
-        PagerDuty requires an Integration Key from the Events API v2 (Add this integration to your PagerDuty service to get this)
+        PagerDuty requires an Integration Key from the Events API v2 (Add this integration to your \
+             PagerDuty service to get this)
 
         export PAGERDUTY_INTEGRATION_KEY=...
 
@@ -65,7 +67,10 @@ fn get_config() -> Config {
         and a sending number owned by that account,
         define environment variable before running `solana-watchtower`:
 
-        export TWILIO_CONFIG='ACCOUNT=<account>,TOKEN=<securityToken>,TO=<receivingNumber>,FROM=<sendingNumber>'")
+        export \
+             TWILIO_CONFIG='ACCOUNT=<account>,TOKEN=<securityToken>,TO=<receivingNumber>,\
+             FROM=<sendingNumber>'",
+        )
         .arg({
             let arg = Arg::with_name("config_file")
                 .short("C")
@@ -110,7 +115,7 @@ fn get_config() -> Config {
                 .value_name("COUNT")
                 .takes_value(true)
                 .default_value("1")
-                .help("How many consecutive failures must occur to trigger a notification")
+                .help("How many consecutive failures must occur to trigger a notification"),
         )
         .arg(
             Arg::with_name("validator_identities")
@@ -119,7 +124,7 @@ fn get_config() -> Config {
                 .takes_value(true)
                 .validator(is_pubkey_or_keypair)
                 .multiple(true)
-                .help("Validator identities to monitor for delinquency")
+                .help("Validator identities to monitor for delinquency"),
         )
         .arg(
             Arg::with_name("minimum_validator_identity_balance")
@@ -128,19 +133,22 @@ fn get_config() -> Config {
                 .takes_value(true)
                 .default_value("10")
                 .validator(is_parsable::<f64>)
-                .help("Alert when the validator identity balance is less than this amount of SOL")
+                .help("Alert when the validator identity balance is less than this amount of SOL"),
         )
         .arg(
             // Deprecated parameter, now always enabled
             Arg::with_name("no_duplicate_notifications")
                 .long("no-duplicate-notifications")
-                .hidden(hidden_unless_forced())
+                .hidden(hidden_unless_forced()),
         )
         .arg(
             Arg::with_name("monitor_active_stake")
                 .long("monitor-active-stake")
                 .takes_value(false)
-                .help("Alert when the current stake for the cluster drops below the amount specified by --active-stake-alert-threshold"),
+                .help(
+                    "Alert when the current stake for the cluster drops below the amount \
+                     specified by --active-stake-alert-threshold",
+                ),
         )
         .arg(
             Arg::with_name("active_stake_alert_threshold")
@@ -155,10 +163,11 @@ fn get_config() -> Config {
             Arg::with_name("ignore_http_bad_gateway")
                 .long("ignore-http-bad-gateway")
                 .takes_value(false)
-                .help("Ignore HTTP 502 Bad Gateway errors from the JSON RPC URL. \
-                    This flag can help reduce false positives, at the expense of \
-                    no alerting should a Bad Gateway error be a side effect of \
-                    the real problem")
+                .help(
+                    "Ignore HTTP 502 Bad Gateway errors from the JSON RPC URL. This flag can help \
+                     reduce false positives, at the expense of no alerting should a Bad Gateway \
+                     error be a side effect of the real problem",
+                ),
         )
         .arg(
             Arg::with_name("name_suffix")
@@ -166,7 +175,7 @@ fn get_config() -> Config {
                 .value_name("SUFFIX")
                 .takes_value(true)
                 .default_value("")
-                .help("Add this string into all notification messages after \"solana-watchtower\"")
+                .help("Add this string into all notification messages after \"solana-watchtower\""),
         )
         .get_matches();
 
@@ -300,7 +309,8 @@ fn main() -> Result<(), Box<dyn error::Error>> {
                     failures.push((
                         "transaction-count",
                         format!(
-                            "Transaction count is not advancing: {transaction_count} <= {last_transaction_count}"
+                            "Transaction count is not advancing: {transaction_count} <= \
+                             {last_transaction_count}"
                         ),
                     ));
                 }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -44,7 +44,10 @@ fn app(crate_version: &str) -> Command {
         .arg_required_else_help(true)
         .subcommand(
             Command::new("new")
-                .about("Generate a new encryption key/keypair file from a random seed phrase and optional BIP39 passphrase")
+                .about(
+                    "Generate a new encryption key/keypair file from a random seed phrase and \
+                     optional BIP39 passphrase",
+                )
                 .disable_version_flag(true)
                 .arg(
                     Arg::new("type")
@@ -53,7 +56,7 @@ fn app(crate_version: &str) -> Command {
                         .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
                         .required(true)
-                        .help("The type of encryption key")
+                        .help("The type of encryption key"),
                 )
                 .arg(
                     Arg::new("outfile")
@@ -68,13 +71,12 @@ fn app(crate_version: &str) -> Command {
                         .long("force")
                         .help("Overwrite the output file if it exists"),
                 )
-                .arg(
-                    Arg::new("silent")
-                        .long("silent")
-                        .help("Do not display seed phrase. Useful when piping output to other programs that prompt for user input, like gpg"),
-                )
+                .arg(Arg::new("silent").long("silent").help(
+                    "Do not display seed phrase. Useful when piping output to other programs that \
+                     prompt for user input, like gpg",
+                ))
                 .key_generation_common_args()
-                .arg(no_outfile_arg().conflicts_with_all(&["outfile", "silent"]))
+                .arg(no_outfile_arg().conflicts_with_all(&["outfile", "silent"])),
         )
         .subcommand(
             Command::new("pubkey")
@@ -87,7 +89,7 @@ fn app(crate_version: &str) -> Command {
                         .possible_values(["elgamal"])
                         .value_name("TYPE")
                         .required(true)
-                        .help("The type of keypair")
+                        .help("The type of keypair"),
                 )
                 .arg(
                     Arg::new("keypair")
@@ -100,7 +102,7 @@ fn app(crate_version: &str) -> Command {
                     Arg::new(SKIP_SEED_PHRASE_VALIDATION_ARG.name)
                         .long(SKIP_SEED_PHRASE_VALIDATION_ARG.long)
                         .help(SKIP_SEED_PHRASE_VALIDATION_ARG.help),
-                )
+                ),
         )
         .subcommand(
             Command::new("recover")
@@ -113,7 +115,7 @@ fn app(crate_version: &str) -> Command {
                         .possible_values(["elgamal", "aes128"])
                         .value_name("TYPE")
                         .required(true)
-                        .help("The type of keypair")
+                        .help("The type of keypair"),
                 )
                 .arg(
                     Arg::new("prompt_signer")
@@ -199,8 +201,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         let phrase: &str = mnemonic.phrase();
                         let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                         println!(
-                            "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new ElGamal keypair:\n{}\n{}",
-                            &divider, elgamal_keypair.pubkey(), &divider, passphrase_message, phrase, &divider
+                            "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new \
+                             ElGamal keypair:\n{}\n{}",
+                            &divider,
+                            elgamal_keypair.pubkey(),
+                            &divider,
+                            passphrase_message,
+                            phrase,
+                            &divider
                         );
                     }
                 }


### PR DESCRIPTION
#### Problem
Long string literals can cause `cargo fmt` to fail; see https://github.com/rust-lang/rustfmt/issues/3863 for more details (namely [this comment of providing the idea for this PR](https://github.com/rust-lang/rustfmt/issues/3863#issuecomment-678632593)). The failure on a long string can cause `rustfmt` to not format entire functions. So, we should utilize the `rustfmt` option to automatically format string literals:
https://rust-lang.github.io/rustfmt/?version=master&search=#format_strings

#### Summary of Changes
Three commits in this PR; the single line of change and then letting fmt do its' thing:
- Add the new rule to rustfmt.toml
- `./cargo nightly fmt` from the repo root to get the vast majority of the files
- `../../cargo nightly fmt` from within `/programs/sbf` to get those files

I have long been annoyed by this; running `cargo fmt` wouldn't fix something that I knew was clearly "wrong" in specific files (such as `main.rs` within ledger-tool)
<img width="383" alt="image" src="https://github.com/solana-labs/solana/assets/5400107/1834cb3b-d1fb-4ccd-8048-85ef27e43edd">

Lastly, we could do a [similar thing with comments](https://rust-lang.github.io/rustfmt/?version=master&search=#wrap_comments); however, I think that should be a separate PR as this one is certainly large enough, and some comments contain ASCII art that wrapping could ruin.