### PR TITLE
Removes unnecessary #[allow(dead_code)] in partitioned rewards

### DIFF
--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -2,7 +2,6 @@
 //!
 use solana_sdk::clock::Slot;
 
-#[allow(dead_code)]
 #[derive(Debug)]
 /// Configuration options for partitioned epoch rewards.
 /// This struct allows various forms of testing, especially prior to feature activation.
@@ -53,7 +52,6 @@ pub enum TestPartitionedEpochRewards {
     },
 }
 
-#[allow(dead_code)]
 impl PartitionedEpochRewardsConfig {
     pub fn new(test: TestPartitionedEpochRewards) -> Self {
         match test {

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -167,7 +167,6 @@ pub(crate) struct RewardsStoreMetrics {
     pub(crate) post_capitalization: u64,
 }
 
-#[allow(dead_code)]
 pub(crate) fn report_partitioned_reward_metrics(bank: &Bank, timings: RewardsStoreMetrics) {
     datapoint_info!(
         "bank-partitioned_epoch_rewards_credit",


### PR DESCRIPTION
#### Problem

There are unnecessary `#[allow(dead_code)]`s in the partitioned rewards code.


#### Summary of Changes

Remove them.