### PR TITLE
Removes glob import of SnapshotKind

### DIFF
--- a/runtime/src/snapshot_package/compare.rs
+++ b/runtime/src/snapshot_package/compare.rs
@@ -33,22 +33,22 @@ pub fn cmp_accounts_package_kinds_by_priority(
     a: &AccountsPackageKind,
     b: &AccountsPackageKind,
 ) -> Ordering {
-    use AccountsPackageKind::*;
+    use AccountsPackageKind as Kind;
     match (a, b) {
         // Epoch Accounts Hash packages
-        (EpochAccountsHash, EpochAccountsHash) => Equal,
-        (EpochAccountsHash, _) => Greater,
-        (_, EpochAccountsHash) => Less,
+        (Kind::EpochAccountsHash, Kind::EpochAccountsHash) => Equal,
+        (Kind::EpochAccountsHash, _) => Greater,
+        (_, Kind::EpochAccountsHash) => Less,
 
         // Snapshot packages
-        (Snapshot(snapshot_kind_a), Snapshot(snapshot_kind_b)) => {
+        (Kind::Snapshot(snapshot_kind_a), Kind::Snapshot(snapshot_kind_b)) => {
             cmp_snapshot_kinds_by_priority(snapshot_kind_a, snapshot_kind_b)
         }
-        (Snapshot(_), _) => Greater,
-        (_, Snapshot(_)) => Less,
+        (Kind::Snapshot(_), _) => Greater,
+        (_, Kind::Snapshot(_)) => Less,
 
         // Accounts Hash Verifier packages
-        (AccountsHashVerifier, AccountsHashVerifier) => Equal,
+        (Kind::AccountsHashVerifier, Kind::AccountsHashVerifier) => Equal,
     }
 }
 
@@ -58,12 +58,12 @@ pub fn cmp_accounts_package_kinds_by_priority(
 /// If two `IncrementalSnapshot`s are compared, their base slots are the tiebreaker.
 #[must_use]
 pub fn cmp_snapshot_kinds_by_priority(a: &SnapshotKind, b: &SnapshotKind) -> Ordering {
-    use SnapshotKind::*;
+    use SnapshotKind as Kind;
     match (a, b) {
-        (FullSnapshot, FullSnapshot) => Equal,
-        (FullSnapshot, IncrementalSnapshot(_)) => Greater,
-        (IncrementalSnapshot(_), FullSnapshot) => Less,
-        (IncrementalSnapshot(base_slot_a), IncrementalSnapshot(base_slot_b)) => {
+        (Kind::FullSnapshot, Kind::FullSnapshot) => Equal,
+        (Kind::FullSnapshot, Kind::IncrementalSnapshot(_)) => Greater,
+        (Kind::IncrementalSnapshot(_), Kind::FullSnapshot) => Less,
+        (Kind::IncrementalSnapshot(base_slot_a), Kind::IncrementalSnapshot(base_slot_b)) => {
             base_slot_a.cmp(base_slot_b)
         }
     }


### PR DESCRIPTION
#### Problem

Well... today I learned about glob imports of enums and how they interact with match statements. Basically, glob imports of an enum that are used with a `match` can be a footgun. Refer to this playground:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9f0ce5f074f7b4a71f487ae8c6a1902d


#### Summary of Changes

Removes glob import of SnapshotKind and AccountsPackageKind.