### PR TITLE
[zk-token-sdk] Fix transfer with fee edge case error

### DIFF
--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -41,6 +41,8 @@ use {
 const MAX_FEE_BASIS_POINTS: u64 = 10_000;
 #[cfg(not(target_os = "solana"))]
 const ONE_IN_BASIS_POINTS: u128 = MAX_FEE_BASIS_POINTS as u128;
+#[cfg(not(target_os = "solana"))]
+const MAX_DELTA_RANGE: u64 = MAX_FEE_BASIS_POINTS - 1;
 
 #[cfg(not(target_os = "solana"))]
 const TRANSFER_SOURCE_AMOUNT_BITS: usize = 64;
@@ -62,6 +64,7 @@ lazy_static::lazy_static! {
     pub static ref COMMITMENT_MAX: PedersenCommitment = Pedersen::encode((1_u64 <<
                                                                          TRANSFER_AMOUNT_LO_NEGATED_BITS) - 1);
     pub static ref COMMITMENT_MAX_FEE_BASIS_POINTS: PedersenCommitment = Pedersen::encode(MAX_FEE_BASIS_POINTS);
+    pub static ref COMMITMENT_MAX_DELTA_RANGE: PedersenCommitment = Pedersen::encode(MAX_DELTA_RANGE);
 }
 
 /// The instruction data that is needed for the `ProofInstruction::TransferWithFee` instruction.
@@ -563,7 +566,7 @@ impl TransferWithFeeProof {
                 transfer_amount_lo,
                 transfer_amount_hi,
                 delta_fee,
-                MAX_FEE_BASIS_POINTS - delta_fee,
+                MAX_DELTA_RANGE - delta_fee,
                 fee_amount_lo,
                 fee_amount_hi,
             ],
@@ -708,7 +711,7 @@ impl TransferWithFeeProof {
 
         // verify range proof
         let new_source_commitment = self.new_source_commitment.try_into()?;
-        let claimed_commitment_negated = &(*COMMITMENT_MAX_FEE_BASIS_POINTS) - &claimed_commitment;
+        let claimed_commitment_negated = &(*COMMITMENT_MAX_DELTA_RANGE) - &claimed_commitment;
 
         range_proof.verify(
             vec![

--- a/zk-token-sdk/src/instruction/transfer/with_fee.rs
+++ b/zk-token-sdk/src/instruction/transfer/with_fee.rs
@@ -566,8 +566,14 @@ impl TransferWithFeeProof {
             transfer_amount_hi,
             TRANSFER_AMOUNT_LO_BITS,
         );
-        let amount_sub_fee = combined_amount - combined_fee_amount;
+        let amount_sub_fee = combined_amount
+            .checked_sub(combined_fee_amount)
+            .ok_or(ProofGenerationError::FeeCalculation)?;
         let amount_sub_fee_opening = combined_opening - combined_fee_opening;
+
+        let delta_negated = MAX_DELTA_RANGE
+            .checked_sub(delta_fee)
+            .ok_or(ProofGenerationError::FeeCalculation)?;
 
         let range_proof = RangeProof::new(
             vec![
@@ -575,7 +581,7 @@ impl TransferWithFeeProof {
                 transfer_amount_lo,
                 transfer_amount_hi,
                 delta_fee,
-                MAX_DELTA_RANGE - delta_fee,
+                delta_negated,
                 fee_amount_lo,
                 fee_amount_hi,
                 amount_sub_fee,


### PR DESCRIPTION
#### Problem
In the way the transfer with fee proof is currently calculated, it is possible for transfer fee to be greater than the transfer amount. This stems from some edge cases that were missed in the way range proof is used.
1. We call the difference of `transfer_fee * 10_000 - transfer_amount * fee_basis_point` the `delta_fee`. If the fee is calculated correctly, then the `delta_fee` must be in the range `0 <= delta_fee < 10_000`. We use range proof to check this. However, since range proof only works for ranges of power-of-two, we require the prover to generate two range proofs: (i) `0 <= delta_fee < 16_384` (16384 = 2^14) and (ii) `0 <= 10_000 - delta_fee < 16_384`. However, if `delta_fee = 10_000`, then both conditions (i) and (ii) are satisfied. What we really want for condition (ii) is `0 <= 9_999 - delta_fee < 16_384`.
2. If the calculated fee is less than the max fee parameter, then the fee sigma proof enforces the transfer fee to be less than or equal to the transfer amount. However, if the max fee parameter is greater than the transfer amount, then the fee sigma proof is insufficient to certify that the fee is at most the transfer amount.

https://github.com/solana-labs/solana/issues/33526

#### Summary of Changes
1. Fixed the off-by-one error
2. Added an additional range proof to certify that the transfer fee is at most the transfer amount. Specifically, in the batched range proof condition, I added the condition `transfer_amount - transfer_fee` is a positive 64-bit number. Since the range proofs are batched, this additional condition does not increase the cost or size of the range proof itself.
3. Removed unchecked arithmetic.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
