### PR TITLE
Removes unnecessary #[allow(dead_code)] in stake flags

### DIFF
--- a/sdk/program/src/stake/stake_flags.rs
+++ b/sdk/program/src/stake/stake_flags.rs
@@ -1,7 +1,6 @@
 use borsh::{BorshDeserialize, BorshSchema, BorshSerialize};
 
 /// Additional flags for stake state.
-#[allow(dead_code)]
 #[derive(
     Serialize,
     Deserialize,
@@ -23,7 +22,6 @@ pub struct StakeFlags {
 }
 
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
-#[allow(dead_code)]
 impl StakeFlags {
     ///  Stake must be fully activated before deactivation is allowed (bit 1).
     pub const MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED: Self =
@@ -52,7 +50,6 @@ impl StakeFlags {
     }
 }
 
-#[allow(dead_code)]
 impl Default for StakeFlags {
     fn default() -> Self {
         StakeFlags::empty()


### PR DESCRIPTION
#### Problem

There are unnecessary `#[allow(dead_code)]`s in the stake flags code.


#### Summary of Changes

Remove them.