### PR TITLE
consensus: use gossip duplicate vote in switching proof

### DIFF
--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -219,7 +219,7 @@ impl Tvu {
                 leader_schedule_cache.clone(),
                 verified_vote_receiver,
                 completed_data_sets_sender,
-                duplicate_slots_sender,
+                duplicate_slots_sender.clone(),
                 ancestor_hashes_replay_update_receiver,
                 dumped_slots_receiver,
                 popular_pruned_forks_sender,
@@ -327,6 +327,7 @@ impl Tvu {
                 blockstore,
                 leader_schedule_cache.clone(),
                 bank_forks.clone(),
+                duplicate_slots_sender,
             ),
         );
 

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -28,7 +28,7 @@ use {
     solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signer},
     solana_vote_program::vote_transaction,
     std::{
-        collections::{HashMap, HashSet},
+        collections::{BTreeMap, HashMap, HashSet},
         sync::{Arc, RwLock},
     },
     trees::{tr, Tree, TreeWalk},
@@ -188,6 +188,7 @@ impl VoteSimulator {
             tower,
             &self.latest_validator_votes_for_frozen_banks,
             &self.heaviest_subtree_fork_choice,
+            &BTreeMap::default(),
         );
 
         // Make sure this slot isn't locked out or failing threshold

--- a/gossip/src/cluster_info_metrics.rs
+++ b/gossip/src/cluster_info_metrics.rs
@@ -637,6 +637,8 @@ pub(crate) fn submit_gossip_stats(
             crds_stats.pull.counts[12],
             i64
         ),
+        ("DuplicateVote-push", crds_stats.push.counts[13], i64),
+        ("DuplicateVote-pull", crds_stats.pull.counts[13], i64),
         (
             "all-push",
             crds_stats.push.counts.iter().sum::<usize>(),
@@ -684,6 +686,8 @@ pub(crate) fn submit_gossip_stats(
             crds_stats.pull.fails[12],
             i64
         ),
+        ("DuplicateVote-push", crds_stats.push.fails[13], i64),
+        ("DuplicateVote-pull", crds_stats.pull.fails[13], i64),
         ("all-push", crds_stats.push.fails.iter().sum::<usize>(), i64),
         ("all-pull", crds_stats.pull.fails.iter().sum::<usize>(), i64),
     );

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -103,7 +103,7 @@ pub enum GossipRoute<'a> {
     PushMessage(/*from:*/ &'a Pubkey),
 }
 
-type CrdsCountsArray = [usize; 13];
+type CrdsCountsArray = [usize; 14];
 
 pub(crate) struct CrdsDataStats {
     pub(crate) counts: CrdsCountsArray,
@@ -722,6 +722,7 @@ impl CrdsDataStats {
             CrdsData::SnapshotHashes(_) => 10,
             CrdsData::ContactInfo(_) => 11,
             CrdsData::RestartLastVotedForkSlots(_) => 12,
+            CrdsData::DuplicateVote(_) => 13,
             // Update CrdsCountsArray if new items are added here.
         }
     }

--- a/gossip/src/duplicate_shred.rs
+++ b/gossip/src/duplicate_shred.rs
@@ -56,6 +56,8 @@ pub enum Error {
     BlockstoreInsertFailed(#[from] BlockstoreError),
     #[error("data chunk mismatch")]
     DataChunkMismatch,
+    #[error("unable to send duplicate slot to state machine")]
+    DuplicateSlotSenderFailure,
     #[error("invalid chunk_index: {chunk_index}, num_chunks: {num_chunks}")]
     InvalidChunkIndex { chunk_index: u8, num_chunks: u8 },
     #[error("invalid duplicate shreds")]

--- a/gossip/src/duplicate_vote_listener.rs
+++ b/gossip/src/duplicate_vote_listener.rs
@@ -1,0 +1,67 @@
+use {
+    crate::{
+        cluster_info::{ClusterInfo, GOSSIP_SLEEP_MILLIS},
+        crds::Cursor,
+        crds_value::DuplicateVote,
+    },
+    crossbeam_channel::Sender,
+    solana_sdk::{hash::Hash, pubkey::Pubkey, slot_history::Slot},
+    solana_vote_program::vote_state::VoteTransaction,
+    std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        thread::{self, sleep, Builder, JoinHandle},
+        time::Duration,
+    },
+};
+
+pub struct DuplicateVoteListener {
+    thread_hdl: JoinHandle<()>,
+}
+
+impl DuplicateVoteListener {
+    pub fn new(
+        exit: Arc<AtomicBool>,
+        cluster_info: Arc<ClusterInfo>,
+        sender: Sender<(Pubkey, VoteTransaction, Slot, Hash)>,
+    ) -> Self {
+        let listen_thread = Builder::new()
+            .name("solDupVoteLstnr".to_string())
+            .spawn(move || {
+                Self::recv_loop(exit, &cluster_info, sender);
+            })
+            .unwrap();
+
+        Self {
+            thread_hdl: listen_thread,
+        }
+    }
+
+    pub fn join(self) -> thread::Result<()> {
+        self.thread_hdl.join()
+    }
+
+    fn recv_loop(
+        exit: Arc<AtomicBool>,
+        cluster_info: &ClusterInfo,
+        sender: Sender<(Pubkey, VoteTransaction, Slot, Hash)>,
+    ) {
+        let mut cursor = Cursor::default();
+        while !exit.load(Ordering::Relaxed) {
+            let votes: Vec<DuplicateVote> = cluster_info.get_duplicate_vote(&mut cursor);
+            for vote in votes {
+                let DuplicateVote {
+                    from,
+                    vote_tx,
+                    slot,
+                    hash,
+                    ..
+                } = vote;
+                sender.send((from, vote_tx, slot, hash)).unwrap();
+            }
+            sleep(Duration::from_millis(GOSSIP_SLEEP_MILLIS));
+        }
+    }
+}

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -16,6 +16,7 @@ mod deprecated;
 pub mod duplicate_shred;
 pub mod duplicate_shred_handler;
 pub mod duplicate_shred_listener;
+pub mod duplicate_vote_listener;
 pub mod epoch_slots;
 pub mod gossip_error;
 pub mod gossip_service;

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3732,6 +3732,9 @@ fn test_kill_partition_switch_threshold_progress() {
 #[test]
 #[serial]
 #[allow(unused_attributes)]
+// This test does not work under the assumption that duplicate proofs are propagated through gossip
+// ignore for now.
+#[ignore]
 fn test_duplicate_shreds_broadcast_leader() {
     // Create 4 nodes:
     // 1) Bad leader sending different versions of shreds to both of the other nodes


### PR DESCRIPTION
duplicate vote messages from gossip can be used as part of the switching proof 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
