### PR TITLE
ci: block automerge until clippy (macos-latest) green

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -58,6 +58,9 @@ pull_request_rules:
           # only require docs checks if docs files changed
           - -files~=^docs/
           - status-success=build & deploy docs
+        - or:
+          - -files~=(\.rs|Cargo\.toml|Cargo\.lock)$
+          - check-success=clippy (macos-latest)
     actions:
       merge:
         method: squash


### PR DESCRIPTION
#### Problem

I forgot to add `clippy (macos-latest)` to our mergify auto-merge check:

https://discord.com/channels/428295358100013066/560503042458517505/1181629892803178586

#### Summary of Changes

add it!