### PR TITLE
Only compile bench_program_alu for x86_64

### DIFF
--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -2,6 +2,7 @@
 #![cfg(feature = "sbf_c")]
 #![allow(clippy::uninlined_format_args)]
 #![allow(clippy::arithmetic_side_effects)]
+#![cfg_attr(not(target_arch = "x86_64"), allow(dead_code, unused_imports))]
 
 use {
     solana_rbpf::memory_region::MemoryState,
@@ -101,6 +102,7 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(target_arch = "x86_64")]
 fn bench_program_alu(bencher: &mut Bencher) {
     let ns_per_s = 1000000000;
     let one_million = 1000000;


### PR DESCRIPTION
#### Problem
Running `./ci/test-checks.sh` currently fails on mac arm64 because of the [call to `jit_compile()`](https://github.com/solana-labs/solana/blob/c3323c0c36384130103506818dc752ecec559f2d/programs/sbf/benches/bpf_loader.rs#L127), which [only supports x86_64](https://github.com/solana-labs/rbpf/blob/b503a1867a9cfa13f93b4d99679a17fe219831de/src/elf.rs#L307).
It would be helpful to be able to run these checks to completion on mac dev machines.

#### Summary of Changes
Add attribute to only compile bench on x86_64 and ignore the dead-code and unused-import warnings that result.