### PR TITLE
Finish unified scheduler plumbing with min impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,6 +5972,7 @@ dependencies = [
  "solana-tpu-client",
  "solana-transaction-status",
  "solana-turbine",
+ "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote",
  "solana-vote-program",
@@ -6431,6 +6432,7 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-streamer",
  "solana-transaction-status",
+ "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote-program",
  "solana_rbpf",
@@ -7542,6 +7544,24 @@ dependencies = [
  "solana-streamer",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-unified-scheduler-logic"
+version = "1.18.0"
+
+[[package]]
+name = "solana-unified-scheduler-pool"
+version = "1.18.0"
+dependencies = [
+ "assert_matches",
+ "solana-ledger",
+ "solana-logger",
+ "solana-program-runtime",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-unified-scheduler-logic",
+ "solana-vote",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7561,7 +7561,6 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-unified-scheduler-logic",
- "solana-unified-scheduler-pool",
  "solana-vote",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7561,6 +7561,7 @@ dependencies = [
  "solana-runtime",
  "solana-sdk",
  "solana-unified-scheduler-logic",
+ "solana-unified-scheduler-pool",
  "solana-vote",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,8 @@ members = [
     "transaction-status",
     "turbine",
     "udp-client",
+    "unified-scheduler-logic",
+    "unified-scheduler-pool",
     "upload-perf",
     "validator",
     "version",
@@ -357,6 +359,8 @@ solana-pubsub-client = { path = "pubsub-client", version = "=1.18.0" }
 solana-quic-client = { path = "quic-client", version = "=1.18.0" }
 solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.18.0" }
 solana-remote-wallet = { path = "remote-wallet", version = "=1.18.0", default-features = false }
+solana-unified-scheduler-logic = { path = "unified-scheduler-logic", version = "=1.18.0" }
+solana-unified-scheduler-pool = { path = "unified-scheduler-pool", version = "=1.18.0" }
 solana-rpc = { path = "rpc", version = "=1.18.0" }
 solana-rpc-client = { path = "rpc-client", version = "=1.18.0", default-features = false }
 solana-rpc-client-api = { path = "rpc-client-api", version = "=1.18.0" }

--- a/ci/run-sanity.sh
+++ b/ci/run-sanity.sh
@@ -39,4 +39,5 @@ $solana_ledger_tool create-snapshot --ledger config/ledger "$snapshot_slot" conf
 cp config/ledger/genesis.tar.bz2 config/snapshot-ledger
 $solana_ledger_tool copy --ledger config/ledger \
   --target-db config/snapshot-ledger --starting-slot "$snapshot_slot" --ending-slot "$latest_slot"
-$solana_ledger_tool verify --ledger config/snapshot-ledger
+$solana_ledger_tool verify --ledger config/snapshot-ledger --block-verification-method blockstore-processor
+$solana_ledger_tool verify --ledger config/snapshot-ledger --block-verification-method unified-scheduler

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -69,6 +69,7 @@ solana-streamer = { workspace = true }
 solana-tpu-client = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
 solana-vote = { workspace = true }
 solana-vote-program = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -96,6 +96,7 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 systemstat = { workspace = true }
 test-case = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -96,7 +96,6 @@ solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 solana-stake-program = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
 static_assertions = { workspace = true }
 systemstat = { workspace = true }
 test-case = { workspace = true }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -817,7 +817,7 @@ impl Validator {
 
         match &config.block_verification_method {
             BlockVerificationMethod::BlockstoreProcessor => {
-                info!("not installing scheduler pool...");
+                info!("no scheduler pool is installed for block verification...");
             }
             BlockVerificationMethod::UnifiedScheduler => {
                 let scheduler_pool = DefaultSchedulerPool::new_dyn(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -118,6 +118,7 @@ use {
     solana_send_transaction_service::send_transaction_service,
     solana_streamer::{socket::SocketAddrSpace, streamer::StakedNodes},
     solana_turbine::{self, broadcast_stage::BroadcastStageType},
+    solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_vote_program::vote_state,
     solana_wen_restart::wen_restart::wait_for_wen_restart,
     std::{
@@ -144,6 +145,7 @@ const WAIT_FOR_SUPERMAJORITY_THRESHOLD_PERCENT: u64 = 80;
 pub enum BlockVerificationMethod {
     #[default]
     BlockstoreProcessor,
+    UnifiedScheduler,
 }
 
 impl BlockVerificationMethod {
@@ -812,6 +814,24 @@ impl Validator {
         // block min prioritization fee cache should be readable by RPC, and writable by validator
         // (by both replay stage and banking stage)
         let prioritization_fee_cache = Arc::new(PrioritizationFeeCache::default());
+
+        match &config.block_verification_method {
+            BlockVerificationMethod::BlockstoreProcessor => {
+                info!("not installing scheduler pool...");
+            }
+            BlockVerificationMethod::UnifiedScheduler => {
+                let scheduler_pool = DefaultSchedulerPool::new_dyn(
+                    config.runtime_config.log_messages_bytes_limit,
+                    transaction_status_sender.clone(),
+                    Some(replay_vote_sender.clone()),
+                    prioritization_fee_cache.clone(),
+                );
+                bank_forks
+                    .write()
+                    .unwrap()
+                    .install_scheduler_pool(scheduler_pool);
+            }
+        }
 
         let leader_schedule_cache = Arc::new(leader_schedule_cache);
         let entry_notification_sender = entry_notifier_service

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -45,6 +45,7 @@ solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }
 solana-transaction-status = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 solana_rbpf = { workspace = true, features = ["debugger"] }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -45,7 +45,7 @@ solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
+solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 solana_rbpf = { workspace = true, features = ["debugger"] }

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -45,7 +45,7 @@ solana-stake-program = { workspace = true }
 solana-storage-bigtable = { workspace = true }
 solana-streamer = { workspace = true }
 solana-transaction-status = { workspace = true }
-solana-unified-scheduler-pool = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true, features = ["dev-context-only-utils"] }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 solana_rbpf = { workspace = true, features = ["debugger"] }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -309,7 +309,7 @@ pub fn load_and_process_ledger(
     );
     match block_verification_method {
         BlockVerificationMethod::BlockstoreProcessor => {
-            info!("not installing scheduler pool...");
+            info!("no scheduler pool is installed for block verification...");
         }
         BlockVerificationMethod::UnifiedScheduler => {
             let no_transaction_status_sender = None;

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -30,6 +30,7 @@ use {
             PrunedBanksRequestHandler, SnapshotRequestHandler,
         },
         bank_forks::BankForks,
+        prioritization_fee_cache::PrioritizationFeeCache,
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
@@ -42,6 +43,7 @@ use {
         timing::timestamp,
     },
     solana_streamer::socket::SocketAddrSpace,
+    solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{
         path::{Path, PathBuf},
         process::exit,
@@ -305,6 +307,25 @@ pub fn load_and_process_ledger(
         "Using: block-verification-method: {}",
         block_verification_method,
     );
+    match block_verification_method {
+        BlockVerificationMethod::BlockstoreProcessor => {
+            info!("not installing scheduler pool...");
+        }
+        BlockVerificationMethod::UnifiedScheduler => {
+            let no_transaction_status_sender = None;
+            let no_replay_vote_sender = None;
+            let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+            bank_forks
+                .write()
+                .unwrap()
+                .install_scheduler_pool(DefaultSchedulerPool::new_dyn(
+                    process_options.runtime_config.log_messages_bytes_limit,
+                    no_transaction_status_sender,
+                    no_replay_vote_sender,
+                    ignored_prioritization_fee_cache,
+                ));
+        }
+    }
 
     let node_id = Arc::new(Keypair::new());
     let cluster_info = Arc::new(ClusterInfo::new(

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -74,7 +74,7 @@ use {
     thiserror::Error,
 };
 
-struct TransactionBatchWithIndexes<'a, 'b> {
+pub struct TransactionBatchWithIndexes<'a, 'b> {
     pub batch: TransactionBatch<'a, 'b>,
     pub transaction_indexes: Vec<usize>,
 }
@@ -134,7 +134,7 @@ fn get_first_error(
     first_err
 }
 
-fn execute_batch(
+pub fn execute_batch(
     batch: &TransactionBatchWithIndexes,
     bank: &Arc<Bank>,
     transaction_status_sender: Option<&TransactionStatusSender>,
@@ -1832,7 +1832,7 @@ pub struct TransactionStatusBatch {
     pub transaction_indexes: Vec<usize>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TransactionStatusSender {
     pub sender: Sender<TransactionStatusMessage>,
 }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -4569,8 +4569,8 @@ pub mod tests {
                     .times(1)
                     .returning(|| ());
                 (
-                    Box::new(mocked_uninstalled_scheduler),
                     (Ok(()), ExecuteTimings::default()),
+                    Box::new(mocked_uninstalled_scheduler),
                 )
             });
         let bank = BankWithScheduler::new(bank, Some(Box::new(mocked_scheduler)));

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5041,6 +5041,7 @@ dependencies = [
  "solana-tpu-client",
  "solana-transaction-status",
  "solana-turbine",
+ "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote",
  "solana-vote-program",
@@ -6543,6 +6544,22 @@ dependencies = [
  "solana-streamer",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-unified-scheduler-logic"
+version = "1.18.0"
+
+[[package]]
+name = "solana-unified-scheduler-pool"
+version = "1.18.0"
+dependencies = [
+ "solana-ledger",
+ "solana-program-runtime",
+ "solana-runtime",
+ "solana-sdk",
+ "solana-unified-scheduler-logic",
+ "solana-vote",
 ]
 
 [[package]]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4290,7 +4290,7 @@ impl Bank {
     }
 
     /// Prepare a transaction batch from a single transaction without locking accounts
-    pub(crate) fn prepare_unlocked_batch_from_single_tx<'a>(
+    pub fn prepare_unlocked_batch_from_single_tx<'a>(
         &'a self,
         transaction: &'a SanitizedTransaction,
     ) -> TransactionBatch<'_, '_> {

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -119,7 +119,7 @@ pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn wait_for_termination(
         self: Box<Self>,
         is_dropped: bool,
-    ) -> (UninstalledSchedulerBox, ResultWithTimings);
+    ) -> (ResultWithTimings, UninstalledSchedulerBox);
 
     /// Pause a scheduler after processing to update bank's recent blockhash.
     ///
@@ -364,7 +364,7 @@ impl BankWithSchedulerInner {
                 scheduler.pause_for_recent_blockhash();
                 None
             } else {
-                let (uninstalled_scheduler, result_with_timings) = scheduler
+                let (result_with_timings, uninstalled_scheduler) = scheduler
                     .take()
                     .map(|scheduler| scheduler.wait_for_termination(reason.is_dropped()))
                     .unzip();
@@ -458,8 +458,8 @@ mod tests {
                         .times(1)
                         .returning(|| ());
                     (
-                        Box::new(mock_uninstalled),
                         (Ok(()), ExecuteTimings::default()),
+                        Box::new(mock_uninstalled),
                     )
                 });
         }

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -99,6 +99,7 @@ pub trait InstalledSchedulerPool: Send + Sync + Debug {
 )]
 pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn id(&self) -> SchedulerId;
+    #[cfg(feature = "dev-context-only-utils")]
     fn context(&self) -> &SchedulingContext;
 
     // Calling this is illegal as soon as wait_for_termination is called.
@@ -226,6 +227,7 @@ pub type InstalledSchedulerRwLock = RwLock<Option<DefaultInstalledSchedulerBox>>
 impl BankWithScheduler {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(bank: Arc<Bank>, scheduler: Option<DefaultInstalledSchedulerBox>) -> Self {
+        #[cfg(feature = "dev-context-only-utils")]
         if let Some(bank_in_context) = scheduler
             .as_ref()
             .map(|scheduler| scheduler.context().bank())

--- a/runtime/src/installed_scheduler_pool.rs
+++ b/runtime/src/installed_scheduler_pool.rs
@@ -99,7 +99,6 @@ pub trait InstalledSchedulerPool: Send + Sync + Debug {
 )]
 pub trait InstalledScheduler: Send + Sync + Debug + 'static {
     fn id(&self) -> SchedulerId;
-    #[cfg(feature = "dev-context-only-utils")]
     fn context(&self) -> &SchedulingContext;
 
     // Calling this is illegal as soon as wait_for_termination is called.
@@ -227,7 +226,6 @@ pub type InstalledSchedulerRwLock = RwLock<Option<DefaultInstalledSchedulerBox>>
 impl BankWithScheduler {
     #[cfg_attr(feature = "dev-context-only-utils", qualifiers(pub))]
     pub(crate) fn new(bank: Arc<Bank>, scheduler: Option<DefaultInstalledSchedulerBox>) -> Self {
-        #[cfg(feature = "dev-context-only-utils")]
         if let Some(bank_in_context) = scheduler
             .as_ref()
             .map(|scheduler| scheduler.context().bank())

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -142,6 +142,7 @@ type SlotPrioritizationFee = DashMap<BankId, PrioritizationFee>;
 /// Stores up to MAX_NUM_RECENT_BLOCKS recent block's prioritization fee,
 /// A separate internal thread `service_thread` handles additional tasks when a bank is frozen,
 /// and collecting stats and reporting metrics.
+#[derive(Debug)]
 pub struct PrioritizationFeeCache {
     cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
     service_thread: Option<JoinHandle<()>>,

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "solana-unified-scheduler-logic"
+description = "The Solana unified scheduler logic"
+documentation = "https://docs.rs/solana-unified-scheduler-logic"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1,0 +1,1 @@
+// This file will be populated with actual implementation later.

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "solana-unified-scheduler-pool"
+description = "The Solana unified scheduler pool"
+documentation = "https://docs.rs/solana-unified-scheduler-pool"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-ledger = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-runtime = { workspace = true }
+solana-sdk = { workspace = true }
+solana-unified-scheduler-logic = { workspace = true }
+solana-vote = { workspace = true }
+
+[dev-dependencies]
+assert_matches = { workspace = true }
+solana-logger = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -21,3 +21,10 @@ solana-vote = { workspace = true }
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
+# See order-crates-for-publishing.py for using this unusual `path = "."`
+solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }
+
+[features]
+dev-context-only-utils = [
+  "solana-runtime/dev-context-only-utils",
+]

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -21,10 +21,3 @@ solana-vote = { workspace = true }
 assert_matches = { workspace = true }
 solana-logger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
-# See order-crates-for-publishing.py for using this unusual `path = "."`
-solana-unified-scheduler-pool = { path = ".", features = ["dev-context-only-utils"] }
-
-[features]
-dev-context-only-utils = [
-  "solana-runtime/dev-context-only-utils",
-]

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -240,6 +240,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         self.id
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
     fn context(&self) -> &SchedulingContext {
         self.context.as_ref().expect("active context should exist")
     }
@@ -256,7 +257,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
             TH::handle(
                 result,
                 timings,
-                self.context().bank(),
+                self.context.as_ref().unwrap().bank(),
                 transaction,
                 index,
                 &self.pool.handler_context,
@@ -563,6 +564,7 @@ mod tests {
             self.0.id()
         }
 
+        #[cfg(feature = "dev-context-only-utils")]
         fn context(&self) -> &SchedulingContext {
             self.0.context()
         }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -33,7 +33,6 @@ use {
     },
 };
 
-const PRIMARY_SCHEDULER_ID: SchedulerId = 0;
 type AtomicSchedulerId = AtomicU64;
 
 // SchedulerPool must be accessed via dyn by solana-runtime code, because its internal fields'
@@ -87,7 +86,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
                 prioritization_fee_cache,
             },
             weak_self: weak_self.clone(),
-            next_scheduler_id: AtomicSchedulerId::new(PRIMARY_SCHEDULER_ID),
+            next_scheduler_id: AtomicSchedulerId::default(),
             _phantom: PhantomData,
         })
     }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -270,6 +270,11 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         if keep_result_with_timings {
             None
         } else {
+            drop(
+                self.context
+                    .take()
+                    .expect("active context should be dropped"),
+            );
             // current simplest form of this trait impl doesn't block the current thread materially
             // just with the following single mutex lock. Suppose more elaborated synchronization
             // across worker threads here in the future...
@@ -280,12 +285,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         }
     }
 
-    fn return_to_pool(mut self: Box<Self>) {
-        drop(
-            self.context
-                .take()
-                .expect("active context should be dropped"),
-        );
+    fn return_to_pool(self: Box<Self>) {
         self.pool.clone().return_scheduler(self)
     }
 }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -285,9 +285,11 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
     fn wait_for_termination(
         mut self: Box<Self>,
         _is_dropped: bool,
-    ) -> (UninstalledSchedulerBox, ResultWithTimings) {
-        let result_with_timings = self.do_wait_for_termination().unwrap();
-        (Box::new(self.into_inner()), result_with_timings)
+    ) -> (ResultWithTimings, UninstalledSchedulerBox) {
+        (
+            self.do_wait_for_termination().unwrap(),
+            Box::new(self.into_inner()),
+        )
     }
 
     fn pause_for_recent_blockhash(&mut self) {
@@ -396,7 +398,7 @@ mod tests {
         scheduler.pause_for_recent_blockhash();
         assert_matches!(
             Box::new(scheduler).wait_for_termination(false),
-            (_, (Ok(()), _))
+            ((Ok(()), _), _)
         );
     }
 
@@ -610,7 +612,7 @@ mod tests {
         fn wait_for_termination(
             self: Box<Self>,
             is_dropped: bool,
-        ) -> (UninstalledSchedulerBox, ResultWithTimings) {
+        ) -> (ResultWithTimings, UninstalledSchedulerBox) {
             self.do_wait();
             Box::new(self.0).wait_for_termination(is_dropped)
         }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -70,6 +70,8 @@ pub type DefaultSchedulerPool =
     SchedulerPool<PooledScheduler<DefaultTaskHandler>, DefaultTaskHandler>;
 
 impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
+    // Some internal impl and test code want an actual concrete type, NOT the
+    // `dyn InstalledSchedulerPool`. So don't merge this into `Self::new_dyn()`.
     fn new(
         log_messages_bytes_limit: Option<usize>,
         transaction_status_sender: Option<TransactionStatusSender>,
@@ -90,6 +92,8 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
         })
     }
 
+    // This apparently-meaningless wrapper is handy, because some callers explicitly want
+    // `dyn InstalledSchedulerPool` to be returned for type inference convenience.
     pub fn new_dyn(
         log_messages_bytes_limit: Option<usize>,
         transaction_status_sender: Option<TransactionStatusSender>,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -539,7 +539,7 @@ mod tests {
             genesis_config.hash(),
         ));
         assert_matches!(
-            bank.simulate_transaction_unchecked(tx1.clone()).result,
+            bank.simulate_transaction_unchecked(tx1, false).result,
             Ok(_)
         );
         scheduler.schedule_execution(&(tx1, 0));

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -58,7 +58,7 @@ pub struct SchedulerPool<S: SpawnableScheduler<TH>, TH: TaskHandler> {
     // memory increase.
     weak_self: Weak<Self>,
     next_scheduler_id: AtomicSchedulerId,
-    _phantom: PhantomData<(S, TH)>,
+    _phantom: PhantomData<TH>,
 }
 
 pub type DefaultSchedulerPool =

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -250,8 +250,9 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         let (result, timings) =
             result_with_timings.get_or_insert_with(|| (Ok(()), ExecuteTimings::default()));
 
-        // ... so, we're NOT scheduling at all; rather, just execute tx straight off.  we doesn't
-        // need to solve inter-tx locking deps only in the case of single-thread fifo like this.
+        // ... so, we're NOT scheduling at all here; rather, just execute tx straight off. the
+        // inter-tx locking deps aren't needed to be resolved in the case of single-threaded FIFO
+        // like this.
         if result.is_ok() {
             TH::handle(
                 result,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -174,7 +174,7 @@ impl TaskHandler for DefaultTaskRunner {
         index: usize,
         pool: &SchedulerPool<S, Self>,
     ) {
-        // scheduler must properly prevent conflicting tx executions, task handler isn't
+        // scheduler must properly prevent conflicting tx executions. thus, task handler isn't
         // responsible for locking.
         let batch = bank.prepare_unlocked_batch_from_single_tx(transaction);
         let batch_with_indexes = TransactionBatchWithIndexes {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -239,7 +239,7 @@ impl<TH: TaskHandler> SpawnableScheduler<TH> for PooledScheduler<TH> {
 
     fn into_inner(self) -> (ResultWithTimings, Self::Inner) {
         (
-            self.result_with_timings.into_inner().expect("no poisoned"),
+            self.result_with_timings.into_inner().expect("not poisoned"),
             self.inner,
         )
     }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1,0 +1,749 @@
+//! Transaction scheduling code.
+//!
+//! This crate implements two solana-runtime traits (`InstalledScheduler` and
+//! `InstalledSchedulerPool`) to provide concrete transaction scheduling implementation (including
+//! executing txes and committing tx results).
+//!
+//! At highest level, this crate takes `SanitizedTransaction`s via its `schedule_execution()` and
+//! commits any side-effects (i.e. on-chain state changes) into `Bank`s via `solana-ledger`'s
+//! helper fun called `execute_batch()`.
+
+use {
+    solana_ledger::blockstore_processor::{
+        execute_batch, TransactionBatchWithIndexes, TransactionStatusSender,
+    },
+    solana_program_runtime::timings::ExecuteTimings,
+    solana_runtime::{
+        bank::Bank,
+        installed_scheduler_pool::{
+            InstalledScheduler, InstalledSchedulerPool, InstalledSchedulerPoolArc,
+            ResultWithTimings, SchedulerId, SchedulingContext, WaitReason,
+        },
+        prioritization_fee_cache::PrioritizationFeeCache,
+    },
+    solana_sdk::transaction::{Result, SanitizedTransaction},
+    solana_vote::vote_sender_types::ReplayVoteSender,
+    std::{
+        fmt::Debug,
+        marker::PhantomData,
+        sync::{
+            atomic::{AtomicU64, Ordering::Relaxed},
+            Arc, Mutex, Weak,
+        },
+    },
+};
+
+const PRIMARY_SCHEDULER_ID: SchedulerId = 0;
+type AtomicSchedulerId = AtomicU64;
+
+// SchedulerPool must be accessed via dyn by solana-runtime code, because its internal fields'
+// types aren't available in the solana-runtime (currently TransactionStatusSender; also,
+// PohRecorder in the future)...
+#[derive(Debug)]
+pub struct SchedulerPool<S: SpawnableScheduler<TH>, TH: TaskHandler> {
+    schedulers: Mutex<Vec<Box<S>>>,
+    log_messages_bytes_limit: Option<usize>,
+    transaction_status_sender: Option<TransactionStatusSender>,
+    replay_vote_sender: Option<ReplayVoteSender>,
+    prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    // weak_self could be elided by changing InstalledScheduler::take_scheduler()'s receiver to
+    // Arc<Self> from &Self, because SchedulerPool is used as in the form of Arc<SchedulerPool>
+    // almost always. But, this would cause wasted and noisy Arc::clone()'s at every call sites.
+    //
+    // Alternatively, `impl InstalledScheduler for Arc<SchedulerPool>` approach could be explored
+    // but it entails its own problems due to rustc's coherence and necessitated newtype with the
+    // type graph of InstalledScheduler being quite elaborate.
+    //
+    // After these considerations, this weak_self approach is chosen at the cost of some additional
+    // memory increase.
+    weak_self: Weak<Self>,
+    next_scheduler_id: AtomicSchedulerId,
+    _phantom: PhantomData<(S, TH)>,
+}
+
+pub type DefaultSchedulerPool =
+    SchedulerPool<PooledScheduler<DefaultTaskRunner>, DefaultTaskRunner>;
+
+impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
+    fn new(
+        log_messages_bytes_limit: Option<usize>,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        replay_vote_sender: Option<ReplayVoteSender>,
+        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    ) -> Arc<Self> {
+        Arc::new_cyclic(|weak_self| Self {
+            schedulers: Mutex::default(),
+            log_messages_bytes_limit,
+            transaction_status_sender,
+            replay_vote_sender,
+            prioritization_fee_cache,
+            weak_self: weak_self.clone(),
+            next_scheduler_id: AtomicSchedulerId::new(PRIMARY_SCHEDULER_ID),
+            _phantom: PhantomData,
+        })
+    }
+
+    pub fn new_dyn(
+        log_messages_bytes_limit: Option<usize>,
+        transaction_status_sender: Option<TransactionStatusSender>,
+        replay_vote_sender: Option<ReplayVoteSender>,
+        prioritization_fee_cache: Arc<PrioritizationFeeCache>,
+    ) -> InstalledSchedulerPoolArc {
+        Self::new(
+            log_messages_bytes_limit,
+            transaction_status_sender,
+            replay_vote_sender,
+            prioritization_fee_cache,
+        )
+    }
+
+    // See a comment at the weak_self field for justification of this.
+    fn self_arc(&self) -> Arc<Self> {
+        self.weak_self
+            .upgrade()
+            .expect("self-referencing Arc-ed pool")
+    }
+
+    fn new_scheduler_id(&self) -> SchedulerId {
+        self.next_scheduler_id.fetch_add(1, Relaxed)
+    }
+
+    fn return_scheduler(&self, scheduler: Box<S>) {
+        assert!(!scheduler.has_context());
+
+        self.schedulers
+            .lock()
+            .expect("not poisoned")
+            .push(scheduler);
+    }
+
+    fn do_take_scheduler(&self, context: SchedulingContext) -> Box<S> {
+        // pop is intentional for filo, expecting relatively warmed-up scheduler due to having been
+        // returned recently
+        if let Some(mut scheduler) = self.schedulers.lock().expect("not poisoned").pop() {
+            scheduler.replace_context(context);
+            scheduler
+        } else {
+            Box::new(S::spawn(
+                self.self_arc(),
+                context,
+                TH::recreate_handler_with_pool(self),
+            ))
+        }
+    }
+}
+
+impl<S: SpawnableScheduler<TH>, TH: TaskHandler> InstalledSchedulerPool for SchedulerPool<S, TH> {
+    fn take_scheduler(&self, context: SchedulingContext) -> Box<dyn InstalledScheduler> {
+        self.do_take_scheduler(context)
+    }
+}
+
+pub trait TaskHandler: Send + Sync + Debug + Sized + 'static {
+    fn recreate_handler_with_pool<S: SpawnableScheduler<Self>>(
+        pool: &SchedulerPool<S, Self>,
+    ) -> Self;
+
+    fn handle<S: SpawnableScheduler<Self>>(
+        &self,
+        result: &mut Result<()>,
+        timings: &mut ExecuteTimings,
+        bank: &Arc<Bank>,
+        transaction: &SanitizedTransaction,
+        index: usize,
+        pool: &SchedulerPool<S, Self>,
+    );
+}
+
+#[derive(Debug)]
+pub struct DefaultTaskRunner;
+
+impl TaskHandler for DefaultTaskRunner {
+    fn recreate_handler_with_pool<S: SpawnableScheduler<Self>>(
+        _pool: &SchedulerPool<S, Self>,
+    ) -> Self {
+        Self
+    }
+
+    fn handle<S: SpawnableScheduler<Self>>(
+        &self,
+        result: &mut Result<()>,
+        timings: &mut ExecuteTimings,
+        bank: &Arc<Bank>,
+        transaction: &SanitizedTransaction,
+        index: usize,
+        pool: &SchedulerPool<S, Self>,
+    ) {
+        // scheduler must properly prevent conflicting tx executions, task handler isn't
+        // responsible for locking.
+        let batch = bank.prepare_unlocked_batch_from_single_tx(transaction);
+        let batch_with_indexes = TransactionBatchWithIndexes {
+            batch,
+            transaction_indexes: vec![index],
+        };
+
+        *result = execute_batch(
+            &batch_with_indexes,
+            bank,
+            pool.transaction_status_sender.as_ref(),
+            pool.replay_vote_sender.as_ref(),
+            timings,
+            pool.log_messages_bytes_limit,
+            &pool.prioritization_fee_cache,
+        );
+    }
+}
+
+// Currently, simplest possible implementation (i.e. single-threaded)
+// this will be replaced with more proper implementation...
+// not usable at all, especially for mainnet-beta
+#[derive(Debug)]
+pub struct PooledScheduler<TH: TaskHandler> {
+    id: SchedulerId,
+    pool: Arc<SchedulerPool<Self, TH>>,
+    context: Option<SchedulingContext>,
+    result_with_timings: Mutex<Option<ResultWithTimings>>,
+    handler: TH,
+}
+
+impl<TH: TaskHandler> PooledScheduler<TH> {
+    fn do_spawn(
+        pool: Arc<SchedulerPool<Self, TH>>,
+        initial_context: SchedulingContext,
+        handler: TH,
+    ) -> Self {
+        Self {
+            id: pool.new_scheduler_id(),
+            pool,
+            context: Some(initial_context),
+            result_with_timings: Mutex::default(),
+            handler,
+        }
+    }
+}
+
+pub trait SpawnableScheduler<TH: TaskHandler>: InstalledScheduler {
+    fn has_context(&self) -> bool;
+
+    fn replace_context(&mut self, context: SchedulingContext);
+
+    fn spawn(
+        pool: Arc<SchedulerPool<Self, TH>>,
+        initial_context: SchedulingContext,
+        handler: TH,
+    ) -> Self
+    where
+        Self: Sized;
+}
+
+impl<TH: TaskHandler> SpawnableScheduler<TH> for PooledScheduler<TH> {
+    fn has_context(&self) -> bool {
+        self.context.is_some()
+    }
+
+    fn replace_context(&mut self, context: SchedulingContext) {
+        self.context = Some(context);
+        *self.result_with_timings.lock().expect("not poisoned") = None;
+    }
+
+    fn spawn(
+        pool: Arc<SchedulerPool<Self, TH>>,
+        initial_context: SchedulingContext,
+        handler: TH,
+    ) -> Self {
+        Self::do_spawn(pool, initial_context, handler)
+    }
+}
+
+impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
+    fn id(&self) -> SchedulerId {
+        self.id
+    }
+
+    fn context(&self) -> &SchedulingContext {
+        self.context.as_ref().expect("active context should exist")
+    }
+
+    fn schedule_execution(&self, &(transaction, index): &(&SanitizedTransaction, usize)) {
+        let result_with_timings = &mut *self.result_with_timings.lock().expect("not poisoned");
+        let (result, timings) =
+            result_with_timings.get_or_insert_with(|| (Ok(()), ExecuteTimings::default()));
+
+        // ... so, we're NOT scheduling at all; rather, just execute tx straight off.  we doesn't
+        // need to solve inter-tx locking deps only in the case of single-thread fifo like this.
+        if result.is_ok() {
+            TH::handle(
+                &self.handler,
+                result,
+                timings,
+                self.context().bank(),
+                transaction,
+                index,
+                &self.pool,
+            );
+        }
+    }
+
+    fn wait_for_termination(&mut self, wait_reason: &WaitReason) -> Option<ResultWithTimings> {
+        let keep_result_with_timings = wait_reason.is_paused();
+
+        if keep_result_with_timings {
+            None
+        } else {
+            drop(
+                self.context
+                    .take()
+                    .expect("active context should be dropped"),
+            );
+            // current simplest form of this trait impl doesn't block the current thread materially
+            // just with the following single mutex lock. Suppose more elaborated synchronization
+            // across worker threads here in the future...
+            self.result_with_timings
+                .lock()
+                .expect("not poisoned")
+                .take()
+        }
+    }
+
+    fn return_to_pool(self: Box<Self>) {
+        self.pool.clone().return_scheduler(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        assert_matches::assert_matches,
+        solana_runtime::{
+            bank::Bank,
+            bank_forks::BankForks,
+            genesis_utils::{create_genesis_config, GenesisConfigInfo},
+            installed_scheduler_pool::{BankWithScheduler, SchedulingContext},
+            prioritization_fee_cache::PrioritizationFeeCache,
+        },
+        solana_sdk::{
+            clock::MAX_PROCESSING_AGE,
+            pubkey::Pubkey,
+            signer::keypair::Keypair,
+            system_transaction,
+            transaction::{SanitizedTransaction, TransactionError},
+        },
+        std::{sync::Arc, thread::JoinHandle},
+    };
+
+    #[test]
+    fn test_scheduler_pool_new() {
+        solana_logger::setup();
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+
+        // this indirectly proves that there should be circular link because there's only one Arc
+        // at this moment now
+        assert_eq!((Arc::strong_count(&pool), Arc::weak_count(&pool)), (1, 1));
+        let debug = format!("{pool:#?}");
+        assert!(!debug.is_empty());
+    }
+
+    #[test]
+    fn test_scheduler_spawn() {
+        solana_logger::setup();
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+        let bank = Arc::new(Bank::default_for_tests());
+        let context = SchedulingContext::new(bank);
+        let scheduler = pool.take_scheduler(context);
+
+        let debug = format!("{scheduler:#?}");
+        assert!(!debug.is_empty());
+    }
+
+    #[test]
+    fn test_scheduler_pool_filo() {
+        solana_logger::setup();
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool = DefaultSchedulerPool::new(None, None, None, ignored_prioritization_fee_cache);
+        let bank = Arc::new(Bank::default_for_tests());
+        let context = &SchedulingContext::new(bank);
+
+        let mut scheduler1 = pool.do_take_scheduler(context.clone());
+        let scheduler_id1 = scheduler1.id();
+        let mut scheduler2 = pool.do_take_scheduler(context.clone());
+        let scheduler_id2 = scheduler2.id();
+        assert_ne!(scheduler_id1, scheduler_id2);
+
+        assert_matches!(
+            scheduler1.wait_for_termination(&WaitReason::TerminatedToFreeze),
+            None
+        );
+        pool.return_scheduler(scheduler1);
+        assert_matches!(
+            scheduler2.wait_for_termination(&WaitReason::TerminatedToFreeze),
+            None
+        );
+        pool.return_scheduler(scheduler2);
+
+        let scheduler3 = pool.do_take_scheduler(context.clone());
+        assert_eq!(scheduler_id2, scheduler3.id());
+        let scheduler4 = pool.do_take_scheduler(context.clone());
+        assert_eq!(scheduler_id1, scheduler4.id());
+    }
+
+    #[test]
+    fn test_scheduler_pool_context_drop_unless_reinitialized() {
+        solana_logger::setup();
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool = DefaultSchedulerPool::new(None, None, None, ignored_prioritization_fee_cache);
+        let bank = Arc::new(Bank::default_for_tests());
+        let context = &SchedulingContext::new(bank);
+
+        let mut scheduler = pool.do_take_scheduler(context.clone());
+
+        assert!(scheduler.has_context());
+        assert_matches!(
+            scheduler.wait_for_termination(&WaitReason::PausedForRecentBlockhash),
+            None
+        );
+        assert!(scheduler.has_context());
+        assert_matches!(
+            scheduler.wait_for_termination(&WaitReason::TerminatedToFreeze),
+            None
+        );
+        assert!(!scheduler.has_context());
+    }
+
+    #[test]
+    fn test_scheduler_pool_context_replace() {
+        solana_logger::setup();
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool = DefaultSchedulerPool::new(None, None, None, ignored_prioritization_fee_cache);
+        let old_bank = &Arc::new(Bank::default_for_tests());
+        let new_bank = &Arc::new(Bank::default_for_tests());
+        assert!(!Arc::ptr_eq(old_bank, new_bank));
+
+        let old_context = &SchedulingContext::new(old_bank.clone());
+        let new_context = &SchedulingContext::new(new_bank.clone());
+
+        let mut scheduler = pool.do_take_scheduler(old_context.clone());
+        let scheduler_id = scheduler.id();
+        assert_matches!(
+            scheduler.wait_for_termination(&WaitReason::TerminatedToFreeze),
+            None
+        );
+        pool.return_scheduler(scheduler);
+
+        let scheduler = pool.take_scheduler(new_context.clone());
+        assert_eq!(scheduler_id, scheduler.id());
+        assert!(Arc::ptr_eq(scheduler.context().bank(), new_bank));
+    }
+
+    #[test]
+    fn test_scheduler_pool_install_into_bank_forks() {
+        solana_logger::setup();
+
+        let bank = Bank::default_for_tests();
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let mut bank_forks = bank_forks.write().unwrap();
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+        bank_forks.install_scheduler_pool(pool);
+    }
+
+    #[test]
+    fn test_scheduler_install_into_bank() {
+        solana_logger::setup();
+
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let child_bank = Bank::new_from_parent(bank, &Pubkey::default(), 1);
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+
+        let bank = Bank::default_for_tests();
+        let bank_forks = BankForks::new_rw_arc(bank);
+        let mut bank_forks = bank_forks.write().unwrap();
+
+        // existing banks in bank_forks shouldn't process transactions anymore in general, so
+        // shouldn't be touched
+        assert!(!bank_forks
+            .working_bank_with_scheduler()
+            .has_installed_scheduler());
+        bank_forks.install_scheduler_pool(pool);
+        assert!(!bank_forks
+            .working_bank_with_scheduler()
+            .has_installed_scheduler());
+
+        let mut child_bank = bank_forks.insert(child_bank);
+        assert!(child_bank.has_installed_scheduler());
+        bank_forks.remove(child_bank.slot());
+        child_bank.drop_scheduler();
+        assert!(!child_bank.has_installed_scheduler());
+    }
+
+    #[test]
+    fn test_scheduler_schedule_execution_success() {
+        solana_logger::setup();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let tx0 = &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+        let context = SchedulingContext::new(bank.clone());
+
+        assert_eq!(bank.transaction_count(), 0);
+        let scheduler = pool.take_scheduler(context);
+        scheduler.schedule_execution(&(tx0, 0));
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
+        assert_eq!(bank.transaction_count(), 1);
+    }
+
+    #[test]
+    fn test_scheduler_schedule_execution_failure() {
+        solana_logger::setup();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let unfunded_keypair = Keypair::new();
+        let tx0 = &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &unfunded_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            2,
+            genesis_config.hash(),
+        ));
+        let bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            DefaultSchedulerPool::new_dyn(None, None, None, ignored_prioritization_fee_cache);
+        let context = SchedulingContext::new(bank.clone());
+
+        assert_eq!(bank.transaction_count(), 0);
+        let scheduler = pool.take_scheduler(context);
+        scheduler.schedule_execution(&(tx0, 0));
+        assert_eq!(bank.transaction_count(), 0);
+
+        let tx1 = &SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+            &mint_keypair,
+            &solana_sdk::pubkey::new_rand(),
+            3,
+            genesis_config.hash(),
+        ));
+        assert_matches!(
+            bank.simulate_transaction_unchecked(tx1.clone()).result,
+            Ok(_)
+        );
+        scheduler.schedule_execution(&(tx1, 0));
+        // transaction_count should remain same as scheduler should be bailing out.
+        assert_eq!(bank.transaction_count(), 0);
+
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        assert_matches!(
+            bank.wait_for_completed_scheduler(),
+            Some((
+                Err(solana_sdk::transaction::TransactionError::AccountNotFound),
+                _timings
+            ))
+        );
+    }
+
+    #[derive(Debug)]
+    struct AsyncScheduler<const TRIGGER_RACE_CONDITION: bool>(
+        PooledScheduler<DefaultTaskRunner>,
+        Mutex<Vec<JoinHandle<ResultWithTimings>>>,
+    );
+
+    impl<const TRIGGER_RACE_CONDITION: bool> InstalledScheduler
+        for AsyncScheduler<TRIGGER_RACE_CONDITION>
+    {
+        fn id(&self) -> SchedulerId {
+            self.0.id()
+        }
+
+        fn context(&self) -> &SchedulingContext {
+            self.0.context()
+        }
+
+        fn schedule_execution<'a>(
+            &'a self,
+            &(transaction, index): &'a (&'a SanitizedTransaction, usize),
+        ) {
+            let transaction_and_index = (transaction.clone(), index);
+            let context = self.context().clone();
+            let pool = self.0.pool.clone();
+
+            self.1.lock().unwrap().push(std::thread::spawn(move || {
+                // intentionally sleep to simulate race condition where register_recent_blockhash
+                // is handle before finishing executing scheduled transactions
+                std::thread::sleep(std::time::Duration::from_secs(1));
+
+                let mut result = Ok(());
+                let mut timings = ExecuteTimings::default();
+
+                <DefaultTaskRunner as TaskHandler>::handle(
+                    &DefaultTaskRunner,
+                    &mut result,
+                    &mut timings,
+                    context.bank(),
+                    &transaction_and_index.0,
+                    transaction_and_index.1,
+                    &pool,
+                );
+                (result, timings)
+            }));
+        }
+
+        fn wait_for_termination(&mut self, reason: &WaitReason) -> Option<ResultWithTimings> {
+            if TRIGGER_RACE_CONDITION && matches!(reason, WaitReason::PausedForRecentBlockhash) {
+                // this is equivalent to NOT calling wait_for_paused_scheduler() in
+                // register_recent_blockhash().
+                return None;
+            }
+
+            let mut overall_result = Ok(());
+            let mut overall_timings = ExecuteTimings::default();
+            for handle in self.1.lock().unwrap().drain(..) {
+                let (result, timings) = handle.join().unwrap();
+                match result {
+                    Ok(()) => {}
+                    Err(e) => overall_result = Err(e),
+                }
+                overall_timings.accumulate(&timings);
+            }
+            *self.0.result_with_timings.lock().unwrap() = Some((overall_result, overall_timings));
+
+            self.0.wait_for_termination(reason)
+        }
+
+        fn return_to_pool(self: Box<Self>) {
+            Box::new(self.0).return_to_pool()
+        }
+    }
+
+    impl<const TRIGGER_RACE_CONDITION: bool> SpawnableScheduler<DefaultTaskRunner>
+        for AsyncScheduler<TRIGGER_RACE_CONDITION>
+    {
+        fn has_context(&self) -> bool {
+            self.0.has_context()
+        }
+
+        fn replace_context(&mut self, context: SchedulingContext) {
+            self.0.replace_context(context)
+        }
+
+        fn spawn(
+            pool: Arc<SchedulerPool<Self, DefaultTaskRunner>>,
+            initial_context: SchedulingContext,
+            handler: DefaultTaskRunner,
+        ) -> Self {
+            AsyncScheduler::<TRIGGER_RACE_CONDITION>(
+                PooledScheduler::<DefaultTaskRunner> {
+                    id: pool.new_scheduler_id(),
+                    pool: SchedulerPool::new(
+                        pool.log_messages_bytes_limit,
+                        pool.transaction_status_sender.clone(),
+                        pool.replay_vote_sender.clone(),
+                        pool.prioritization_fee_cache.clone(),
+                    ),
+                    context: Some(initial_context),
+                    result_with_timings: Mutex::default(),
+                    handler,
+                },
+                Mutex::new(vec![]),
+            )
+        }
+    }
+
+    fn do_test_scheduler_schedule_execution_recent_blockhash_edge_case<
+        const TRIGGER_RACE_CONDITION: bool,
+    >() {
+        solana_logger::setup();
+
+        let GenesisConfigInfo {
+            genesis_config,
+            mint_keypair,
+            ..
+        } = create_genesis_config(10_000);
+        let very_old_valid_tx =
+            SanitizedTransaction::from_transaction_for_tests(system_transaction::transfer(
+                &mint_keypair,
+                &solana_sdk::pubkey::new_rand(),
+                2,
+                genesis_config.hash(),
+            ));
+        let mut bank = Arc::new(Bank::new_for_tests(&genesis_config));
+        for _ in 0..MAX_PROCESSING_AGE {
+            bank.fill_bank_with_ticks_for_tests();
+            bank.freeze();
+            bank = Arc::new(Bank::new_from_parent(
+                bank.clone(),
+                &Pubkey::default(),
+                bank.slot().checked_add(1).unwrap(),
+            ));
+        }
+        let context = SchedulingContext::new(bank.clone());
+
+        let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
+        let pool =
+            SchedulerPool::<AsyncScheduler<TRIGGER_RACE_CONDITION>, DefaultTaskRunner>::new_dyn(
+                None,
+                None,
+                None,
+                ignored_prioritization_fee_cache,
+            );
+        let scheduler = pool.take_scheduler(context);
+
+        let bank = BankWithScheduler::new(bank, Some(scheduler));
+        assert_eq!(bank.transaction_count(), 0);
+
+        // schedule but not immediately execute transaction
+        bank.schedule_transaction_executions([(&very_old_valid_tx, &0)].into_iter());
+        // this calls register_recent_blockhash internally
+        bank.fill_bank_with_ticks_for_tests();
+
+        if TRIGGER_RACE_CONDITION {
+            // very_old_valid_tx is wrongly handled as expired!
+            assert_matches!(
+                bank.wait_for_completed_scheduler(),
+                Some((Err(TransactionError::BlockhashNotFound), _))
+            );
+            assert_eq!(bank.transaction_count(), 0);
+        } else {
+            assert_matches!(bank.wait_for_completed_scheduler(), Some((Ok(()), _)));
+            assert_eq!(bank.transaction_count(), 1);
+        }
+    }
+
+    #[test]
+    fn test_scheduler_schedule_execution_recent_blockhash_edge_case_with_race() {
+        do_test_scheduler_schedule_execution_recent_blockhash_edge_case::<true>();
+    }
+
+    #[test]
+    fn test_scheduler_schedule_execution_recent_blockhash_edge_case_without_race() {
+        do_test_scheduler_schedule_execution_recent_blockhash_edge_case::<false>();
+    }
+}

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -271,11 +271,6 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         if keep_result_with_timings {
             None
         } else {
-            drop(
-                self.context
-                    .take()
-                    .expect("active context should be dropped"),
-            );
             // current simplest form of this trait impl doesn't block the current thread materially
             // just with the following single mutex lock. Suppose more elaborated synchronization
             // across worker threads here in the future...
@@ -286,7 +281,12 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         }
     }
 
-    fn return_to_pool(self: Box<Self>) {
+    fn return_to_pool(mut self: Box<Self>) {
+        drop(
+            self.context
+                .take()
+                .expect("active context should be dropped"),
+        );
         self.pool.clone().return_scheduler(self)
     }
 }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -240,7 +240,6 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
         self.id
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
     fn context(&self) -> &SchedulingContext {
         self.context.as_ref().expect("active context should exist")
     }
@@ -257,7 +256,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
             TH::handle(
                 result,
                 timings,
-                self.context.as_ref().unwrap().bank(),
+                self.context().bank(),
                 transaction,
                 index,
                 &self.pool.handler_context,
@@ -564,7 +563,6 @@ mod tests {
             self.0.id()
         }
 
-        #[cfg(feature = "dev-context-only-utils")]
         fn context(&self) -> &SchedulingContext {
             self.0.context()
         }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1,12 +1,12 @@
 //! Transaction scheduling code.
 //!
-//! This crate implements two solana-runtime traits (`InstalledScheduler` and
-//! `InstalledSchedulerPool`) to provide concrete transaction scheduling implementation (including
-//! executing txes and committing tx results).
+//! This crate implements 3 solana-runtime traits (`InstalledScheduler`, `UninstalledScheduler` and
+//! `InstalledSchedulerPool`) to provide a concrete transaction scheduling implementation
+//! (including executing txes and committing tx results).
 //!
-//! At highest level, this crate takes `SanitizedTransaction`s via its `schedule_execution()` and
-//! commits any side-effects (i.e. on-chain state changes) into `Bank`s via `solana-ledger`'s
-//! helper fun called `execute_batch()`.
+//! At the highest level, this crate takes `SanitizedTransaction`s via its `schedule_execution()`
+//! and commits any side-effects (i.e. on-chain state changes) into the associated `Bank` via
+//! `solana-ledger`'s helper function called `execute_batch()`.
 
 use {
     solana_ledger::blockstore_processor::{
@@ -35,9 +35,9 @@ use {
 
 type AtomicSchedulerId = AtomicU64;
 
-// SchedulerPool must be accessed via dyn by solana-runtime code, because its internal fields'
-// types aren't available in the solana-runtime (currently TransactionStatusSender; also,
-// PohRecorder in the future)...
+// SchedulerPool must be accessed as a dyn trait from solana-runtime, because SchedulerPool
+// contain some internal fields, whose types aren't available in solana-runtime (currently
+// TransactionStatusSender; also, PohRecorder in the future)...
 #[derive(Debug)]
 pub struct SchedulerPool<S: SpawnableScheduler<TH>, TH: TaskHandler> {
     scheduler_inners: Mutex<Vec<S::Inner>>,
@@ -107,7 +107,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
         )
     }
 
-    // See a comment at the weak_self field for justification of this.
+    // See a comment at the weak_self field for justification of this method's existence.
     fn self_arc(&self) -> Arc<Self> {
         self.weak_self
             .upgrade()

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -69,7 +69,11 @@ pub struct HandlerContext {
 pub type DefaultSchedulerPool =
     SchedulerPool<PooledScheduler<DefaultTaskHandler>, DefaultTaskHandler>;
 
-impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
+impl<S, TH> SchedulerPool<S, TH>
+where
+    S: SpawnableScheduler<TH>,
+    TH: TaskHandler,
+{
     // Some internal impl and test code want an actual concrete type, NOT the
     // `dyn InstalledSchedulerPool`. So don't merge this into `Self::new_dyn()`.
     fn new(
@@ -137,7 +141,11 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
     }
 }
 
-impl<S: SpawnableScheduler<TH>, TH: TaskHandler> InstalledSchedulerPool for SchedulerPool<S, TH> {
+impl<S, TH> InstalledSchedulerPool for SchedulerPool<S, TH>
+where
+    S: SpawnableScheduler<TH>,
+    TH: TaskHandler,
+{
     fn take_scheduler(&self, context: SchedulingContext) -> InstalledSchedulerBox {
         Box::new(self.do_take_scheduler(context))
     }
@@ -289,8 +297,10 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
     }
 }
 
-impl<S: SpawnableScheduler<TH, Inner = PooledSchedulerInner<S, TH>>, TH: TaskHandler>
-    UninstalledScheduler for PooledSchedulerInner<S, TH>
+impl<S, TH> UninstalledScheduler for PooledSchedulerInner<S, TH>
+where
+    S: SpawnableScheduler<TH, Inner = PooledSchedulerInner<S, TH>>,
+    TH: TaskHandler,
 {
     fn return_to_pool(self: Box<Self>) {
         self.pool.clone().return_scheduler(*self)

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -36,7 +36,7 @@ use {
 type AtomicSchedulerId = AtomicU64;
 
 // SchedulerPool must be accessed as a dyn trait from solana-runtime, because SchedulerPool
-// contain some internal fields, whose types aren't available in solana-runtime (currently
+// contains some internal fields, whose types aren't available in solana-runtime (currently
 // TransactionStatusSender; also, PohRecorder in the future)...
 #[derive(Debug)]
 pub struct SchedulerPool<S: SpawnableScheduler<TH>, TH: TaskHandler> {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -16,8 +16,9 @@ use {
     solana_runtime::{
         bank::Bank,
         installed_scheduler_pool::{
-            InstalledScheduler, InstalledSchedulerPool, InstalledSchedulerPoolArc,
-            ResultWithTimings, SchedulerId, SchedulingContext, UninstalledScheduler,
+            InstalledScheduler, InstalledSchedulerBox, InstalledSchedulerPool,
+            InstalledSchedulerPoolArc, ResultWithTimings, SchedulerId, SchedulingContext,
+            UninstalledScheduler, UninstalledSchedulerBox,
         },
         prioritization_fee_cache::PrioritizationFeeCache,
     },
@@ -137,7 +138,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> SchedulerPool<S, TH> {
 }
 
 impl<S: SpawnableScheduler<TH>, TH: TaskHandler> InstalledSchedulerPool for SchedulerPool<S, TH> {
-    fn take_scheduler(&self, context: SchedulingContext) -> Box<dyn InstalledScheduler> {
+    fn take_scheduler(&self, context: SchedulingContext) -> InstalledSchedulerBox {
         Box::new(self.do_take_scheduler(context))
     }
 }
@@ -284,7 +285,7 @@ impl<TH: TaskHandler> InstalledScheduler for PooledScheduler<TH> {
     fn wait_for_termination(
         mut self: Box<Self>,
         _is_dropped: bool,
-    ) -> (Box<dyn UninstalledScheduler>, ResultWithTimings) {
+    ) -> (UninstalledSchedulerBox, ResultWithTimings) {
         let result_with_timings = self.do_wait_for_termination().unwrap();
         (Box::new(self.into_inner()), result_with_timings)
     }
@@ -609,7 +610,7 @@ mod tests {
         fn wait_for_termination(
             self: Box<Self>,
             is_dropped: bool,
-        ) -> (Box<dyn UninstalledScheduler>, ResultWithTimings) {
+        ) -> (UninstalledSchedulerBox, ResultWithTimings) {
             self.do_wait();
             Box::new(self.0).wait_for_termination(is_dropped)
         }


### PR DESCRIPTION
#### Problem

I'm quite high in the midnight, concluding all the plumbing efforts so far with this pr.

(translate: there's the last missing piece of code (trait impl boilerplates, cli integration), before landing the unified scheduler impl)

#### Summary of Remedies

get some sleep.

(translate: this pr added the last plumbing with extensive unit tests after these plumbing is confirmed to work at https://github.com/ryoqun/solana/pull/15. also, end to end integration niceties: the dreadful local-cluster test and quick-and-dirty `run-sanity.sh` tweaks).

#### Context

extracted from: https://github.com/solana-labs/solana/pull/33070

also note that this is the next big chunk of code (contains the real code for unified scheduler): https://github.com/ryoqun/solana/pull/15 (a bit desynced from the tip of #33070 right now...)