### PR TITLE
Removes unnecessary #[allow(dead_code)] in tiered storage

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! The account meta and related structs for hot accounts.
 
 use {

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -1,5 +1,5 @@
-#![allow(dead_code)]
 //! The account meta and related structs for the tiered storage.
+
 use {
     crate::{accounts_hash::AccountHash, tiered_storage::owners::OwnerOffset},
     modular_bitfield::prelude::*,


### PR DESCRIPTION
#### Problem

There are unnecessary `#[allow(dead_code)]`s in the tiered storage module.


#### Summary of Changes

Remove them.