### PR TITLE
Removes glob import of ApplyFeatureActivationsCaller

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7875,11 +7875,11 @@ impl Bank {
         caller: ApplyFeatureActivationsCaller,
         debug_do_not_add_builtins: bool,
     ) {
-        use ApplyFeatureActivationsCaller::*;
+        use ApplyFeatureActivationsCaller as Caller;
         let allow_new_activations = match caller {
-            FinishInit => false,
-            NewFromParent => true,
-            WarpFromParent => false,
+            Caller::FinishInit => false,
+            Caller::NewFromParent => true,
+            Caller::WarpFromParent => false,
         };
         let (feature_set, new_feature_activations) =
             self.compute_active_feature_set(allow_new_activations);


### PR DESCRIPTION
#### Problem

Well... today I learned about glob imports of enums and how they interact with match statements. Basically, glob imports of an enum that are used with a `match` can be a footgun. Refer to this playground:

https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9f0ce5f074f7b4a71f487ae8c6a1902d


#### Summary of Changes

Removes glob import of ApplyFeatureActivationsCaller.