### PR TITLE
Refactor: TransactionBatch can own or borrow a slice of borrowable transactions

### DIFF
--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -5,6 +5,7 @@ use {
         accounts::account_rent_state::{check_rent_state_with_account, RentState},
         bank::RewardInterval,
     },
+    core::borrow::Borrow,
     itertools::Itertools,
     log::warn,
     solana_accounts_db::{
@@ -51,7 +52,7 @@ use {
 pub(super) fn load_accounts(
     accounts_db: &AccountsDb,
     ancestors: &Ancestors,
-    txs: &[SanitizedTransaction],
+    txs: &[impl Borrow<SanitizedTransaction>],
     lock_results: Vec<TransactionCheckResult>,
     hash_queue: &BlockhashQueue,
     error_counters: &mut TransactionErrorMetrics,
@@ -68,6 +69,7 @@ pub(super) fn load_accounts(
         .zip(lock_results)
         .map(|etx| match etx {
             (tx, (Ok(()), nonce)) => {
+                let tx = tx.borrow();
                 let lamports_per_signature = nonce
                     .as_ref()
                     .map(|nonce| nonce.lamports_per_signature())

--- a/runtime/src/bank_utils.rs
+++ b/runtime/src/bank_utils.rs
@@ -4,6 +4,7 @@ use {
         bank::Bank,
         genesis_utils::{self, GenesisConfigInfo, ValidatorVoteKeypairs},
     },
+    core::borrow::Borrow,
     solana_sdk::{pubkey::Pubkey, signature::Signer},
 };
 use {
@@ -37,7 +38,7 @@ pub fn setup_bank_and_vote_pubkeys_for_tests(
 }
 
 pub fn find_and_send_votes(
-    sanitized_txs: &[SanitizedTransaction],
+    sanitized_txs: &[impl Borrow<SanitizedTransaction>],
     tx_results: &TransactionResults,
     vote_sender: Option<&ReplayVoteSender>,
 ) {
@@ -49,6 +50,7 @@ pub fn find_and_send_votes(
             .iter()
             .zip(execution_results.iter())
             .for_each(|(tx, result)| {
+                let tx = tx.borrow();
                 if tx.is_simple_vote_transaction() && result.was_executed_successfully() {
                     if let Some(parsed_vote) = vote_parser::parse_sanitized_vote_transaction(tx) {
                         if parsed_vote.1.last_voted_slot().is_some() {


### PR DESCRIPTION
#### Problem

**Experimental refactoring for a transaction scheduler w/ separate receiving**

Much of the transaction processing code is inflexible in terms of ownership of transactions.
While functions handling **individual** transactions correctly take references (or things that can be coerced into references), batch/slice processing functions require that the slice owns the `SanitizedTransaction`.
This is not strictly necessary, and makes the functions not work if we have things like:

- Slice of references: `&[&SanitizedTransaction]`
- Slice of Arc or Rc: `&[&Arc<SanitizedTransaction>]`

#### Summary of Changes
- In functions taking `&[SanitizedTransaction]`, instead take `&[impl Borrow<SanitizedTransaction>]`
- `TransactionBatch` internally stores a `Borrow<[Borrow<SanitizedTransaction>]>`
  - No longer use `Cow`, since that doesn't work with a `Borrow<SanitizedTransaction>`, and we do not need the "clone on write" behavior...since it's immutable.
- `TransactionBatchWithIndexes` uses a concrete `TransactionBatch` type with a non-owned slice of owned `SanitizedTransaction`  

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
