### PR TITLE
Moves val into .extend() instead of &mut and .into_iter()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6136,7 +6136,7 @@ impl Bank {
             self.skipped_rewrites
                 .lock()
                 .unwrap()
-                .extend(&mut results.skipped_rewrites.into_iter());
+                .extend(results.skipped_rewrites);
 
             // We cannot assert here that we collected from all expected keys.
             // Some accounts may have been topped off or may have had all funds removed and gone to 0 lamports.


### PR DESCRIPTION
Originally from https://github.com/solana-labs/solana/pull/34280#discussion_r1410605157, this is a simple cleanup. We can pass the `results.skipped_rewrites` directly into `.extend()`, instead of doing the `&mut` + `.into_iter()`.