### PR TITLE
Removes unnecessary #[allow(dead_code)] in bucket map

### DIFF
--- a/bucket_map/src/bucket.rs
+++ b/bucket_map/src/bucket.rs
@@ -116,7 +116,6 @@ pub struct Bucket<T: Copy + PartialEq + 'static> {
 
     /// true if this bucket was loaded (as opposed to created blank).
     /// When populating, we want to prioritize looking for data on disk that already matches as opposed to writing new data.
-    #[allow(dead_code)]
     reused_file_at_startup: bool,
 }
 

--- a/bucket_map/src/bucket_api.rs
+++ b/bucket_map/src/bucket_api.rs
@@ -26,7 +26,6 @@ pub struct BucketApi<T: Clone + Copy + PartialEq + 'static> {
 
     /// keeps track of which index file this bucket is currently using
     /// or at startup, which bucket file this bucket should initially use
-    #[allow(dead_code)]
     restartable_bucket: RestartableBucket,
 }
 

--- a/bucket_map/src/bucket_storage.rs
+++ b/bucket_map/src/bucket_storage.rs
@@ -219,8 +219,6 @@ impl<O: BucketOccupied> BucketStorage<O> {
         offset
     }
 
-    // temporary tag
-    #[allow(dead_code)]
     /// load and mmap the file that is this disk bucket if possible
     pub(crate) fn load_on_restart(
         path: PathBuf,


### PR DESCRIPTION
#### Problem

There are unnecessary `#[allow(dead_code)]`s in the bucket map code.


#### Summary of Changes

Remove them.