### PR TITLE
Remove WorkingSlot

### DIFF
--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -115,7 +115,7 @@ fn setup(apply_cost_tracker_during_replay: bool) -> BenchFrame {
     bank.write_cost_tracker()
         .unwrap()
         .set_limits(std::u64::MAX, std::u64::MAX, std::u64::MAX);
-    let bank = Arc::new(bank);
+    let bank = bank.wrap_with_bank_forks_for_tests().0;
 
     let ledger_path = TempDir::new().unwrap();
     let blockstore = Arc::new(

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -114,7 +114,7 @@ use {
         loaded_programs::{
             ExtractedPrograms, LoadProgramMetrics, LoadedProgram, LoadedProgramMatchCriteria,
             LoadedProgramType, LoadedPrograms, LoadedProgramsForTxBatch, ProgramRuntimeEnvironment,
-            ProgramRuntimeEnvironments, WorkingSlot, DELAY_VISIBILITY_SLOT_OFFSET,
+            ProgramRuntimeEnvironments, DELAY_VISIBILITY_SLOT_OFFSET,
         },
         log_collector::LogCollector,
         message_processor::MessageProcessor,
@@ -935,19 +935,6 @@ pub struct CommitTransactionCounts {
     pub signature_count: u64,
 }
 
-impl WorkingSlot for Bank {
-    fn current_slot(&self) -> Slot {
-        self.slot
-    }
-
-    fn current_epoch(&self) -> Epoch {
-        self.epoch
-    }
-
-    fn is_ancestor(&self, other: Slot) -> bool {
-        self.ancestors.contains_key(&other)
-    }
-}
 #[derive(Debug, Default)]
 /// result of calculating the stake rewards at end of epoch
 struct StakeRewardCalculation {
@@ -5024,7 +5011,7 @@ impl Bank {
             let loaded_programs_cache = self.loaded_programs_cache.read().unwrap();
             Mutex::into_inner(
                 Arc::into_inner(
-                    loaded_programs_cache.extract(self, programs_and_slots.into_iter()),
+                    loaded_programs_cache.extract(self.slot, programs_and_slots.into_iter()),
                 )
                 .unwrap(),
             )


### PR DESCRIPTION
#### Problem

We need to remove `WorkingSlot`, as described in https://github.com/solana-labs/solana/issues/34169, so that cooperative program loading becomes more straightforward.

#### Summary of Changes

I have removed the trait `WorkingSlot` and all its references.

Fixes #34169
