### PR TITLE
RPC: Add inner instructions to simulate transaction response

### DIFF
--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -1,4 +1,9 @@
 // Re-exported since these have moved to `solana_sdk`.
+#[deprecated(
+    since = "1.18.0",
+    note = "Please use `InnerInstruction`, `InnerInstructions`, or \
+    `InnerInstructionsList` from `solana_sdk::inner_instruction` instead"
+)]
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
     crate::{

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -1,8 +1,7 @@
 // Re-exported since these have moved to `solana_sdk`.
 #[deprecated(
     since = "1.18.0",
-    note = "Please use `InnerInstruction`, `InnerInstructions`, or \
-    `InnerInstructionsList` from `solana_sdk::inner_instruction` instead"
+    note = "Please use `solana_sdk::inner_instruction` types instead"
 )]
 pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -1,3 +1,5 @@
+// Re-exported since these have moved to `solana_sdk`.
+pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList};
 use {
     crate::{
         nonce_info::{NonceFull, NonceInfo, NoncePartial},
@@ -104,22 +106,6 @@ impl DurableNonceFee {
         }
     }
 }
-
-/// An ordered list of compiled instructions that were invoked during a
-/// transaction instruction
-pub type InnerInstructions = Vec<InnerInstruction>;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct InnerInstruction {
-    pub instruction: CompiledInstruction,
-    /// Invocation stack height of this instruction. Instruction stack height
-    /// starts at 1 for transaction instructions.
-    pub stack_height: u8,
-}
-
-/// A list of compiled instructions that were invoked during each instruction of
-/// a transaction
-pub type InnerInstructionsList = Vec<InnerInstructions>;
 
 /// Extract the InnerInstructionsList from a TransactionContext
 pub fn inner_instructions_list_from_instruction_trace(

--- a/banks-interface/src/lib.rs
+++ b/banks-interface/src/lib.rs
@@ -8,6 +8,7 @@ use {
         commitment_config::CommitmentLevel,
         fee_calculator::FeeCalculator,
         hash::Hash,
+        inner_instruction::InnerInstructions,
         message::Message,
         pubkey::Pubkey,
         signature::Signature,
@@ -37,6 +38,7 @@ pub struct TransactionSimulationDetails {
     pub logs: Vec<String>,
     pub units_consumed: u64,
     pub return_data: Option<TransactionReturnData>,
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -194,7 +194,7 @@ fn simulate_transaction(
         post_simulation_accounts: _,
         units_consumed,
         return_data,
-    } = bank.simulate_transaction_unchecked(sanitized_transaction);
+    } = bank.simulate_transaction_unchecked(sanitized_transaction, false);
     let simulation_details = TransactionSimulationDetails {
         logs,
         units_consumed,

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -195,7 +195,8 @@ fn simulate_transaction(
         units_consumed,
         return_data,
         inner_instructions,
-    } = bank.simulate_transaction_unchecked(sanitized_transaction, false);
+    } = bank.simulate_transaction_unchecked(&sanitized_transaction, false);
+
     let simulation_details = TransactionSimulationDetails {
         logs,
         units_consumed,

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -194,11 +194,13 @@ fn simulate_transaction(
         post_simulation_accounts: _,
         units_consumed,
         return_data,
+        inner_instructions,
     } = bank.simulate_transaction_unchecked(sanitized_transaction, false);
     let simulation_details = TransactionSimulationDetails {
         logs,
         units_consumed,
         return_data,
+        inner_instructions,
     };
     BanksTransactionResultWithSimulation {
         result: Some(result),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -54,7 +54,7 @@ use {
         transaction::VersionedTransaction,
     },
     solana_transaction_status::{
-        ConfirmedTransactionWithStatusMeta, InnerInstructions, TransactionStatusMeta,
+        map_inner_instructions, ConfirmedTransactionWithStatusMeta, TransactionStatusMeta,
         TransactionWithStatusMeta, VersionedTransactionWithStatusMeta,
     },
     std::collections::HashMap,
@@ -212,21 +212,7 @@ fn execute_transactions(
                     );
 
                     let inner_instructions = inner_instructions.map(|inner_instructions| {
-                        inner_instructions
-                            .into_iter()
-                            .enumerate()
-                            .map(|(index, instructions)| InnerInstructions {
-                                index: index as u8,
-                                instructions: instructions
-                                    .into_iter()
-                                    .map(|ix| solana_transaction_status::InnerInstruction {
-                                        instruction: ix.instruction,
-                                        stack_height: Some(u32::from(ix.stack_height)),
-                                    })
-                                    .collect(),
-                            })
-                            .filter(|i| !i.instructions.is_empty())
-                            .collect()
+                        map_inner_instructions(inner_instructions).collect()
                     });
 
                     let tx_status_meta = TransactionStatusMeta {

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -766,7 +766,7 @@ fn test_return_data_and_log_data_syscall() {
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
         let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
 
-        let result = bank.simulate_transaction(sanitized_tx);
+        let result = bank.simulate_transaction(sanitized_tx, false);
 
         assert!(result.result.is_ok());
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -766,7 +766,7 @@ fn test_return_data_and_log_data_syscall() {
         let transaction = Transaction::new(&[&mint_keypair], message, blockhash);
         let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(transaction);
 
-        let result = bank.simulate_transaction(sanitized_tx, false);
+        let result = bank.simulate_transaction(&sanitized_tx, false);
 
         assert!(result.result.is_ok());
 

--- a/rpc-client-api/src/config.rs
+++ b/rpc-client-api/src/config.rs
@@ -44,6 +44,8 @@ pub struct RpcSimulateTransactionConfig {
     pub encoding: Option<UiTransactionEncoding>,
     pub accounts: Option<RpcSimulateTransactionAccountsConfig>,
     pub min_context_slot: Option<Slot>,
+    #[serde(default)]
+    pub inner_instructions: bool,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -10,8 +10,8 @@ use {
         transaction::{Result, TransactionError},
     },
     solana_transaction_status::{
-        ConfirmedTransactionStatusWithSignature, TransactionConfirmationStatus, UiConfirmedBlock,
-        UiTransactionReturnData,
+        ConfirmedTransactionStatusWithSignature, InnerInstructions, TransactionConfirmationStatus,
+        UiConfirmedBlock, UiTransactionReturnData,
     },
     std::{collections::HashMap, fmt, net::SocketAddr, str::FromStr},
     thiserror::Error,
@@ -423,6 +423,7 @@ pub struct RpcSimulateTransactionResult {
     pub accounts: Option<Vec<Option<UiAccount>>>,
     pub units_consumed: Option<u64>,
     pub return_data: Option<UiTransactionReturnData>,
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rpc-client-api/src/response.rs
+++ b/rpc-client-api/src/response.rs
@@ -10,8 +10,8 @@ use {
         transaction::{Result, TransactionError},
     },
     solana_transaction_status::{
-        ConfirmedTransactionStatusWithSignature, InnerInstructions, TransactionConfirmationStatus,
-        UiConfirmedBlock, UiTransactionReturnData,
+        ConfirmedTransactionStatusWithSignature, TransactionConfirmationStatus, UiConfirmedBlock,
+        UiInnerInstructions, UiTransactionReturnData,
     },
     std::{collections::HashMap, fmt, net::SocketAddr, str::FromStr},
     thiserror::Error,
@@ -423,7 +423,7 @@ pub struct RpcSimulateTransactionResult {
     pub accounts: Option<Vec<Option<UiAccount>>>,
     pub units_consumed: Option<u64>,
     pub return_data: Option<UiTransactionReturnData>,
-    pub inner_instructions: Option<Vec<InnerInstructions>>,
+    pub inner_instructions: Option<Vec<UiInnerInstructions>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]

--- a/rpc-client/src/mock_sender.rs
+++ b/rpc-client/src/mock_sender.rs
@@ -350,6 +350,7 @@ impl RpcSender for MockSender {
                     accounts: None,
                     units_consumed: None,
                     return_data: None,
+                    inner_instructions: None,
                 },
             })?,
             "getMinimumBalanceForRentExemption" => json![20],

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3676,7 +3676,7 @@ pub mod rpc_full {
                     post_simulation_accounts: _,
                     units_consumed,
                     return_data,
-                } = preflight_bank.simulate_transaction(transaction)
+                } = preflight_bank.simulate_transaction(transaction, false)
                 {
                     match err {
                         TransactionError::BlockhashNotFound => {
@@ -3724,7 +3724,7 @@ pub mod rpc_full {
                 encoding,
                 accounts: config_accounts,
                 min_context_slot,
-                inner_instructions: _,
+                inner_instructions: enable_cpi_recording,
             } = config.unwrap_or_default();
             let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base58);
             let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {
@@ -3762,7 +3762,7 @@ pub mod rpc_full {
                 post_simulation_accounts,
                 units_consumed,
                 return_data,
-            } = bank.simulate_transaction(transaction);
+            } = bank.simulate_transaction(transaction, enable_cpi_recording);
 
             let accounts = if let Some(config_accounts) = config_accounts {
                 let accounts_encoding = config_accounts

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3676,6 +3676,7 @@ pub mod rpc_full {
                     post_simulation_accounts: _,
                     units_consumed,
                     return_data,
+                    inner_instructions: _,
                 } = preflight_bank.simulate_transaction(transaction, false)
                 {
                     match err {
@@ -3762,6 +3763,7 @@ pub mod rpc_full {
                 post_simulation_accounts,
                 units_consumed,
                 return_data,
+                inner_instructions: _,
             } = bank.simulate_transaction(transaction, enable_cpi_recording);
 
             let accounts = if let Some(config_accounts) = config_accounts {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -87,9 +87,9 @@ use {
     solana_storage_bigtable::Error as StorageError,
     solana_streamer::socket::SocketAddrSpace,
     solana_transaction_status::{
-        BlockEncodingOptions, ConfirmedBlock, ConfirmedTransactionStatusWithSignature,
-        ConfirmedTransactionWithStatusMeta, EncodedConfirmedTransactionWithStatusMeta,
-        InnerInstruction, InnerInstructions, Reward, RewardType, TransactionBinaryEncoding,
+        map_inner_instructions, BlockEncodingOptions, ConfirmedBlock,
+        ConfirmedTransactionStatusWithSignature, ConfirmedTransactionWithStatusMeta,
+        EncodedConfirmedTransactionWithStatusMeta, Reward, RewardType, TransactionBinaryEncoding,
         TransactionConfirmationStatus, TransactionStatus, UiConfirmedBlock, UiTransactionEncoding,
     },
     solana_vote_program::vote_state::{VoteState, MAX_LOCKOUT_HISTORY},
@@ -3812,19 +3812,7 @@ pub mod rpc_full {
             };
 
             let inner_instructions = inner_instructions.map(|info| {
-                info.into_iter()
-                    .enumerate()
-                    .map(|(index, instructions)| InnerInstructions {
-                        index: index as u8,
-                        instructions: instructions
-                            .into_iter()
-                            .map(|info| InnerInstruction {
-                                stack_height: Some(u32::from(info.stack_height)),
-                                instruction: info.instruction,
-                            })
-                            .collect(),
-                    })
-                    .filter(|i| !i.instructions.is_empty())
+                map_inner_instructions(info)
                     .map(|converted| UiInnerInstructions::parse(converted, &account_keys))
                     .collect()
             });

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -3724,6 +3724,7 @@ pub mod rpc_full {
                 encoding,
                 accounts: config_accounts,
                 min_context_slot,
+                inner_instructions: _,
             } = config.unwrap_or_default();
             let tx_encoding = encoding.unwrap_or(UiTransactionEncoding::Base58);
             let binary_encoding = tx_encoding.into_binary_encoding().ok_or_else(|| {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -8,7 +8,7 @@ use {
         blockstore_processor::{TransactionStatusBatch, TransactionStatusMessage},
     },
     solana_transaction_status::{
-        extract_and_fmt_memos, InnerInstruction, InnerInstructions, Reward, TransactionStatusMeta,
+        extract_and_fmt_memos, map_inner_instructions, Reward, TransactionStatusMeta,
     },
     std::{
         sync::{
@@ -121,21 +121,7 @@ impl TransactionStatusService {
                         let tx_account_locks = transaction.get_account_locks_unchecked();
 
                         let inner_instructions = inner_instructions.map(|inner_instructions| {
-                            inner_instructions
-                                .into_iter()
-                                .enumerate()
-                                .map(|(index, instructions)| InnerInstructions {
-                                    index: index as u8,
-                                    instructions: instructions
-                                        .into_iter()
-                                        .map(|info| InnerInstruction {
-                                            instruction: info.instruction,
-                                            stack_height: Some(u32::from(info.stack_height)),
-                                        })
-                                        .collect(),
-                                })
-                                .filter(|i| !i.instructions.is_empty())
-                                .collect()
+                            map_inner_instructions(inner_instructions).collect()
                         });
 
                         let pre_token_balances = Some(pre_token_balances);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -150,6 +150,7 @@ use {
         hash::{extend_and_hash, hashv, Hash},
         incinerator,
         inflation::Inflation,
+        inner_instruction::InnerInstructions,
         instruction::InstructionError,
         loader_v4::{self, LoaderV4State, LoaderV4Status},
         message::{AccountKeys, SanitizedMessage},
@@ -338,6 +339,7 @@ pub struct TransactionSimulationResult {
     pub post_simulation_accounts: Vec<TransactionAccount>,
     pub units_consumed: u64,
     pub return_data: Option<TransactionReturnData>,
+    pub inner_instructions: Option<Vec<InnerInstructions>>,
 }
 pub struct TransactionBalancesSet {
     pub pre_balances: TransactionBalances,
@@ -4376,11 +4378,13 @@ impl Bank {
 
         let execution_result = execution_results.pop().unwrap();
         let flattened_result = execution_result.flattened_result();
-        let (logs, return_data) = match execution_result {
-            TransactionExecutionResult::Executed { details, .. } => {
-                (details.log_messages, details.return_data)
-            }
-            TransactionExecutionResult::NotExecuted(_) => (None, None),
+        let (logs, return_data, inner_instructions) = match execution_result {
+            TransactionExecutionResult::Executed { details, .. } => (
+                details.log_messages,
+                details.return_data,
+                details.inner_instructions,
+            ),
+            TransactionExecutionResult::NotExecuted(_) => (None, None, None),
         };
         let logs = logs.unwrap_or_default();
 
@@ -4390,6 +4394,7 @@ impl Bank {
             post_simulation_accounts,
             units_consumed,
             return_data,
+            inner_instructions,
         }
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4309,10 +4309,11 @@ impl Bank {
     pub fn simulate_transaction(
         &self,
         transaction: SanitizedTransaction,
+        enable_cpi_recording: bool,
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
 
-        self.simulate_transaction_unchecked(transaction)
+        self.simulate_transaction_unchecked(transaction, enable_cpi_recording)
     }
 
     /// Run transactions against a bank without committing the results; does not check if the bank
@@ -4320,6 +4321,7 @@ impl Bank {
     pub fn simulate_transaction_unchecked(
         &self,
         transaction: SanitizedTransaction,
+        enable_cpi_recording: bool,
     ) -> TransactionSimulationResult {
         let account_keys = transaction.message().account_keys();
         let number_of_accounts = account_keys.len();
@@ -4337,7 +4339,7 @@ impl Bank {
             // for processing. During forwarding, the transaction could expire if the
             // delay is not accounted for.
             MAX_PROCESSING_AGE - MAX_TRANSACTION_FORWARDING_DELAY,
-            false,
+            enable_cpi_recording,
             true,
             true,
             &mut timings,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4310,7 +4310,7 @@ impl Bank {
     /// Run transactions against a frozen bank without committing the results
     pub fn simulate_transaction(
         &self,
-        transaction: SanitizedTransaction,
+        transaction: &SanitizedTransaction,
         enable_cpi_recording: bool,
     ) -> TransactionSimulationResult {
         assert!(self.is_frozen(), "simulation bank must be frozen");
@@ -4322,13 +4322,13 @@ impl Bank {
     /// is frozen, enabling use in single-Bank test frameworks
     pub fn simulate_transaction_unchecked(
         &self,
-        transaction: SanitizedTransaction,
+        transaction: &SanitizedTransaction,
         enable_cpi_recording: bool,
     ) -> TransactionSimulationResult {
         let account_keys = transaction.message().account_keys();
         let number_of_accounts = account_keys.len();
         let account_overrides = self.get_account_overrides_for_simulation(&account_keys);
-        let batch = self.prepare_unlocked_batch_from_single_tx(&transaction);
+        let batch = self.prepare_unlocked_batch_from_single_tx(transaction);
         let mut timings = ExecuteTimings::default();
 
         let LoadAndExecuteTransactionsOutput {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -14136,6 +14136,6 @@ fn test_failed_simulation_compute_units() {
 
     bank.freeze();
     let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(sanitized, false);
+    let simulation = bank.simulate_transaction(&sanitized, false);
     assert_eq!(TEST_UNITS, simulation.units_consumed);
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -14136,6 +14136,6 @@ fn test_failed_simulation_compute_units() {
 
     bank.freeze();
     let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
-    let simulation = bank.simulate_transaction(sanitized);
+    let simulation = bank.simulate_transaction(sanitized, false);
     assert_eq!(TEST_UNITS, simulation.units_consumed);
 }

--- a/sdk/src/inner_instruction.rs
+++ b/sdk/src/inner_instruction.rs
@@ -1,0 +1,21 @@
+use {
+    crate::instruction::CompiledInstruction,
+    serde::{Deserialize, Serialize},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InnerInstruction {
+    pub instruction: CompiledInstruction,
+    /// Invocation stack height of this instruction. Instruction stack height
+    /// starts at 1 for transaction instructions.
+    pub stack_height: u8,
+}
+
+/// An ordered list of compiled instructions that were invoked during a
+/// transaction instruction
+pub type InnerInstructions = Vec<InnerInstruction>;
+
+/// A list of compiled instructions that were invoked during each instruction of
+/// a transaction
+pub type InnerInstructionsList = Vec<InnerInstructions>;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -78,6 +78,7 @@ pub mod genesis_config;
 pub mod hard_forks;
 pub mod hash;
 pub mod inflation;
+pub mod inner_instruction;
 pub mod log;
 pub mod native_loader;
 pub mod net;

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -230,6 +230,27 @@ pub struct InnerInstruction {
     pub stack_height: Option<u32>,
 }
 
+/// Maps a list of inner instructions from `solana_sdk` into a list of this
+/// crate's representation of inner instructions (with instruction indices).
+pub fn map_inner_instructions(
+    inner_instructions: solana_sdk::inner_instruction::InnerInstructionsList,
+) -> impl Iterator<Item = InnerInstructions> {
+    inner_instructions
+        .into_iter()
+        .enumerate()
+        .map(|(index, instructions)| InnerInstructions {
+            index: index as u8,
+            instructions: instructions
+                .into_iter()
+                .map(|info| InnerInstruction {
+                    stack_height: Some(u32::from(info.stack_height)),
+                    instruction: info.instruction,
+                })
+                .collect(),
+        })
+        .filter(|i| !i.instructions.is_empty())
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UiInnerInstructions {

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -240,7 +240,7 @@ pub struct UiInnerInstructions {
 }
 
 impl UiInnerInstructions {
-    fn parse(inner_instructions: InnerInstructions, account_keys: &AccountKeys) -> Self {
+    pub fn parse(inner_instructions: InnerInstructions, account_keys: &AccountKeys) -> Self {
         Self {
             index: inner_instructions.index,
             instructions: inner_instructions


### PR DESCRIPTION
#### Problem
Wallets use transaction simulation to notify users about the contents of a transaction before they apply their signature. This is the primary method by which wallets, and potentially other dApps and infrastructure, detect malicious instructions.

Currently, transaction simulation offers the ability to observe the resulting account state for various account keys provided and transaction logs. However, it would provide even more enhanced security for Solana users if transaction simulation also returned the parsed inner instructions of a transaction.

#### Summary of Changes
The RPC change includes adding an optional parameter - `innerInstructions: bool` - to `simulateTransaction`, and adding `jsonParsed` inner instructions to the response type if `innerInstructions` is provided as `true`. Similar to `getTransaction`, if the instruction cannot be parsed with `jsonParsed`, it defaults to `json`, where the `data` field is base58 encoded.

This change also required the bank to return `inner_instructions` from its `simulate_transaction` method.