### PR TITLE
ci: get macos clippy auto-merge check follow the triggering rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -59,7 +59,7 @@ pull_request_rules:
           - -files~=^docs/
           - status-success=build & deploy docs
         - or:
-          - -files~=(\.rs|Cargo\.toml|Cargo\.lock)$
+          - -files~=(\.rs|Cargo\.toml|Cargo\.lock|\.github/scripts/cargo-clippy-before-script\.sh|\.github/workflows/cargo\.yml)$
           - check-success=clippy (macos-latest)
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-bpf|cargo-test-bpf|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl.sh|.github/workflows/downstream-project-spl.yml)$


### PR DESCRIPTION
#### Summary of Changes

get macos clippy auto-merge check follow the triggering rules!

https://github.com/solana-labs/solana/blob/fa251768b301f13535dec9ce663ec663bc746271/.github/workflows/cargo.yml#L12-L17