### PR TITLE
Add additional context to ReplayStage log message

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1358,7 +1358,8 @@ impl ReplayStage {
                                 })
                                 .ok();
                         } else {
-                            warn!("Unable to get bank for slot {duplicate_slot} from bank forks");
+                            warn!("Unable to get bank for slot {duplicate_slot} from bank forks \
+                                   while attempting to write bank hash details file");
                         }
                         panic!("We are attempting to dump a block that we produced. \
                             This indicates that we are producing duplicate blocks, \


### PR DESCRIPTION
#### Problem
The pre-existing message doesn't provide context about the caller as BankForks is accessed by lots of places in ReplayStage.

#### Summary of Changes
Add context to the existing log message