### PR TITLE
solana-cli: format strings

### DIFF
--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -80,11 +80,11 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_pubkey)
                                 .help(
-                                    "Lookup table authority address [default: the default \
-                                     configured keypair]. WARNING: Cannot be used for creating a \
-                                     lookup table for a cluster running v1.11
-                                    or earlier which requires the authority to sign for lookup \
-                                     table creation.",
+                                    "Lookup table authority address \
+                                    [default: the default configured keypair]. \
+                                    WARNING: Cannot be used for creating a lookup table for \
+                                    a cluster running v1.11 or earlier which requires the \
+                                    authority to sign for lookup table creation.",
                                 ),
                         )
                         .arg(
@@ -95,8 +95,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .conflicts_with("authority")
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority keypair [default: the default \
-                                     configured keypair].",
+                                    "Lookup table authority keypair \
+                                    [default: the default configured keypair].",
                                 ),
                         )
                         .arg(
@@ -130,8 +130,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority [default: the default configured \
-                                     keypair]",
+                                    "Lookup table authority \
+                                    [default: the default configured keypair]",
                                 ),
                         )
                         .arg(
@@ -160,8 +160,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority [default: the default configured \
-                                     keypair]",
+                                    "Lookup table authority \
+                                    [default: the default configured keypair]",
                                 ),
                         )
                         .arg(
@@ -204,8 +204,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority [default: the default configured \
-                                     keypair]",
+                                    "Lookup table authority \
+                                    [default: the default configured keypair]",
                                 ),
                         )
                         .arg(
@@ -244,8 +244,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_valid_signer)
                                 .help(
-                                    "Lookup table authority [default: the default configured \
-                                     keypair]",
+                                    "Lookup table authority \
+                                    [default: the default configured keypair]",
                                 ),
                         ),
                 )

--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -80,10 +80,12 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .validator(is_pubkey)
                                 .help(
-                                    "Lookup table authority address [default: the default configured keypair]. \
-                                    WARNING: Cannot be used for creating a lookup table for a cluster running v1.11
-                                    or earlier which requires the authority to sign for lookup table creation.",
-                                )
+                                    "Lookup table authority address [default: the default \
+                                     configured keypair]. WARNING: Cannot be used for creating a \
+                                     lookup table for a cluster running v1.11
+                                    or earlier which requires the authority to sign for lookup \
+                                     table creation.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority_signer")
@@ -92,7 +94,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .conflicts_with("authority")
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority keypair [default: the default configured keypair].")
+                                .help(
+                                    "Lookup table authority keypair [default: the default \
+                                     configured keypair].",
+                                ),
                         )
                         .arg(
                             Arg::with_name("payer")
@@ -100,8 +105,11 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("PAYER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Account that will pay rent fees for the created lookup table [default: the default configured keypair]")
-                        )
+                                .help(
+                                    "Account that will pay rent fees for the created lookup table \
+                                     [default: the default configured keypair]",
+                                ),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("freeze")
@@ -113,7 +121,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -121,7 +129,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("bypass_warning")
@@ -140,7 +151,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -148,7 +159,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("payer")
@@ -156,7 +170,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("PAYER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Account that will pay rent fees for the extended lookup table [default: the default configured keypair]")
+                                .help(
+                                    "Account that will pay rent fees for the extended lookup \
+                                     table [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("addresses")
@@ -166,8 +183,8 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .use_delimiter(true)
                                 .required(true)
                                 .validator(is_pubkey)
-                                .help("Comma separated list of addresses to append")
-                        )
+                                .help("Comma separated list of addresses to append"),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("deactivate")
@@ -178,7 +195,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -186,7 +203,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("bypass_warning")
@@ -204,7 +224,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the lookup table")
+                                .help("Address of the lookup table"),
                         )
                         .arg(
                             Arg::with_name("recipient")
@@ -212,7 +232,10 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("RECIPIENT_ADDRESS")
                                 .takes_value(true)
                                 .validator(is_pubkey)
-                                .help("Address of the recipient account to deposit the closed account's lamports [default: the default configured keypair]")
+                                .help(
+                                    "Address of the recipient account to deposit the closed \
+                                     account's lamports [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -220,8 +243,11 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Lookup table authority [default: the default configured keypair]")
-                        )
+                                .help(
+                                    "Lookup table authority [default: the default configured \
+                                     keypair]",
+                                ),
+                        ),
                 )
                 .subcommand(
                     SubCommand::with_name("get")
@@ -231,9 +257,9 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the lookup table to show")
-                        )
-                )
+                                .help("Address of the lookup table to show"),
+                        ),
+                ),
         )
     }
 }
@@ -593,9 +619,9 @@ fn process_create_lookup_table(
     }
 }
 
-pub const FREEZE_LOOKUP_TABLE_WARNING: &str = "WARNING! \
-Once a lookup table is frozen, it can never be modified or unfrozen again. \
-To proceed with freezing, rerun the `freeze` command with the `--bypass-warning` flag";
+pub const FREEZE_LOOKUP_TABLE_WARNING: &str =
+    "WARNING! Once a lookup table is frozen, it can never be modified or unfrozen again. To \
+     proceed with freezing, rerun the `freeze` command with the `--bypass-warning` flag";
 
 fn process_freeze_lookup_table(
     rpc_client: &RpcClient,
@@ -613,9 +639,10 @@ fn process_freeze_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     if !bypass_warning {
@@ -671,9 +698,10 @@ fn process_extend_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let authority_address = authority_signer.pubkey();
@@ -709,10 +737,10 @@ fn process_extend_lookup_table(
     }
 }
 
-pub const DEACTIVATE_LOOKUP_TABLE_WARNING: &str = "WARNING! \
-Once a lookup table is deactivated, it is no longer usable by transactions.
-Deactivated lookup tables may only be closed and cannot be recreated at the same address. \
-To proceed with deactivation, rerun the `deactivate` command with the `--bypass-warning` flag";
+pub const DEACTIVATE_LOOKUP_TABLE_WARNING: &str =
+    "WARNING! Once a lookup table is deactivated, it is no longer usable by transactions.
+Deactivated lookup tables may only be closed and cannot be recreated at the same address. To \
+     proceed with deactivation, rerun the `deactivate` command with the `--bypass-warning` flag";
 
 fn process_deactivate_lookup_table(
     rpc_client: &RpcClient,
@@ -730,9 +758,10 @@ fn process_deactivate_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     if !bypass_warning {
@@ -783,17 +812,19 @@ fn process_close_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let lookup_table_account = AddressLookupTable::deserialize(&lookup_table_account.data)?;
     if lookup_table_account.meta.deactivation_slot == u64::MAX {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not deactivated. Only deactivated lookup tables may be closed",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not deactivated. Only deactivated \
+             lookup tables may be closed",
+        )
+        .into());
     }
 
     let authority_address = authority_signer.pubkey();
@@ -836,9 +867,10 @@ fn process_show_lookup_table(
     })?;
     if !address_lookup_table::program::check_id(&lookup_table_account.owner) {
         return Err(format!(
-                    "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table program",
-                )
-                .into());
+            "Lookup table account {lookup_table_pubkey} is not owned by the Address Lookup Table \
+             program",
+        )
+        .into());
     }
 
     let lookup_table_account = AddressLookupTable::deserialize(&lookup_table_account.data)?;

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -37,8 +37,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
-                     testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): \
+                    [mainnet-beta, testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -77,8 +77,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .hide_possible_values(true)
                 .global(true)
                 .help(
-                    "Return information at the selected commitment level [possible values: \
-                     processed, confirmed, finalized]",
+                    "Return information at the selected commitment level \
+                    [possible values: processed, confirmed, finalized]",
                 ),
         )
         .arg(

--- a/cli/src/clap_app.rs
+++ b/cli/src/clap_app.rs
@@ -37,8 +37,8 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                 .global(true)
                 .validator(is_url_or_moniker)
                 .help(
-                    "URL for Solana's JSON RPC or moniker (or their first letter): \
-                       [mainnet-beta, testnet, devnet, localhost]",
+                    "URL for Solana's JSON RPC or moniker (or their first letter): [mainnet-beta, \
+                     testnet, devnet, localhost]",
                 ),
         )
         .arg(
@@ -67,16 +67,19 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
                     "processed",
                     "confirmed",
                     "finalized",
-                    "recent", // Deprecated as of v1.5.5
-                    "single", // Deprecated as of v1.5.5
+                    "recent",       // Deprecated as of v1.5.5
+                    "single",       // Deprecated as of v1.5.5
                     "singleGossip", // Deprecated as of v1.5.5
-                    "root", // Deprecated as of v1.5.5
-                    "max", // Deprecated as of v1.5.5
+                    "root",         // Deprecated as of v1.5.5
+                    "max",          // Deprecated as of v1.5.5
                 ])
                 .value_name("COMMITMENT_LEVEL")
                 .hide_possible_values(true)
                 .global(true)
-                .help("Return information at the selected commitment level [possible values: processed, confirmed, finalized]"),
+                .help(
+                    "Return information at the selected commitment level [possible values: \
+                     processed, confirmed, finalized]",
+                ),
         )
         .arg(
             Arg::with_name("verbose")
@@ -207,14 +210,14 @@ pub fn get_clap_app<'ab, 'v>(name: &str, about: &'ab str, version: &'v str) -> A
         )
         .subcommand(
             SubCommand::with_name("completion")
-            .about("Generate completion scripts for various shells")
-            .arg(
-                Arg::with_name("shell")
-                .long("shell")
-                .short("s")
-                .takes_value(true)
-                .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
-                .default_value("bash")
-            )
+                .about("Generate completion scripts for various shells")
+                .arg(
+                    Arg::with_name("shell")
+                        .long("shell")
+                        .short("s")
+                        .takes_value(true)
+                        .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"])
+                        .default_value("bash"),
+                ),
         )
 }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -103,20 +103,23 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("catchup")
                 .about("Wait for a validator to catch up to the cluster")
-                .arg(
-                    pubkey!(Arg::with_name("node_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("node_pubkey")
                         .index(1)
                         .value_name("OUR_VALIDATOR_PUBKEY")
                         .required(false),
-                        "Identity pubkey of the validator"),
-                )
+                    "Identity pubkey of the validator"
+                ))
                 .arg(
                     Arg::with_name("node_json_rpc_url")
                         .index(2)
                         .value_name("OUR_URL")
                         .takes_value(true)
                         .validator(is_url)
-                        .help("JSON RPC URL for validator, which is useful for validators with a private RPC service")
+                        .help(
+                            "JSON RPC URL for validator, which is useful for validators with a \
+                             private RPC service",
+                        ),
                 )
                 .arg(
                     Arg::with_name("follow")
@@ -131,19 +134,19 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .value_name("PORT")
                         .default_value(DEFAULT_RPC_PORT_STR)
                         .validator(is_port)
-                        .help("Guess Identity pubkey and validator rpc node assuming local (possibly private) validator"),
+                        .help(
+                            "Guess Identity pubkey and validator rpc node assuming local \
+                             (possibly private) validator",
+                        ),
                 )
-                .arg(
-                    Arg::with_name("log")
-                        .long("log")
-                        .takes_value(false)
-                        .help("Don't update the progress inplace; instead show updates with its own new lines"),
-                ),
+                .arg(Arg::with_name("log").long("log").takes_value(false).help(
+                    "Don't update the progress inplace; instead show updates with its own new \
+                     lines",
+                )),
         )
-        .subcommand(
-            SubCommand::with_name("cluster-date")
-                .about("Get current cluster date, computed from genesis creation time and network time"),
-        )
+        .subcommand(SubCommand::with_name("cluster-date").about(
+            "Get current cluster date, computed from genesis creation time and network time",
+        ))
         .subcommand(
             SubCommand::with_name("cluster-version")
                 .about("Get the version of the cluster entrypoint"),
@@ -151,94 +154,97 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         // Deprecated in v1.8.0
         .subcommand(
             SubCommand::with_name("fees")
-            .about("Display current cluster fees (Deprecated in v1.8.0)")
-            .arg(
-                Arg::with_name("blockhash")
-                    .long("blockhash")
-                    .takes_value(true)
-                    .value_name("BLOCKHASH")
-                    .validator(is_hash)
-                    .help("Query fees for BLOCKHASH instead of the the most recent blockhash")
-            ),
+                .about("Display current cluster fees (Deprecated in v1.8.0)")
+                .arg(
+                    Arg::with_name("blockhash")
+                        .long("blockhash")
+                        .takes_value(true)
+                        .value_name("BLOCKHASH")
+                        .validator(is_hash)
+                        .help("Query fees for BLOCKHASH instead of the the most recent blockhash"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("first-available-block")
                 .about("Get the first available block in the storage"),
         )
-        .subcommand(SubCommand::with_name("block-time")
-            .about("Get estimated production time of a block")
-            .alias("get-block-time")
-            .arg(
-                Arg::with_name("slot")
-                    .index(1)
-                    .takes_value(true)
-                    .value_name("SLOT")
-                    .help("Slot number of the block to query")
-            )
+        .subcommand(
+            SubCommand::with_name("block-time")
+                .about("Get estimated production time of a block")
+                .alias("get-block-time")
+                .arg(
+                    Arg::with_name("slot")
+                        .index(1)
+                        .takes_value(true)
+                        .value_name("SLOT")
+                        .help("Slot number of the block to query"),
+                ),
         )
-        .subcommand(SubCommand::with_name("leader-schedule")
-            .about("Display leader schedule")
-            .arg(
-                Arg::with_name("epoch")
-                    .long("epoch")
-                    .takes_value(true)
-                    .value_name("EPOCH")
-                    .validator(is_epoch)
-                    .help("Epoch to show leader schedule for. [default: current]")
-            )
+        .subcommand(
+            SubCommand::with_name("leader-schedule")
+                .about("Display leader schedule")
+                .arg(
+                    Arg::with_name("epoch")
+                        .long("epoch")
+                        .takes_value(true)
+                        .value_name("EPOCH")
+                        .validator(is_epoch)
+                        .help("Epoch to show leader schedule for. [default: current]"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("epoch-info")
-            .about("Get information about the current epoch")
-            .alias("get-epoch-info"),
+                .about("Get information about the current epoch")
+                .alias("get-epoch-info"),
         )
         .subcommand(
             SubCommand::with_name("genesis-hash")
-            .about("Get the genesis hash")
-            .alias("get-genesis-hash")
+                .about("Get the genesis hash")
+                .alias("get-genesis-hash"),
         )
         .subcommand(
-            SubCommand::with_name("slot").about("Get current slot")
-            .alias("get-slot"),
+            SubCommand::with_name("slot")
+                .about("Get current slot")
+                .alias("get-slot"),
+        )
+        .subcommand(SubCommand::with_name("block-height").about("Get current block height"))
+        .subcommand(SubCommand::with_name("epoch").about("Get current epoch"))
+        .subcommand(
+            SubCommand::with_name("largest-accounts")
+                .about("Get addresses of largest cluster accounts")
+                .arg(
+                    Arg::with_name("circulating")
+                        .long("circulating")
+                        .takes_value(false)
+                        .help("Filter address list to only circulating accounts"),
+                )
+                .arg(
+                    Arg::with_name("non_circulating")
+                        .long("non-circulating")
+                        .takes_value(false)
+                        .conflicts_with("circulating")
+                        .help("Filter address list to only non-circulating accounts"),
+                ),
         )
         .subcommand(
-            SubCommand::with_name("block-height").about("Get current block height"),
+            SubCommand::with_name("supply")
+                .about("Get information about the cluster supply of SOL")
+                .arg(
+                    Arg::with_name("print_accounts")
+                        .long("print-accounts")
+                        .takes_value(false)
+                        .help("Print list of non-circualting account addresses"),
+                ),
         )
         .subcommand(
-            SubCommand::with_name("epoch").about("Get current epoch"),
+            SubCommand::with_name("total-supply")
+                .about("Get total number of SOL")
+                .setting(AppSettings::Hidden),
         )
         .subcommand(
-            SubCommand::with_name("largest-accounts").about("Get addresses of largest cluster accounts")
-            .arg(
-                Arg::with_name("circulating")
-                    .long("circulating")
-                    .takes_value(false)
-                    .help("Filter address list to only circulating accounts")
-            )
-            .arg(
-                Arg::with_name("non_circulating")
-                    .long("non-circulating")
-                    .takes_value(false)
-                    .conflicts_with("circulating")
-                    .help("Filter address list to only non-circulating accounts")
-            ),
-        )
-        .subcommand(
-            SubCommand::with_name("supply").about("Get information about the cluster supply of SOL")
-            .arg(
-                Arg::with_name("print_accounts")
-                    .long("print-accounts")
-                    .takes_value(false)
-                    .help("Print list of non-circualting account addresses")
-            ),
-        )
-        .subcommand(
-            SubCommand::with_name("total-supply").about("Get total number of SOL")
-            .setting(AppSettings::Hidden),
-        )
-        .subcommand(
-            SubCommand::with_name("transaction-count").about("Get current transaction count")
-            .alias("get-transaction-count"),
+            SubCommand::with_name("transaction-count")
+                .about("Get current transaction count")
+                .alias("get-transaction-count"),
         )
         .subcommand(
             SubCommand::with_name("ping")
@@ -265,7 +271,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .short("D")
                         .long("print-timestamp")
                         .takes_value(false)
-                        .help("Print timestamp (unix time + microseconds as in gettimeofday) before each line"),
+                        .help(
+                            "Print timestamp (unix time + microseconds as in gettimeofday) before \
+                             each line",
+                        ),
                 )
                 .arg(
                     Arg::with_name("timeout")
@@ -286,20 +295,17 @@ impl ClusterQuerySubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("logs")
                 .about("Stream transaction logs")
-                .arg(
-                    pubkey!(Arg::with_name("address")
-                        .index(1)
-                        .value_name("ADDRESS"),
-                        "Account address to monitor \
-                         [default: monitor all transactions except for votes] \
-                        ")
-                )
+                .arg(pubkey!(
+                    Arg::with_name("address").index(1).value_name("ADDRESS"),
+                    "Account address to monitor [default: monitor all transactions except for \
+                     votes] "
+                ))
                 .arg(
                     Arg::with_name("include_votes")
                         .long("include-votes")
                         .takes_value(false)
                         .conflicts_with("address")
-                        .help("Include vote transactions when monitoring all transactions")
+                        .help("Include vote transactions when monitoring all transactions"),
                 ),
         )
         .subcommand(
@@ -316,13 +322,16 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("slot_limit")
                         .long("slot-limit")
                         .takes_value(true)
-                        .help("Limit results to this many slots from the end of the epoch [default: full epoch]"),
+                        .help(
+                            "Limit results to this many slots from the end of the epoch [default: \
+                             full epoch]",
+                        ),
                 ),
         )
         .subcommand(
             SubCommand::with_name("gossip")
                 .about("Show the current gossip network nodes")
-                .alias("show-gossip")
+                .alias("show-gossip"),
         )
         .subcommand(
             SubCommand::with_name("stakes")
@@ -333,19 +342,19 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(false)
                         .help("Display balance in lamports instead of SOL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkeys")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkeys")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .multiple(true),
-                        "Only show stake accounts delegated to the provided vote accounts. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("withdraw_authority")
-                    .value_name("PUBKEY")
-                    .long("withdraw-authority"),
-                    "Only show stake accounts with the provided withdraw authority. "),
-                ),
+                    "Only show stake accounts delegated to the provided vote accounts. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("withdraw_authority")
+                        .value_name("PUBKEY")
+                        .long("withdraw-authority"),
+                    "Only show stake accounts with the provided withdraw authority. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("validators")
@@ -394,7 +403,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                     Arg::with_name("keep_unstaked_delinquents")
                         .long("keep-unstaked-delinquents")
                         .takes_value(false)
-                        .help("Don't discard unstaked, delinquent validators")
+                        .help("Don't discard unstaked, delinquent validators"),
                 )
                 .arg(
                     Arg::with_name("delinquent_slot_distance")
@@ -402,25 +411,27 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("SLOT_DISTANCE")
                         .validator(is_slot)
-                        .help(
-                            concatcp!(
-                                "Minimum slot distance from the tip to consider a validator delinquent. [default: ",
-                                DELINQUENT_VALIDATOR_SLOT_DISTANCE,
-                                "]",
-                        ))
+                        .help(concatcp!(
+                            "Minimum slot distance from the tip to consider a validator \
+                             delinquent. [default: ",
+                            DELINQUENT_VALIDATOR_SLOT_DISTANCE,
+                            "]",
+                        )),
                 ),
         )
         .subcommand(
             SubCommand::with_name("transaction-history")
-                .about("Show historical transactions affecting the given address \
-                        from newest to oldest")
-                .arg(
-                    pubkey!(Arg::with_name("address")
+                .about(
+                    "Show historical transactions affecting the given address from newest to \
+                     oldest",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("address")
                         .index(1)
                         .value_name("ADDRESS")
                         .required(true),
-                        "Account address"),
-                )
+                    "Account address"
+                ))
                 .arg(
                     Arg::with_name("limit")
                         .long("limit")
@@ -442,18 +453,22 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("until")
                         .value_name("TRANSACTION_SIGNATURE")
                         .takes_value(true)
-                        .help("List until this transaction signature, if found before limit reached"),
+                        .help(
+                            "List until this transaction signature, if found before limit reached",
+                        ),
                 )
                 .arg(
                     Arg::with_name("show_transactions")
                         .long("show-transactions")
                         .takes_value(false)
                         .help("Display the full transactions"),
-                )
+                ),
         )
         .subcommand(
             SubCommand::with_name("wait-for-max-stake")
-                .about("Wait for the max stake of any one node to drop below a percentage of total.")
+                .about(
+                    "Wait for the max stake of any one node to drop below a percentage of total.",
+                )
                 .arg(
                     Arg::with_name("max_percent")
                         .long("max-percent")
@@ -475,7 +490,10 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                                 .map(|_| ())
                                 .map_err(|e| e.to_string())
                         })
-                        .help("Length of data field in the account to calculate rent for, or moniker: [nonce, stake, system, vote]"),
+                        .help(
+                            "Length of data field in the account to calculate rent for, or \
+                             moniker: [nonce, stake, system, vote]",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lamports")
@@ -502,8 +520,8 @@ pub fn parse_catchup(
     // requirement of node_pubkey is relaxed only if our_localhost_port
     if our_localhost_port.is_none() && node_pubkey.is_none() {
         return Err(CliError::BadParameter(
-            "OUR_VALIDATOR_PUBKEY (and possibly OUR_URL) must be specified \
-             unless --our-localhost is given"
+            "OUR_VALIDATOR_PUBKEY (and possibly OUR_URL) must be specified unless --our-localhost \
+             is given"
                 .into(),
         ));
     }
@@ -737,8 +755,7 @@ pub fn process_catchup(
         if node_json_rpc_url.is_some() && node_json_rpc_url != gussed_default {
             // go to new line to leave this message on console
             println!(
-                "Prefering explicitly given rpc ({}) as us, \
-                 although --our-localhost is given\n",
+                "Prefering explicitly given rpc ({}) as us, although --our-localhost is given\n",
                 node_json_rpc_url.as_ref().unwrap()
             );
         } else {
@@ -754,8 +771,8 @@ pub fn process_catchup(
             (if node_pubkey.is_some() && node_pubkey != guessed_default {
                 // go to new line to leave this message on console
                 println!(
-                    "Prefering explicitly given node pubkey ({}) as us, \
-                     although --our-localhost is given\n",
+                    "Prefering explicitly given node pubkey ({}) as us, although --our-localhost \
+                     is given\n",
                     node_pubkey.unwrap()
                 );
                 node_pubkey
@@ -807,13 +824,18 @@ pub fn process_catchup(
 
     if reported_node_pubkey != node_pubkey {
         return Err(format!(
-            "The identity reported by node RPC URL does not match.  Expected: {node_pubkey:?}.  Reported: {reported_node_pubkey:?}"
+            "The identity reported by node RPC URL does not match.  Expected: {node_pubkey:?}.  \
+             Reported: {reported_node_pubkey:?}"
         )
         .into());
     }
 
     if rpc_client.get_identity()? == node_pubkey {
-        return Err("Both RPC URLs reference the same node, unable to monitor for catchup.  Try a different --url".into());
+        return Err(
+            "Both RPC URLs reference the same node, unable to monitor for catchup.  Try a \
+             different --url"
+                .into(),
+        );
     }
 
     let mut previous_rpc_slot = std::u64::MAX;
@@ -1213,44 +1235,45 @@ pub fn process_show_block_production(
         CliError::RpcRequestError("Failed to deserialize slot history".to_string())
     })?;
 
-    let (confirmed_blocks, start_slot) = if start_slot >= slot_history.oldest()
-        && end_slot <= slot_history.newest()
-    {
-        // Fast, more reliable path using the SlotHistory sysvar
+    let (confirmed_blocks, start_slot) =
+        if start_slot >= slot_history.oldest() && end_slot <= slot_history.newest() {
+            // Fast, more reliable path using the SlotHistory sysvar
 
-        let confirmed_blocks: Vec<_> = (start_slot..=end_slot)
-            .filter(|slot| slot_history.check(*slot) == slot_history::Check::Found)
-            .collect();
-        (confirmed_blocks, start_slot)
-    } else {
-        // Slow, less reliable path using `getBlocks`.
-        //
-        // "less reliable" because if the RPC node has holds in its ledger then the block production data will be
-        // incorrect.  This condition currently can't be detected over RPC
-        //
+            let confirmed_blocks: Vec<_> = (start_slot..=end_slot)
+                .filter(|slot| slot_history.check(*slot) == slot_history::Check::Found)
+                .collect();
+            (confirmed_blocks, start_slot)
+        } else {
+            // Slow, less reliable path using `getBlocks`.
+            //
+            // "less reliable" because if the RPC node has holds in its ledger then the block production data will be
+            // incorrect.  This condition currently can't be detected over RPC
+            //
 
-        let minimum_ledger_slot = rpc_client.minimum_ledger_slot()?;
-        if minimum_ledger_slot > end_slot {
-            return Err(format!(
-                    "Ledger data not available for slots {start_slot} to {end_slot} (minimum ledger slot is {minimum_ledger_slot})"
+            let minimum_ledger_slot = rpc_client.minimum_ledger_slot()?;
+            if minimum_ledger_slot > end_slot {
+                return Err(format!(
+                    "Ledger data not available for slots {start_slot} to {end_slot} (minimum \
+                     ledger slot is {minimum_ledger_slot})"
                 )
                 .into());
-        }
+            }
 
-        if minimum_ledger_slot > start_slot {
-            progress_bar.println(format!(
+            if minimum_ledger_slot > start_slot {
+                progress_bar.println(format!(
                     "{}",
                     style(format!(
-                        "Note: Requested start slot was {start_slot} but minimum ledger slot is {minimum_ledger_slot}"
+                        "Note: Requested start slot was {start_slot} but minimum ledger slot is \
+                         {minimum_ledger_slot}"
                     ))
                     .italic(),
                 ));
-            start_slot = minimum_ledger_slot;
-        }
+                start_slot = minimum_ledger_slot;
+            }
 
-        let confirmed_blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
-        (confirmed_blocks, start_slot)
-    };
+            let confirmed_blocks = rpc_client.get_blocks(start_slot, Some(end_slot))?;
+            (confirmed_blocks, start_slot)
+        };
 
     let start_slot_index = (start_slot - first_slot_in_epoch) as usize;
     let end_slot_index = (end_slot - first_slot_in_epoch) as usize;
@@ -1281,7 +1304,8 @@ pub fn process_show_block_production(
     }
 
     progress_bar.set_message(format!(
-        "Processing {total_slots} slots containing {total_blocks_produced} blocks and {total_slots_skipped} empty slots..."
+        "Processing {total_slots} slots containing {total_blocks_produced} blocks and \
+         {total_slots_skipped} empty slots..."
     ));
 
     let mut confirmed_blocks_index = 0;

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -189,7 +189,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("EPOCH")
                         .validator(is_epoch)
-                        .help("Epoch to show leader schedule for. [default: current]"),
+                        .help("Epoch to show leader schedule for [default: current]"),
                 ),
         )
         .subcommand(
@@ -323,8 +323,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .long("slot-limit")
                         .takes_value(true)
                         .help(
-                            "Limit results to this many slots from the end of the epoch [default: \
-                             full epoch]",
+                            "Limit results to this many slots from the end of the epoch \
+                            [default: full epoch]",
                         ),
                 ),
         )
@@ -413,7 +413,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .validator(is_slot)
                         .help(concatcp!(
                             "Minimum slot distance from the tip to consider a validator \
-                             delinquent. [default: ",
+                             delinquent [default: ",
                             DELINQUENT_VALIDATOR_SLOT_DISTANCE,
                             "]",
                         )),

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -240,7 +240,9 @@ impl fmt::Display for CliClusterSoftwareVersions {
             f,
             "{}",
             style(format!(
-                "{software_version_title:<max_software_version_len$}  {stake_percent_title:>max_stake_percent_len$}  {rpc_percent_title:>max_rpc_percent_len$}",
+                "{software_version_title:<max_software_version_len$}  \
+                 {stake_percent_title:>max_stake_percent_len$}  \
+                 {rpc_percent_title:>max_rpc_percent_len$}",
             ))
             .bold(),
         )?;
@@ -318,8 +320,12 @@ impl fmt::Display for CliClusterFeatureSets {
             writeln!(
                 f,
                 "\n{}",
-                style("To activate features the tool and cluster feature sets must match, select a tool version that matches the cluster")
-                    .bold())?;
+                style(
+                    "To activate features the tool and cluster feature sets must match, select a \
+                     tool version that matches the cluster"
+                )
+                .bold()
+            )?;
         } else {
             if !self.stake_allowed {
                 write!(
@@ -349,7 +355,10 @@ impl fmt::Display for CliClusterFeatureSets {
             f,
             "{}",
             style(format!(
-                "{software_versions_title:<max_software_versions_len$}  {feature_set_title:<max_feature_set_len$}  {stake_percent_title:>max_stake_percent_len$}  {rpc_percent_title:>max_rpc_percent_len$}",
+                "{software_versions_title:<max_software_versions_len$}  \
+                 {feature_set_title:<max_feature_set_len$}  \
+                 {stake_percent_title:>max_stake_percent_len$}  \
+                 {rpc_percent_title:>max_rpc_percent_len$}",
             ))
             .bold(),
         )?;
@@ -402,8 +411,8 @@ fn check_rpc_genesis_hash(
         if rpc_genesis_hash != genesis_hash {
             return Err(format!(
                 "The genesis hash for the specified cluster {cluster_type:?} does not match the \
-                genesis hash reported by the specified RPC. Cluster genesis hash: {genesis_hash}, \
-                RPC reported genesis hash: {rpc_genesis_hash}"
+                 genesis hash reported by the specified RPC. Cluster genesis hash: \
+                 {genesis_hash}, RPC reported genesis hash: {rpc_genesis_hash}"
             )
             .into());
         }
@@ -927,11 +936,17 @@ fn process_activate(
 
     if !feature_activation_allowed(rpc_client, false)?.0 {
         match force {
-        ForceActivation::Almost =>
-            return Err("Add force argument once more to override the sanity check to force feature activation ".into()),
-        ForceActivation::Yes => println!("FEATURE ACTIVATION FORCED"),
-        ForceActivation::No =>
-            return Err("Feature activation is not allowed at this time".into()),
+            ForceActivation::Almost => {
+                return Err(
+                    "Add force argument once more to override the sanity check to force feature \
+                     activation "
+                        .into(),
+                )
+            }
+            ForceActivation::Yes => println!("FEATURE ACTIVATION FORCED"),
+            ForceActivation::No => {
+                return Err("Feature activation is not allowed at this time".into())
+            }
         }
     }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -27,7 +27,8 @@ fn parse_settings(matches: &ArgMatches<'_>) -> Result<bool, Box<dyn error::Error
             let config_file = match matches.value_of("config_file") {
                 None => {
                     println!(
-                        "{} Either provide the `--config` arg or ensure home directory exists to use the default config location",
+                        "{} Either provide the `--config` arg or ensure home directory exists to \
+                         use the default config location",
                         style("No config file found.").bold()
                     );
                     return Ok(false);

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -48,20 +48,20 @@ impl NonceSubCommands for App<'_, '_> {
         self.subcommand(
             SubCommand::with_name("authorize-nonce-account")
                 .about("Assign account authority to a new entity")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_authority")
+                    "Address of the nonce account. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_authority")
                         .index(2)
                         .value_name("AUTHORITY_PUBKEY")
                         .required(true),
-                        "Account to be granted authority of the nonce account. "),
-                )
+                    "Account to be granted authority of the nonce account. "
+                ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -85,20 +85,26 @@ impl NonceSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount_or_all)
-                        .help("The amount to load the nonce account with, in SOL; accepts keyword ALL"),
+                        .help(
+                            "The amount to load the nonce account with, in SOL; accepts keyword \
+                             ALL",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name(NONCE_AUTHORITY_ARG.name)
+                .arg(pubkey!(
+                    Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
                         .value_name("PUBKEY"),
-                        "Assign noncing authority to another entity. "),
-                )
+                    "Assign noncing authority to another entity. "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the NONCE_ACCOUNT pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the NONCE_ACCOUNT pubkey",
+                        ),
                 )
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -107,24 +113,24 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("nonce")
                 .about("Get the current nonce value")
                 .alias("get-nonce")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account to display. "),
-                ),
+                    "Address of the nonce account to display. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("new-nonce")
                 .about("Generate a new nonce, rendering the existing nonce useless")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account. "),
-                )
+                    "Address of the nonce account. "
+                ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
@@ -133,13 +139,13 @@ impl NonceSubCommands for App<'_, '_> {
             SubCommand::with_name("nonce-account")
                 .about("Show the contents of a nonce account")
                 .alias("show-nonce-account")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Address of the nonce account to display. "),
-                )
+                    "Address of the nonce account to display. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -150,20 +156,20 @@ impl NonceSubCommands for App<'_, '_> {
         .subcommand(
             SubCommand::with_name("withdraw-from-nonce-account")
                 .about("Withdraw SOL from the nonce account")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Nonce account to withdraw from. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Nonce account to withdraw from. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The account to which the SOL should be transferred. "),
-                )
+                    "The account to which the SOL should be transferred. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -179,15 +185,17 @@ impl NonceSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("upgrade-nonce-account")
-                .about("One-time idempotent upgrade of legacy nonce versions \
-                        in order to bump them out of chain blockhash domain.")
-                .arg(
-                    pubkey!(Arg::with_name("nonce_account_pubkey")
+                .about(
+                    "One-time idempotent upgrade of legacy nonce versions in order to bump them \
+                     out of chain blockhash domain.",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("nonce_account_pubkey")
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Nonce account to upgrade. "),
-                )
+                    "Nonce account to upgrade. "
+                ))
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),
         )
@@ -502,7 +510,8 @@ pub fn process_create_nonce_account(
     let minimum_balance = rpc_client.get_minimum_balance_for_rent_exemption(State::size())?;
     if lamports < minimum_balance {
         return Err(CliError::BadParameter(format!(
-            "need at least {minimum_balance} lamports for nonce account to be rent exempt, provided lamports: {lamports}"
+            "need at least {minimum_balance} lamports for nonce account to be rent exempt, \
+             provided lamports: {lamports}"
         ))
         .into());
     }

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -198,8 +198,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(false)
                                 .help(
-                                    "Maximum length of the upgradeable program [default: twice \
-                                     the length of the original deployed program]",
+                                    "Maximum length of the upgradeable program \
+                                    [default: twice the length of the original deployed program]",
                                 ),
                         )
                         .arg(
@@ -248,8 +248,8 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(false)
                                 .help(
-                                    "Maximum length of the upgradeable program [default: twice \
-                                     the length of the original deployed program]",
+                                    "Maximum length of the upgradeable program \
+                                    [default: twice the length of the original deployed program]",
                                 ),
                         ),
                 )

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -63,10 +63,10 @@ use {
     },
 };
 
-pub const CLOSE_PROGRAM_WARNING: &str = "WARNING! \
-Closed programs cannot be recreated at the same program id. \
-Once a program is closed, it can never be invoked again. \
-To proceed with closing, rerun the `close` command with the `--bypass-warning` flag";
+pub const CLOSE_PROGRAM_WARNING: &str = "WARNING! Closed programs cannot be recreated at the same \
+                                         program id. Once a program is closed, it can never be \
+                                         invoked again. To proceed with closing, rerun the \
+                                         `close` command with the `--bypass-warning` flag";
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ProgramCliCommand {
@@ -145,7 +145,7 @@ impl ProgramSubCommands for App<'_, '_> {
                         .long("skip-fee-check")
                         .hidden(hidden_unless_forced())
                         .takes_value(false)
-                        .global(true)
+                        .global(true),
                 )
                 .subcommand(
                     SubCommand::with_name("deploy")
@@ -163,8 +163,10 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Intermediate buffer account to write data to, which can be used to resume a failed deploy \
-                                      [default: random address]")
+                                .help(
+                                    "Intermediate buffer account to write data to, which can be \
+                                     used to resume a failed deploy [default: random address]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("upgrade_authority")
@@ -172,19 +174,22 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("UPGRADE_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade authority [default: the default configured keypair]",
+                                ),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("program_id")
+                        .arg(pubkey!(
+                            Arg::with_name("program_id")
                                 .long("program-id")
                                 .value_name("PROGRAM_ID"),
-                                "Executable program's address, must be a keypair for initial deploys, can be a pubkey for upgrades \
-                                [default: address of keypair at /path/to/program-keypair.json if present, otherwise a random address]"),
-                        )
+                            "Executable program's address, must be a keypair for initial deploys, \
+                             can be a pubkey for upgrades [default: address of keypair at \
+                             /path/to/program-keypair.json if present, otherwise a random address]"
+                        ))
                         .arg(
                             Arg::with_name("final")
                                 .long("final")
-                                .help("The program will not be upgradeable")
+                                .help("The program will not be upgradeable"),
                         )
                         .arg(
                             Arg::with_name("max_len")
@@ -192,14 +197,19 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("max_len")
                                 .takes_value(true)
                                 .required(false)
-                                .help("Maximum length of the upgradeable program \
-                                      [default: twice the length of the original deployed program]")
+                                .help(
+                                    "Maximum length of the upgradeable program [default: twice \
+                                     the length of the original deployed program]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("allow_excessive_balance")
                                 .long("allow-excessive-deploy-account-balance")
                                 .takes_value(false)
-                                .help("Use the designated program id even if the account already holds a large balance of SOL")
+                                .help(
+                                    "Use the designated program id even if the account already \
+                                     holds a large balance of SOL",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -219,7 +229,9 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer account to write data into [default: random address]")
+                                .help(
+                                    "Buffer account to write data into [default: random address]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("buffer_authority")
@@ -227,7 +239,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer authority [default: the default configured keypair]")
+                                .help("Buffer authority [default: the default configured keypair]"),
                         )
                         .arg(
                             Arg::with_name("max_len")
@@ -235,8 +247,10 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("max_len")
                                 .takes_value(true)
                                 .required(false)
-                                .help("Maximum length of the upgradeable program \
-                                      [default: twice the length of the original deployed program]")
+                                .help(
+                                    "Maximum length of the upgradeable program [default: twice \
+                                     the length of the original deployed program]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -248,7 +262,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_PUBKEY")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Public key of the buffer")
+                                .help("Public key of the buffer"),
                         )
                         .arg(
                             Arg::with_name("buffer_authority")
@@ -256,15 +270,15 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("BUFFER_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Buffer authority [default: the default configured keypair]")
+                                .help("Buffer authority [default: the default configured keypair]"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("new_buffer_authority")
+                        .arg(pubkey!(
+                            Arg::with_name("new_buffer_authority")
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
                                 .required(true),
-                                "Address of the new buffer authority"),
-                        )
+                            "Address of the new buffer authority"
+                        )),
                 )
                 .subcommand(
                     SubCommand::with_name("set-upgrade-authority")
@@ -275,7 +289,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the program to upgrade")
+                                .help("Address of the program to upgrade"),
                         )
                         .arg(
                             Arg::with_name("upgrade_authority")
@@ -283,7 +297,9 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("UPGRADE_AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade authority [default: the default configured keypair]",
+                                ),
                         )
                         .arg(
                             Arg::with_name("new_upgrade_authority")
@@ -291,21 +307,32 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("NEW_UPGRADE_AUTHORITY")
                                 .required_unless("final")
                                 .takes_value(true)
-                                .help("New upgrade authority (keypair or pubkey). It is strongly recommended to pass in a keypair to prevent mistakes in setting the upgrade authority. You can opt out of this behavior by passing --skip-new-upgrade-authority-signer-check if you are really confident that you are setting the correct authority. Alternatively, If you wish to make the program immutable, you should ignore this arg and pass the --final flag."
-                        )
+                                .help(
+                                    "New upgrade authority (keypair or pubkey). It is strongly \
+                                     recommended to pass in a keypair to prevent mistakes in \
+                                     setting the upgrade authority. You can opt out of this \
+                                     behavior by passing \
+                                     --skip-new-upgrade-authority-signer-check if you are really \
+                                     confident that you are setting the correct authority. \
+                                     Alternatively, If you wish to make the program immutable, \
+                                     you should ignore this arg and pass the --final flag.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("final")
                                 .long("final")
                                 .conflicts_with("new_upgrade_authority")
-                                .help("The program will not be upgradeable")
+                                .help("The program will not be upgradeable"),
                         )
                         .arg(
                             Arg::with_name("skip_new_upgrade_authority_signer_check")
                                 .long("skip-new-upgrade-authority-signer-check")
                                 .requires("new_upgrade_authority")
                                 .takes_value(false)
-                                .help("Set this flag if you don't want the new authority to sign the set-upgrade-authority transaction."),
+                                .help(
+                                    "Set this flag if you don't want the new authority to sign \
+                                     the set-upgrade-authority transaction.",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -316,7 +343,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the buffer or program to show")
+                                .help("Address of the buffer or program to show"),
                         )
                         .arg(
                             Arg::with_name("programs")
@@ -324,7 +351,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .conflicts_with("account")
                                 .conflicts_with("buffers")
                                 .required_unless_one(&["account", "buffers"])
-                                .help("Show every upgradeable program that matches the authority")
+                                .help("Show every upgradeable program that matches the authority"),
                         )
                         .arg(
                             Arg::with_name("buffers")
@@ -332,22 +359,22 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .conflicts_with("account")
                                 .conflicts_with("programs")
                                 .required_unless_one(&["account", "programs"])
-                                .help("Show every upgradeable buffer that matches the authority")
+                                .help("Show every upgradeable buffer that matches the authority"),
                         )
                         .arg(
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
                                 .conflicts_with("buffer_authority")
-                                .help("Show accounts for all authorities")
+                                .help("Show accounts for all authorities"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("buffer_authority")
+                        .arg(pubkey!(
+                            Arg::with_name("buffer_authority")
                                 .long("buffer-authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                                "Authority [default: the default configured keypair]"),
-                        )
+                            "Authority [default: the default configured keypair]"
+                        ))
                         .arg(
                             Arg::with_name("lamports")
                                 .long("lamports")
@@ -364,7 +391,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the buffer or program")
+                                .help("Address of the buffer or program"),
                         )
                         .arg(
                             Arg::with_name("output_location")
@@ -390,7 +417,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("buffers")
                                 .conflicts_with("account")
                                 .required_unless("account")
-                                .help("Close all buffer accounts that match the authority")
+                                .help("Close all buffer accounts that match the authority"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -399,15 +426,18 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Upgrade or buffer authority [default: the default configured keypair]")
+                                .help(
+                                    "Upgrade or buffer authority [default: the default configured \
+                                     keypair]",
+                                ),
                         )
-
-                        .arg(
-                            pubkey!(Arg::with_name("recipient_account")
+                        .arg(pubkey!(
+                            Arg::with_name("recipient_account")
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
-                                "Address of the account to deposit the closed account's lamports [default: the default configured keypair]"),
-                        )
+                            "Address of the account to deposit the closed account's lamports \
+                             [default: the default configured keypair]"
+                        ))
                         .arg(
                             Arg::with_name("lamports")
                                 .long("lamports")
@@ -423,7 +453,9 @@ impl ProgramSubCommands for App<'_, '_> {
                 )
                 .subcommand(
                     SubCommand::with_name("extend")
-                        .about("Extend the length of an upgradeable program to deploy larger programs")
+                        .about(
+                            "Extend the length of an upgradeable program to deploy larger programs",
+                        )
                         .arg(
                             Arg::with_name("program_id")
                                 .index(1)
@@ -440,14 +472,20 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .takes_value(true)
                                 .required(true)
                                 .validator(is_parsable::<u32>)
-                                .help("Number of bytes that will be allocated for the program's data account")
-                        )
-                )
+                                .help(
+                                    "Number of bytes that will be allocated for the program's \
+                                     data account",
+                                ),
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("deploy")
-                .about("Deploy has been removed. Use `solana program deploy` instead to deploy upgradeable programs")
-                .setting(AppSettings::Hidden)
+                .about(
+                    "Deploy has been removed. Use `solana program deploy` instead to deploy \
+                     upgradeable programs",
+                )
+                .setting(AppSettings::Hidden),
         )
     }
 }
@@ -1381,7 +1419,8 @@ fn get_programs(
             let results = get_accounts_with_filter(rpc_client, filters, 0)?;
             if results.len() != 1 {
                 return Err(format!(
-                    "Error: More than one Program associated with ProgramData account {programdata_address}"
+                    "Error: More than one Program associated with ProgramData account \
+                     {programdata_address}"
                 )
                 .into());
             }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -114,7 +114,10 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program account signer. The program data is written to the associated account.")
+                                .help(
+                                    "Program account signer. The program data is written to the \
+                                     associated account.",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -122,7 +125,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -140,7 +145,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("buffer")
@@ -148,7 +153,10 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("BUFFER_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Optional intermediate buffer account to write data to, which can be used to resume a failed deploy")
+                                .help(
+                                    "Optional intermediate buffer account to write data to, which \
+                                     can be used to resume a failed deploy",
+                                ),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -156,7 +164,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -167,7 +177,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -175,7 +185,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -186,7 +198,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("program-id")
                                 .value_name("PROGRAM_ID")
                                 .takes_value(true)
-                                .help("Executable program's address")
+                                .help("Executable program's address"),
                         )
                         .arg(
                             Arg::with_name("authority")
@@ -194,7 +206,9 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("AUTHORITY_SIGNER")
                                 .takes_value(true)
                                 .validator(is_valid_signer)
-                                .help("Program authority [default: the default configured keypair]")
+                                .help(
+                                    "Program authority [default: the default configured keypair]",
+                                ),
                         ),
                 )
                 .subcommand(
@@ -205,22 +219,22 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
-                                .help("Address of the program to show")
+                                .help("Address of the program to show"),
                         )
                         .arg(
                             Arg::with_name("all")
                                 .long("all")
                                 .conflicts_with("account")
                                 .conflicts_with("buffer_authority")
-                                .help("Show accounts for all authorities")
+                                .help("Show accounts for all authorities"),
                         )
-                        .arg(
-                            pubkey!(Arg::with_name("authority")
+                        .arg(pubkey!(
+                            Arg::with_name("authority")
                                 .long("authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                                "Authority [default: the default configured keypair]"),
-                        ),
+                            "Authority [default: the default configured keypair]"
+                        )),
                 )
                 .subcommand(
                     SubCommand::with_name("dump")
@@ -231,7 +245,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .value_name("ACCOUNT_ADDRESS")
                                 .takes_value(true)
                                 .required(true)
-                                .help("Address of the buffer or program")
+                                .help("Address of the buffer or program"),
                         )
                         .arg(
                             Arg::with_name("output_location")
@@ -241,7 +255,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .required(true)
                                 .help("/path/to/program.so"),
                         ),
-                )
+                ),
         )
     }
 }
@@ -955,7 +969,11 @@ fn build_create_buffer_message(
 
         if account.lamports < lamports_required || account.data.len() != expected_account_data_len {
             if program_address == buffer_address {
-                return Err("Buffer account passed could be for a different deploy? It has different size/lamports".into());
+                return Err(
+                    "Buffer account passed could be for a different deploy? It has different \
+                     size/lamports"
+                        .into(),
+                );
             }
 
             let (truncate_instructions, balance_needed) = build_truncate_instructions(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -164,7 +164,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .value_name("PUBKEY"),
-                    "Authority to modify lockups. "
+                    "Authority to modify lockups"
                 ))
                 .arg(
                     Arg::with_name("seed")
@@ -783,8 +783,8 @@ impl StakeSubCommands for App<'_, '_> {
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help(
-                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
-                             only]",
+                            "Display rewards for NUM recent epochs, max 10 \
+                            [default: latest epoch only]",
                         ),
                 ),
         )

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -144,7 +144,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create (or base of derived address if --seed is used)")
+                        .help(
+                            "Stake account to create (or base of derived address if --seed is \
+                             used)",
+                        ),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -153,28 +156,35 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to send to the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("custodian")
+                .arg(pubkey!(
+                    Arg::with_name("custodian")
                         .long("custodian")
                         .value_name("PUBKEY"),
-                        "Authority to modify lockups. ")
-                )
+                    "Authority to modify lockups. "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -182,7 +192,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name(STAKE_AUTHORITY_ARG.name)
@@ -190,7 +203,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(STAKE_AUTHORITY_ARG.help)
+                        .help(STAKE_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
@@ -198,7 +211,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(WITHDRAW_AUTHORITY_ARG.help)
+                        .help(WITHDRAW_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name("from")
@@ -212,7 +225,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("create-stake-account-checked")
@@ -224,7 +237,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create (or base of derived address if --seed is used)")
+                        .help(
+                            "Stake account to create (or base of derived address if --seed is \
+                             used)",
+                        ),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -233,15 +249,19 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to send to the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to send to the stake account, in SOL; accepts keyword ALL",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the STAKE_ACCOUNT_KEYPAIR pubkey",
+                        ),
                 )
                 .arg(
                     Arg::with_name(STAKE_AUTHORITY_ARG.name)
@@ -249,7 +269,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("PUBKEY")
                         .takes_value(true)
                         .validator(is_valid_pubkey)
-                        .help(STAKE_AUTHORITY_ARG.help)
+                        .help(STAKE_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name(WITHDRAW_AUTHORITY_ARG.name)
@@ -257,7 +277,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .help(WITHDRAW_AUTHORITY_ARG.help)
+                        .help(WITHDRAW_AUTHORITY_ARG.help),
                 )
                 .arg(
                     Arg::with_name("from")
@@ -271,7 +291,7 @@ impl StakeSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("delegate-stake")
@@ -281,28 +301,28 @@ impl StakeSubCommands for App<'_, '_> {
                         .long("force")
                         .takes_value(false)
                         .hidden(hidden_unless_forced()) // Don't document this argument to discourage its use
-                        .help("Override vote account sanity checks (use carefully!)")
+                        .help("Override vote account sanity checks (use carefully!)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to delegate")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                    "Stake account to delegate"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The vote account to which the stake will be delegated")
-                )
+                    "The vote account to which the stake will be delegated"
+                ))
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("redelegate-stake")
@@ -312,24 +332,24 @@ impl StakeSubCommands for App<'_, '_> {
                         .long("force")
                         .takes_value(false)
                         .hidden(hidden_unless_forced()) // Don't document this argument to discourage its use
-                        .help("Override vote account sanity checks (use carefully!)")
+                        .help("Override vote account sanity checks (use carefully!)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Existing delegated stake account that has been fully activated. \
-                        On success this stake account will be scheduled for deactivation and the rent-exempt balance \
-                        may be withdrawn once fully deactivated")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                    "Existing delegated stake account that has been fully activated. On success \
+                     this stake account will be scheduled for deactivation and the rent-exempt \
+                     balance may be withdrawn once fully deactivated"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("REDELEGATED_VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The vote account to which the stake will be redelegated")
-                )
+                    "The vote account to which the stake will be redelegated"
+                ))
                 .arg(
                     Arg::with_name("redelegation_stake_account")
                         .index(3)
@@ -337,42 +357,43 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Stake account to create for the redelegation. \
-                               On success this stake account will be created and scheduled for activation with all \
-                               the stake in the existing stake account, exclusive of the rent-exempt balance retained \
-                               in the existing account")
+                        .help(
+                            "Stake account to create for the redelegation. On success this stake \
+                             account will be created and scheduled for activation with all the \
+                             stake in the existing stake account, exclusive of the rent-exempt \
+                             balance retained in the existing account",
+                        ),
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
-                .arg(memo_arg())
+                .arg(memo_arg()),
         )
-
         .subcommand(
             SubCommand::with_name("stake-authorize")
                 .about("Authorize a new signing keypair for the given stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                        "Stake account in which to set a new authority. ")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_stake_authority")
+                    "Stake account in which to set a new authority. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
                         .required_unless("new_withdraw_authority")
                         .value_name("PUBKEY"),
-                        "New authorized staker")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("new_withdraw_authority")
+                    "New authorized staker"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("new_withdraw_authority")
                         .long("new-withdraw-authority")
                         .required_unless("new_stake_authority")
                         .value_name("PUBKEY"),
-                        "New authorized withdrawer. ")
-                )
+                    "New authorized withdrawer. "
+                ))
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
                 .offline_args()
@@ -383,21 +404,27 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-authorize-checked")
-                .about("Authorize a new signing keypair for the given stake account, checking the authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .about(
+                    "Authorize a new signing keypair for the given stake account, checking the \
+                     authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                        "Stake account in which to set a new authority. ")
-                )
+                    "Stake account in which to set a new authority. "
+                ))
                 .arg(
                     Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
@@ -405,7 +432,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .required_unless("new_withdraw_authority")
-                        .help("New authorized staker")
+                        .help("New authorized staker"),
                 )
                 .arg(
                     Arg::with_name("new_withdraw_authority")
@@ -414,7 +441,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_valid_signer)
                         .required_unless("new_stake_authority")
-                        .help("New authorized withdrawer")
+                        .help("New authorized withdrawer"),
                 )
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
@@ -426,53 +453,62 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("deactivate-stake")
                 .about("Deactivate the delegated stake from the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to be deactivated (or base of derived address if --seed is used). ")
-                )
+                    "Stake account to be deactivated (or base of derived address if --seed is \
+                     used). "
+                ))
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of STAKE_ACCOUNT_ADDRESS")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of STAKE_ACCOUNT_ADDRESS",
+                        ),
                 )
                 .arg(
                     Arg::with_name("delinquent")
                         .long("delinquent")
                         .takes_value(false)
                         .conflicts_with(SIGN_ONLY_ARG.name)
-                        .help("Deactivate abandoned stake that is currently delegated to a delinquent vote account")
+                        .help(
+                            "Deactivate abandoned stake that is currently delegated to a \
+                             delinquent vote account",
+                        ),
                 )
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("split-stake")
                 .about("Duplicate a stake account, splitting the tokens between the two")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to split (or base of derived address if --seed is used). ")
-                )
+                    "Stake account to split (or base of derived address if --seed is used). "
+                ))
                 .arg(
                     Arg::with_name("split_stake_account")
                         .index(2)
@@ -480,7 +516,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("Keypair of the new stake account")
+                        .help("Keypair of the new stake account"),
                 )
                 .arg(
                     Arg::with_name("amount")
@@ -489,18 +525,20 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .required(true)
-                        .help("The amount to move into the new stake account, in SOL")
+                        .help("The amount to move into the new stake account, in SOL"),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of SPLIT_STAKE_ACCOUNT")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of SPLIT_STAKE_ACCOUNT",
+                        ),
                 )
                 .arg(stake_authority_arg())
-                .offline_args_config(&SignOnlySplitNeedsRent{})
+                .offline_args_config(&SignOnlySplitNeedsRent {})
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
@@ -512,52 +550,55 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount)
                         .requires("sign_only")
-                        .help("Offline signing only: the rent-exempt amount to move into the new \
-                                stake account, in SOL")
-                )
+                        .help(
+                            "Offline signing only: the rent-exempt amount to move into the new \
+                             stake account, in SOL",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("merge-stake")
                 .about("Merges one stake account into another")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account to merge into")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("source_stake_account_pubkey")
+                    "Stake account to merge into"
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("source_stake_account_pubkey")
                         .index(2)
                         .value_name("SOURCE_STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Source stake account for the merge.  If successful, this stake account \
-                         will no longer exist after the merge")
-                )
+                    "Source stake account for the merge.  If successful, this stake account will \
+                     no longer exist after the merge"
+                ))
                 .arg(stake_authority_arg())
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("withdraw-stake")
                 .about("Withdraw the unstaked SOL from the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account from which to withdraw (or base of derived address if --seed is used). ")
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Stake account from which to withdraw (or base of derived address if --seed \
+                     is used). "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "Recipient of withdrawn SOL")
-                )
+                    "Recipient of withdrawn SOL"
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -565,15 +606,20 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_amount_or_all)
                         .required(true)
-                        .help("The amount to withdraw from the stake account, in SOL; accepts keyword ALL")
+                        .help(
+                            "The amount to withdraw from the stake account, in SOL; accepts \
+                             keyword ALL",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account \
-                               will be at a derived address of STAKE_ACCOUNT_ADDRESS")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of STAKE_ACCOUNT_ADDRESS",
+                        ),
                 )
                 .arg(withdraw_authority_arg())
                 .offline_args()
@@ -581,24 +627,27 @@ impl StakeSubCommands for App<'_, '_> {
                 .arg(fee_payer_arg())
                 .arg(custodian_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-set-lockup")
                 .about("Set Lockup for the stake account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account for which to set lockup parameters. ")
-                )
+                    "Stake account for which to set lockup parameters. "
+                ))
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -606,48 +655,56 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_custodian")
+                .arg(pubkey!(
+                    Arg::with_name("new_custodian")
                         .long("new-custodian")
                         .value_name("PUBKEY"),
-                        "Identity of a new lockup custodian. ")
+                    "Identity of a new lockup custodian. "
+                ))
+                .group(
+                    ArgGroup::with_name("lockup_details")
+                        .args(&["lockup_epoch", "lockup_date", "new_custodian"])
+                        .multiple(true)
+                        .required(true),
                 )
-                .group(ArgGroup::with_name("lockup_details")
-                    .args(&["lockup_epoch", "lockup_date", "new_custodian"])
-                    .multiple(true)
-                    .required(true))
                 .arg(
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Keypair of the existing custodian [default: cli config pubkey]")
+                        .help("Keypair of the existing custodian [default: cli config pubkey]"),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-set-lockup-checked")
                 .about("Set Lockup for the stake account, checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Stake account for which to set lockup parameters. ")
-                )
+                    "Stake account for which to set lockup parameters. "
+                ))
                 .arg(
                     Arg::with_name("lockup_epoch")
                         .long("lockup-epoch")
                         .value_name("NUMBER")
                         .takes_value(true)
-                        .help("The epoch height at which this account will be available for withdrawal")
+                        .help(
+                            "The epoch height at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("lockup_date")
@@ -655,7 +712,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("RFC3339 DATETIME")
                         .validator(is_rfc3339_datetime)
                         .takes_value(true)
-                        .help("The date and time at which this account will be available for withdrawal")
+                        .help(
+                            "The date and time at which this account will be available for \
+                             withdrawal",
+                        ),
                 )
                 .arg(
                     Arg::with_name("new_custodian")
@@ -663,42 +723,44 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("KEYPAIR")
                         .takes_value(true)
                         .validator(is_valid_signer)
-                        .help("Keypair of a new lockup custodian")
+                        .help("Keypair of a new lockup custodian"),
                 )
-                .group(ArgGroup::with_name("lockup_details")
-                    .args(&["lockup_epoch", "lockup_date", "new_custodian"])
-                    .multiple(true)
-                    .required(true))
+                .group(
+                    ArgGroup::with_name("lockup_details")
+                        .args(&["lockup_epoch", "lockup_date", "new_custodian"])
+                        .multiple(true)
+                        .required(true),
+                )
                 .arg(
                     Arg::with_name("custodian")
                         .long("custodian")
                         .takes_value(true)
                         .value_name("KEYPAIR")
                         .validator(is_valid_signer)
-                        .help("Keypair of the existing custodian [default: cli config pubkey]")
+                        .help("Keypair of the existing custodian [default: cli config pubkey]"),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("stake-account")
                 .about("Show the contents of a stake account")
                 .alias("show-stake-account")
-                .arg(
-                    pubkey!(Arg::with_name("stake_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("stake_account_pubkey")
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "The stake account to display. ")
-                )
+                    "The stake account to display. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL")
+                        .help("Display balance in lamports instead of SOL"),
                 )
                 .arg(
                     Arg::with_name("with_rewards")
@@ -710,7 +772,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("csv")
                         .long("csv")
                         .takes_value(false)
-                        .help("Format stake rewards data in csv")
+                        .help("Format stake rewards data in csv"),
                 )
                 .arg(
                     Arg::with_name("num_rewards_epochs")
@@ -720,7 +782,10 @@ impl StakeSubCommands for App<'_, '_> {
                         .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
-                        .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
+                        .help(
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
+                        ),
                 ),
         )
         .subcommand(
@@ -731,7 +796,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display balance in lamports instead of SOL")
+                        .help("Display balance in lamports instead of SOL"),
                 )
                 .arg(
                     Arg::with_name("limit")
@@ -739,13 +804,12 @@ impl StakeSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("NUM")
                         .default_value("10")
-                        .validator(|s| {
-                            s.parse::<usize>()
-                                .map(|_| ())
-                                .map_err(|e| e.to_string())
-                        })
-                        .help("Display NUM recent epochs worth of stake history in text mode. 0 for all")
-                )
+                        .validator(|s| s.parse::<usize>().map(|_| ()).map_err(|e| e.to_string()))
+                        .help(
+                            "Display NUM recent epochs worth of stake history in text mode. 0 for \
+                             all",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("stake-minimum-delegation")
@@ -754,8 +818,8 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("lamports")
                         .long("lamports")
                         .takes_value(false)
-                        .help("Display minimum delegation in lamports instead of SOL")
-                )
+                        .help("Display minimum delegation in lamports instead of SOL"),
+                ),
         )
     }
 }
@@ -1456,7 +1520,8 @@ pub fn process_create_stake_account(
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, provided lamports: {lamports}"
+                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
+                 provided lamports: {lamports}"
             ))
             .into());
         }
@@ -1919,7 +1984,8 @@ pub fn process_split_stake(
                 format!("Stake account {split_stake_account_address} already exists")
             } else {
                 format!(
-                    "Account {split_stake_account_address} already exists and is not a stake account"
+                    "Account {split_stake_account_address} already exists and is not a stake \
+                     account"
                 )
             };
             return Err(CliError::BadParameter(err_msg).into());
@@ -1930,7 +1996,8 @@ pub fn process_split_stake(
 
         if lamports < minimum_balance {
             return Err(CliError::BadParameter(format!(
-                "need at least {minimum_balance} lamports for stake account to be rent exempt, provided lamports: {lamports}"
+                "need at least {minimum_balance} lamports for stake account to be rent exempt, \
+                 provided lamports: {lamports}"
             ))
             .into());
         }
@@ -2359,7 +2426,8 @@ pub(crate) fn check_current_authority(
 ) -> Result<(), CliError> {
     if !permitted_authorities.contains(provided_current_authority) {
         Err(CliError::RpcRequestError(format!(
-            "Invalid authority provided: {provided_current_authority:?}, expected {permitted_authorities:?}"
+            "Invalid authority provided: {provided_current_authority:?}, expected \
+             {permitted_authorities:?}"
         )))
     } else {
         Ok(())
@@ -2622,8 +2690,8 @@ pub fn process_delegate_stake(
             ))
         } else {
             Err(CliError::DynamicProgramError(format!(
-                "Unable to delegate.  Vote account appears delinquent \
-                 because its current root slot, {root_slot}, is less than {min_root_slot}"
+                "Unable to delegate.  Vote account appears delinquent because its current root \
+                 slot, {root_slot}, is less than {min_root_slot}"
             )))
         };
 

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -88,7 +88,11 @@ fn verify_keybase(
         if client.head(&url).send()?.status().is_success() {
             Ok(())
         } else {
-            Err(format!("keybase_username could not be confirmed at: {url}. Please add this pubkey file to your keybase profile to connect").into())
+            Err(format!(
+                "keybase_username could not be confirmed at: {url}. Please add this pubkey file \
+                 to your keybase profile to connect"
+            )
+            .into())
         }
     } else {
         Err(format!("keybase_username could not be parsed as String: {keybase_username}").into())
@@ -204,7 +208,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
                                 .value_name("DETAILS")
                                 .takes_value(true)
                                 .validator(check_details_length)
-                                .help("Validator description")
+                                .help("Validator description"),
                         )
                         .arg(
                             Arg::with_name("force")
@@ -223,9 +227,12 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
                                 .value_name("PUBKEY")
                                 .takes_value(true)
                                 .validator(is_pubkey)
-                                .help("The pubkey of the Validator info account; without this argument, returns all"),
+                                .help(
+                                    "The pubkey of the Validator info account; without this \
+                                     argument, returns all",
+                                ),
                         ),
-                )
+                ),
         )
     }
 }
@@ -607,7 +614,12 @@ mod tests {
         let max_short_string =
             "Max Length String KWpP299aFCBWvWg1MHpSuaoTsud7cv8zMJsh99aAtP8X1s26yrR1".to_string();
         // 300-character string
-        let max_long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut libero quam, volutpat et aliquet eu, varius in mi. Aenean vestibulum ex in tristique faucibus. Maecenas in imperdiet turpis. Nullam feugiat aliquet erat. Morbi malesuada turpis sed dui pulvinar lobortis. Pellentesque a lectus eu leo nullam.".to_string();
+        let max_long_string = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut libero \
+                               quam, volutpat et aliquet eu, varius in mi. Aenean vestibulum ex \
+                               in tristique faucibus. Maecenas in imperdiet turpis. Nullam \
+                               feugiat aliquet erat. Morbi malesuada turpis sed dui pulvinar \
+                               lobortis. Pellentesque a lectus eu leo nullam."
+            .to_string();
         let mut info = Map::new();
         info.insert("name".to_string(), Value::String(max_short_string.clone()));
         info.insert(

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -229,7 +229,7 @@ impl ValidatorInfoSubCommands for App<'_, '_> {
                                 .validator(is_pubkey)
                                 .help(
                                     "The pubkey of the Validator info account; without this \
-                                     argument, returns all",
+                                     argument, returns all Validator info accounts",
                                 ),
                         ),
                 ),

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -70,15 +70,15 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Keypair of validator that will vote with this account"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("authorized_withdrawer")
+                .arg(pubkey!(
+                    Arg::with_name("authorized_withdrawer")
                         .index(3)
                         .value_name("WITHDRAWER_PUBKEY")
                         .takes_value(true)
                         .required(true)
                         .long("authorized-withdrawer"),
-                        "Public key of the authorized withdrawer")
-                )
+                    "Public key of the authorized withdrawer"
+                ))
                 .arg(
                     Arg::with_name("commission")
                         .long("commission")
@@ -87,43 +87,48 @@ impl VoteSubCommands for App<'_, '_> {
                         .default_value("100")
                         .help("The commission taken on reward redemption (0-100)"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("authorized_voter")
+                .arg(pubkey!(
+                    Arg::with_name("authorized_voter")
                         .long("authorized-voter")
                         .value_name("VOTER_PUBKEY"),
-                        "Public key of the authorized voter [default: validator identity pubkey]. "),
-                )
+                    "Public key of the authorized voter [default: validator identity pubkey]. "
+                ))
                 .arg(
                     Arg::with_name("allow_unsafe_authorized_withdrawer")
                         .long("allow-unsafe-authorized-withdrawer")
                         .takes_value(false)
-                        .help("Allow an authorized withdrawer pubkey to be identical to the validator identity \
-                               account pubkey or vote account pubkey, which is normally an unsafe \
-                               configuration and should be avoided."),
+                        .help(
+                            "Allow an authorized withdrawer pubkey to be identical to the \
+                             validator identity account pubkey or vote account pubkey, which is \
+                             normally an unsafe configuration and should be avoided.",
+                        ),
                 )
                 .arg(
                     Arg::with_name("seed")
                         .long("seed")
                         .value_name("STRING")
                         .takes_value(true)
-                        .help("Seed for address generation; if specified, the resulting account will be at a derived address of the VOTE ACCOUNT pubkey")
+                        .help(
+                            "Seed for address generation; if specified, the resulting account \
+                             will be at a derived address of the VOTE ACCOUNT pubkey",
+                        ),
                 )
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-voter")
                 .about("Authorize a new vote signing keypair for the given vote account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized voter. "),
-                )
+                    "Vote account in which to set the authorized voter. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -132,29 +137,29 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Current authorized vote signer."),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_authorized_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("new_authorized_pubkey")
                         .index(3)
                         .value_name("NEW_AUTHORIZED_PUBKEY")
                         .required(true),
-                        "New authorized vote signer. "),
-                )
+                    "New authorized vote signer. "
+                ))
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer")
                 .about("Authorize a new withdraw signing keypair for the given vote account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized withdrawer. "),
-                )
+                    "Vote account in which to set the authorized withdrawer. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -163,30 +168,32 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(is_valid_signer)
                         .help("Current authorized withdrawer."),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("new_authorized_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("new_authorized_pubkey")
                         .index(3)
                         .value_name("AUTHORIZED_PUBKEY")
                         .required(true),
-                        "New authorized withdrawer. "),
-                )
+                    "New authorized withdrawer. "
+                ))
                 .offline_args()
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-voter-checked")
-                .about("Authorize a new vote signing keypair for the given vote account, \
-                    checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .about(
+                    "Authorize a new vote signing keypair for the given vote account, checking \
+                     the new authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized voter. "),
-                )
+                    "Vote account in which to set the authorized voter. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -207,19 +214,21 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-authorize-withdrawer-checked")
-                .about("Authorize a new withdraw signing keypair for the given vote account, \
-                    checking the new authority as a signer")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .about(
+                    "Authorize a new withdraw signing keypair for the given vote account, \
+                     checking the new authority as a signer",
+                )
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account in which to set the authorized withdrawer. "),
-                )
+                    "Vote account in which to set the authorized withdrawer. "
+                ))
                 .arg(
                     Arg::with_name("authorized")
                         .index(2)
@@ -240,18 +249,18 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-update-validator")
                 .about("Update the vote account's validator identity")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to update. "),
-                )
+                    "Vote account to update. "
+                ))
                 .arg(
                     Arg::with_name("new_identity_account")
                         .index(2)
@@ -274,18 +283,18 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-update-commission")
                 .about("Update the vote account's commission")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to update. "),
-                )
+                    "Vote account to update. "
+                ))
                 .arg(
                     Arg::with_name("commission")
                         .index(2)
@@ -293,7 +302,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_percentage)
-                        .help("The new commission")
+                        .help("The new commission"),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -308,19 +317,19 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg())
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("vote-account")
                 .about("Show the contents of a vote account")
                 .alias("show-vote-account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account pubkey. "),
-                )
+                    "Vote account pubkey. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -347,26 +356,29 @@ impl VoteSubCommands for App<'_, '_> {
                         .validator(|s| is_within_range(s, 1..=50))
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
-                        .help("Display rewards for NUM recent epochs, max 10 [default: latest epoch only]"),
+                        .help(
+                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
+                             only]",
+                        ),
                 ),
         )
         .subcommand(
             SubCommand::with_name("withdraw-from-vote-account")
                 .about("Withdraw lamports from a vote account into a specified account")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account from which to withdraw. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Vote account from which to withdraw. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The recipient of withdrawn SOL. "),
-                )
+                    "The recipient of withdrawn SOL. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(3)
@@ -374,7 +386,10 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_amount_or_all)
-                        .help("The amount to withdraw, in SOL; accepts keyword ALL, which for this command means account balance minus rent-exempt minimum"),
+                        .help(
+                            "The amount to withdraw, in SOL; accepts keyword ALL, which for this \
+                             command means account balance minus rent-exempt minimum",
+                        ),
                 )
                 .arg(
                     Arg::with_name("authorized_withdrawer")
@@ -388,26 +403,25 @@ impl VoteSubCommands for App<'_, '_> {
                 .nonce_args(false)
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg()
-            )
+                .arg(compute_unit_price_arg()),
         )
         .subcommand(
             SubCommand::with_name("close-vote-account")
                 .about("Close a vote account and withdraw all funds remaining")
-                .arg(
-                    pubkey!(Arg::with_name("vote_account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("vote_account_pubkey")
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                        "Vote account to be closed. "),
-                )
-                .arg(
-                    pubkey!(Arg::with_name("destination_account_pubkey")
+                    "Vote account to be closed. "
+                ))
+                .arg(pubkey!(
+                    Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The recipient of all withdrawn SOL. "),
-                )
+                    "The recipient of all withdrawn SOL. "
+                ))
                 .arg(
                     Arg::with_name("authorized_withdrawer")
                         .long("authorized-withdrawer")
@@ -418,8 +432,7 @@ impl VoteSubCommands for App<'_, '_> {
                 )
                 .arg(fee_payer_arg())
                 .arg(memo_arg())
-                .arg(compute_unit_price_arg()
-            )
+                .arg(compute_unit_price_arg()),
         )
     }
 }
@@ -451,15 +464,15 @@ pub fn parse_create_vote_account(
     if !allow_unsafe {
         if authorized_withdrawer == vote_account_pubkey.unwrap() {
             return Err(CliError::BadParameter(
-                "Authorized withdrawer pubkey is identical to vote \
-                                               account pubkey, an unsafe configuration"
+                "Authorized withdrawer pubkey is identical to vote account pubkey, an unsafe \
+                 configuration"
                     .to_owned(),
             ));
         }
         if authorized_withdrawer == identity_pubkey.unwrap() {
             return Err(CliError::BadParameter(
-                "Authorized withdrawer pubkey is identical to identity \
-                                               account pubkey, an unsafe configuration"
+                "Authorized withdrawer pubkey is identical to identity account pubkey, an unsafe \
+                 configuration"
                     .to_owned(),
             ));
         }
@@ -956,8 +969,10 @@ pub fn process_vote_authorize(
                 if let Some(signer) = new_authorized_signer {
                     if signer.is_interactive() {
                         return Err(CliError::BadParameter(format!(
-                            "invalid new authorized vote signer {new_authorized_pubkey:?}. Interactive vote signers not supported"
-                        )).into());
+                            "invalid new authorized vote signer {new_authorized_pubkey:?}. \
+                             Interactive vote signers not supported"
+                        ))
+                        .into());
                     }
                 }
             }
@@ -1337,7 +1352,9 @@ pub fn process_withdraw_from_vote_account(
             let balance_remaining = current_balance.saturating_sub(withdraw_amount);
             if balance_remaining < minimum_balance && balance_remaining != 0 {
                 return Err(CliError::BadParameter(format!(
-                    "Withdraw amount too large. The vote account balance must be at least {} SOL to remain rent exempt", lamports_to_sol(minimum_balance)
+                    "Withdraw amount too large. The vote account balance must be at least {} SOL \
+                     to remain rent exempt",
+                    lamports_to_sol(minimum_balance)
                 ))
                 .into());
             }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -357,8 +357,8 @@ impl VoteSubCommands for App<'_, '_> {
                         .default_value_if("with_rewards", None, "1")
                         .requires("with_rewards")
                         .help(
-                            "Display rewards for NUM recent epochs, max 10 [default: latest epoch \
-                             only]",
+                            "Display rewards for NUM recent epochs, max 10 \
+                            [default: latest epoch only]",
                         ),
                 ),
         )

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -60,13 +60,13 @@ impl WalletSubCommands for App<'_, '_> {
             SubCommand::with_name("account")
                 .about("Show the contents of an account")
                 .alias("account")
-                .arg(
-                    pubkey!(Arg::with_name("account_pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("account_pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
                         .required(true),
-                        "Account key URI. ")
-                )
+                    "Account key URI. "
+                ))
                 .arg(
                     Arg::with_name("output_file")
                         .long("output-file")
@@ -104,22 +104,22 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The airdrop amount to request, in SOL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("to")
+                .arg(pubkey!(
+                    Arg::with_name("to")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS"),
-                        "The account address of airdrop recipient. "),
-                ),
+                    "The account address of airdrop recipient. "
+                )),
         )
         .subcommand(
             SubCommand::with_name("balance")
                 .about("Get your balance")
-                .arg(
-                    pubkey!(Arg::with_name("pubkey")
+                .arg(pubkey!(
+                    Arg::with_name("pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS"),
-                        "The account address of the balance to check. ")
-                )
+                    "The account address of the balance to check. "
+                ))
                 .arg(
                     Arg::with_name("lamports")
                         .long("lamports")
@@ -138,23 +138,19 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The transaction signature to confirm"),
                 )
-                .after_help(// Formatted specifically for the manually-indented heredoc string
-                   "Note: This will show more detailed information for finalized transactions with verbose mode (-v/--verbose).\
-                  \n\
-                  \nAccount modes:\
-                  \n  |srwx|\
-                  \n    s: signed\
-                  \n    r: readable (always true)\
-                  \n    w: writable\
-                  \n    x: program account (inner instructions excluded)\
-                   "
+                .after_help(
+                    // Formatted specifically for the manually-indented heredoc string
+                    "Note: This will show more detailed information for finalized transactions \
+                     with verbose mode (-v/--verbose).\n\nAccount modes:\n  |srwx|\n    s: \
+                     signed\n    r: readable (always true)\n    w: writable\n    x: program \
+                     account (inner instructions excluded)",
                 ),
         )
         .subcommand(
             SubCommand::with_name("create-address-with-seed")
                 .about(
-                    "Generate a derived account address with a seed. \
-                    For program derived addresses (PDAs), use the find-program-derived-address command instead"
+                    "Generate a derived account address with a seed. For program derived \
+                     addresses (PDAs), use the find-program-derived-address command instead",
                 )
                 .arg(
                     Arg::with_name("seed")
@@ -172,49 +168,48 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \n\
-                             or one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, \nor \
+                             one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("from")
+                .arg(pubkey!(
+                    Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_PUBKEY")
                         .required(false),
-                        "From (base) key, [default: cli config keypair]. "),
+                    "From (base) key, [default: cli config keypair]. "
+                )),
+        )
+        .subcommand(
+            SubCommand::with_name("find-program-derived-address")
+                .about("Generate a program derived account address with a seed")
+                .arg(
+                    Arg::with_name("program_id")
+                        .index(1)
+                        .value_name("PROGRAM_ID")
+                        .takes_value(true)
+                        .required(true)
+                        .help(
+                            "The program_id that the address will ultimately be used for, \nor \
+                             one of NONCE, STAKE, and VOTE keywords",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("seeds")
+                        .min_values(0)
+                        .value_name("SEED")
+                        .takes_value(true)
+                        .validator(is_structured_seed)
+                        .help(
+                            "The seeds. \nEach one must match the pattern PREFIX:VALUE. \nPREFIX \
+                             can be one of [string, pubkey, hex, u8] \nor matches the pattern \
+                             [u,i][16,32,64,128][le,be] (for example u64le) for number values \
+                             \n[u,i] - represents whether the number is unsigned or signed, \
+                             \n[16,32,64,128] - represents the bit length, and \n[le,be] - \
+                             represents the byte order - little endian or big endian",
+                        ),
                 ),
         )
-            .subcommand(
-                SubCommand::with_name("find-program-derived-address")
-                    .about("Generate a program derived account address with a seed")
-                    .arg(
-                        Arg::with_name("program_id")
-                                .index(1)
-                                .value_name("PROGRAM_ID")
-                                .takes_value(true)
-                                .required(true)
-                                .help(
-                                    "The program_id that the address will ultimately be used for, \n\
-                                    or one of NONCE, STAKE, and VOTE keywords",
-                                ),
-                        )
-                    .arg(
-                        Arg::with_name("seeds")
-                            .min_values(0)
-                            .value_name("SEED")
-                            .takes_value(true)
-                            .validator(is_structured_seed)
-                            .help(
-                                "The seeds. \n\
-                                Each one must match the pattern PREFIX:VALUE. \n\
-                                PREFIX can be one of [string, pubkey, hex, u8] \n\
-                                or matches the pattern [u,i][16,32,64,128][le,be] (for example u64le) for number values \n\
-                                [u,i] - represents whether the number is unsigned or signed, \n\
-                                [16,32,64,128] - represents the bit length, and \n\
-                                [le,be] - represents the byte order - little endian or big endian"
-                            ),
-                    ),
-            )
         .subcommand(
             SubCommand::with_name("decode-transaction")
                 .about("Decode a serialized transaction")
@@ -239,7 +234,10 @@ impl WalletSubCommands for App<'_, '_> {
         )
         .subcommand(
             SubCommand::with_name("resolve-signer")
-                .about("Checks that a signer is valid, and returns its specific path; useful for signers that may be specified generally, eg. usb://ledger")
+                .about(
+                    "Checks that a signer is valid, and returns its specific path; useful for \
+                     signers that may be specified generally, eg. usb://ledger",
+                )
                 .arg(
                     Arg::with_name("signer")
                         .index(1)
@@ -247,20 +245,20 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .validator(is_valid_signer)
-                        .help("The signer path to resolve")
-                )
+                        .help("The signer path to resolve"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("transfer")
                 .about("Transfer funds between system accounts")
                 .alias("pay")
-                .arg(
-                    pubkey!(Arg::with_name("to")
+                .arg(pubkey!(
+                    Arg::with_name("to")
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                        "The account address of recipient. "),
-                )
+                    "The account address of recipient. "
+                ))
                 .arg(
                     Arg::with_name("amount")
                         .index(2)
@@ -270,17 +268,20 @@ impl WalletSubCommands for App<'_, '_> {
                         .required(true)
                         .help("The amount to send, in SOL; accepts keyword ALL"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("from")
+                .arg(pubkey!(
+                    Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_ADDRESS"),
-                        "Source account of funds (if different from client local account). "),
-                )
+                    "Source account of funds (if different from client local account). "
+                ))
                 .arg(
                     Arg::with_name("no_wait")
                         .long("no-wait")
                         .takes_value(false)
-                        .help("Return signature immediately after submitting the transaction, instead of waiting for confirmations"),
+                        .help(
+                            "Return signature immediately after submitting the transaction, \
+                             instead of waiting for confirmations",
+                        ),
                 )
                 .arg(
                     Arg::with_name("derived_address_seed")
@@ -289,7 +290,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("SEED_STRING")
                         .requires("derived_address_program_id")
                         .validator(is_derived_address_seed)
-                        .hidden(hidden_unless_forced())
+                        .hidden(hidden_unless_forced()),
                 )
                 .arg(
                     Arg::with_name("derived_address_program_id")
@@ -297,13 +298,13 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("PROGRAM_ID")
                         .requires("derived_address_seed")
-                        .hidden(hidden_unless_forced())
+                        .hidden(hidden_unless_forced()),
                 )
                 .arg(
                     Arg::with_name("allow_unfunded_recipient")
                         .long("allow-unfunded-recipient")
                         .takes_value(false)
-                        .help("Complete the transfer even if the recipient address is not funded")
+                        .help("Complete the transfer even if the recipient address is not funded"),
                 )
                 .offline_args()
                 .nonce_args(false)
@@ -320,7 +321,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("STRING")
                         .required(true)
-                        .help("The message text to be signed")
+                        .help("The message text to be signed"),
                 )
                 .arg(
                     Arg::with_name("version")
@@ -331,10 +332,10 @@ impl WalletSubCommands for App<'_, '_> {
                         .default_value("0")
                         .validator(|p| match p.parse::<u8>() {
                             Err(_) => Err(String::from("Must be unsigned integer")),
-                            Ok(_) => { Ok(()) }
+                            Ok(_) => Ok(()),
                         })
-                        .help("The off-chain message version")
-                )
+                        .help("The off-chain message version"),
+                ),
         )
         .subcommand(
             SubCommand::with_name("verify-offchain-signature")
@@ -345,7 +346,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .value_name("STRING")
                         .required(true)
-                        .help("The text of the original message")
+                        .help("The text of the original message"),
                 )
                 .arg(
                     Arg::with_name("signature")
@@ -353,7 +354,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .value_name("SIGNATURE")
                         .takes_value(true)
                         .required(true)
-                        .help("The message signature to verify")
+                        .help("The message signature to verify"),
                 )
                 .arg(
                     Arg::with_name("version")
@@ -364,17 +365,17 @@ impl WalletSubCommands for App<'_, '_> {
                         .default_value("0")
                         .validator(|p| match p.parse::<u8>() {
                             Err(_) => Err(String::from("Must be unsigned integer")),
-                            Ok(_) => { Ok(()) }
+                            Ok(_) => Ok(()),
                         })
-                        .help("The off-chain message version")
+                        .help("The off-chain message version"),
                 )
-                .arg(
-                    pubkey!(Arg::with_name("signer")
+                .arg(pubkey!(
+                    Arg::with_name("signer")
                         .long("signer")
                         .value_name("PUBKEY")
                         .required(false),
-                        "The pubkey of the message signer (if different from config default)")
-                )
+                    "The pubkey of the message signer (if different from config default)"
+                )),
         )
     }
 }
@@ -889,9 +890,8 @@ pub fn process_transfer(
             .value;
         if recipient_balance == 0 {
             return Err(format!(
-                "The recipient address ({to}) is not funded. \
-                                Add `--allow-unfunded-recipient` to complete the transfer \
-                               "
+                "The recipient address ({to}) is not funded. Add `--allow-unfunded-recipient` to \
+                 complete the transfer "
             )
             .into());
         }

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -140,10 +140,16 @@ impl WalletSubCommands for App<'_, '_> {
                 )
                 .after_help(
                     // Formatted specifically for the manually-indented heredoc string
-                    "Note: This will show more detailed information for finalized transactions \
-                     with verbose mode (-v/--verbose).\n\nAccount modes:\n  |srwx|\n    s: \
-                     signed\n    r: readable (always true)\n    w: writable\n    x: program \
-                     account (inner instructions excluded)",
+                    "Note: This will show more detailed information for finalized \
+                    transactions with verbose mode (-v/--verbose).\
+                    \n\
+                    \nAccount modes:\
+                    \n  |srwx|\
+                    \n    s: signed\
+                    \n    r: readable (always true)\
+                    \n    w: writable\
+                    \n    x: program account (inner instructions excluded)\
+                    ",
                 ),
         )
         .subcommand(
@@ -168,8 +174,8 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \nor \
-                             one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, \n\
+                             or one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
                 .arg(pubkey!(
@@ -190,8 +196,8 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .help(
-                            "The program_id that the address will ultimately be used for, \nor \
-                             one of NONCE, STAKE, and VOTE keywords",
+                            "The program_id that the address will ultimately be used for, \n\
+                             or one of NONCE, STAKE, and VOTE keywords",
                         ),
                 )
                 .arg(
@@ -201,12 +207,14 @@ impl WalletSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .validator(is_structured_seed)
                         .help(
-                            "The seeds. \nEach one must match the pattern PREFIX:VALUE. \nPREFIX \
-                             can be one of [string, pubkey, hex, u8] \nor matches the pattern \
-                             [u,i][16,32,64,128][le,be] (for example u64le) for number values \
-                             \n[u,i] - represents whether the number is unsigned or signed, \
-                             \n[16,32,64,128] - represents the bit length, and \n[le,be] - \
-                             represents the byte order - little endian or big endian",
+                            "The seeds. \n\
+                            Each one must match the pattern PREFIX:VALUE. \n\
+                            PREFIX can be one of [string, pubkey, hex, u8] \n\
+                            or matches the pattern [u,i][16,32,64,128][le,be] \
+                            (for example u64le) for number values \n\
+                            [u,i] - represents whether the number is unsigned or signed, \n\
+                            [16,32,64,128] - represents the bit length, and \n\
+                            [le,be] - represents the byte order - little endian or big endian",
                         ),
                 ),
         )


### PR DESCRIPTION
This PR is spun out from https://github.com/solana-labs/solana/pull/34274

#### Problem
Long string literals can cause rustfmt to fail, which results in rustfmt failing to format entire functions. There are many instances of this in the solana-cli.

#### Summary of Changes
Format and wrap strings to allow rustfmt to work again.
This PR was initiated by adding `format_strings = true` to the workspace rustfmt.toml. In general, this did a nice job.

However, I chose to manually preserve or improve some of the original strings where the formatting seemed to break readability. (It is just my own personal preference that `[default: ..]` blocks not be broken across multiple lines.)
If we impose `format_strings` on the workspace in the future, these strings will be "wrong" and need fixing.
