### PR TITLE
[TieredStorage] Boundary check for accessing hot account meta

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -283,9 +283,10 @@ impl HotStorageReader {
     ) -> TieredStorageResult<&HotAccountMeta> {
         let internal_account_offset = account_offset.offset();
         assert!(
-            internal_account_offset <= 
-            (self.footer.index_block_offset as usize)
-                .saturating_sub(std::mem::size_of::<HotAccountMeta>()));
+            internal_account_offset
+                <= (self.footer.index_block_offset as usize)
+                    .saturating_sub(std::mem::size_of::<HotAccountMeta>())
+        );
 
         let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, internal_account_offset)?;
         Ok(meta)

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -282,6 +282,15 @@ impl HotStorageReader {
         account_offset: HotAccountOffset,
     ) -> TieredStorageResult<&HotAccountMeta> {
         let internal_account_offset = account_offset.offset();
+        let boundary = (self.footer.index_block_offset as usize)
+            .saturating_sub(std::mem::size_of::<HotAccountMeta>());
+
+        if internal_account_offset > boundary {
+            return Err(TieredStorageError::OffsetOutOfBounds(
+                internal_account_offset,
+                boundary,
+            ));
+        }
 
         let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, internal_account_offset)?;
         Ok(meta)
@@ -538,7 +547,7 @@ pub mod tests {
             .collect();
 
         let account_offsets: Vec<_>;
-        let footer = TieredStorageFooter {
+        let mut footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             account_entry_count: NUM_ACCOUNTS,
             ..TieredStorageFooter::default()
@@ -557,6 +566,7 @@ pub mod tests {
                 .collect();
             // while the test only focuses on account metas, writing a footer
             // here is necessary to make it a valid tiered-storage file.
+            footer.index_block_offset = current_offset as u64;
             footer.write_footer_block(&file).unwrap();
         }
 
@@ -566,7 +576,37 @@ pub mod tests {
             let meta = hot_storage.get_account_meta_from_offset(*offset).unwrap();
             assert_eq!(meta, expected_meta);
         }
+
         assert_eq!(&footer, hot_storage.footer());
+    }
+
+    #[test]
+    fn test_get_acount_meta_from_offset_out_of_bounds() {
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir
+            .path()
+            .join("test_get_acount_meta_from_offset_out_of_bounds");
+
+        let footer = TieredStorageFooter {
+            account_meta_format: AccountMetaFormat::Hot,
+            index_block_offset: 160,
+            ..TieredStorageFooter::default()
+        };
+
+        {
+            let file = TieredStorageFile::new_writable(&path).unwrap();
+            footer.write_footer_block(&file).unwrap();
+        }
+
+        let hot_storage = HotStorageReader::new_from_path(&path).unwrap();
+        let offset = HotAccountOffset::new(footer.index_block_offset as usize).unwrap();
+        // Read from index_block_offset, which offset doesn't belong to
+        // account blocks.  Expect Err here.
+        assert!(matches!(
+            hot_storage.get_account_meta_from_offset(offset),
+            Err(TieredStorageError::OffsetOutOfBounds(_, _)),
+        ));
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -576,9 +576,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "offset.saturating_add(std::mem::size_of::<HotAccountMeta>()) <=\\n    self.footer.index_block_offset"
-    )]
+    #[should_panic(expected = "self.footer.index_block_offset")]
     fn test_get_acount_meta_from_offset_out_of_bounds() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -286,8 +286,8 @@ impl HotStorageReader {
         assert!(
             offset.saturating_add(std::mem::size_of::<HotAccountMeta>())
                 <= self.footer.index_block_offset as usize,
-            "HotAccountOffset ({}) exceeds accounts blocks offset boundary ({}).",
-            offset.saturating_add(std::mem::size_of::<HotAccountMeta>()),
+            "reading HotAccountOffset ({}) would exceed accounts blocks offset boundary ({}).",
+            offset,
             self.footer.index_block_offset,
         );
         let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, offset)?;
@@ -579,7 +579,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "exceeds accounts blocks offset boundary")]
+    #[should_panic(expected = "would exceed accounts blocks offset boundary")]
     fn test_get_acount_meta_from_offset_out_of_bounds() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -285,7 +285,10 @@ impl HotStorageReader {
 
         assert!(
             offset.saturating_add(std::mem::size_of::<HotAccountMeta>())
-                <= self.footer.index_block_offset as usize
+                <= self.footer.index_block_offset as usize,
+            "HotAccountOffset ({}) exceeds accounts blocks offset boundary ({}).",
+            offset.saturating_add(std::mem::size_of::<HotAccountMeta>()),
+            self.footer.index_block_offset,
         );
         let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, offset)?;
         Ok(meta)
@@ -576,7 +579,7 @@ pub mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "self.footer.index_block_offset")]
+    #[should_panic(expected = "exceeds accounts blocks offset boundary")]
     fn test_get_acount_meta_from_offset_out_of_bounds() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();


### PR DESCRIPTION
#### Problem
Hot accounts are stored in accounts blocks, whose offset is smaller than
the index block offset.  However, the current code doesn't perform
any boundary checks when accessing hot account meta.

#### Summary of Changes
Adds boundary check when accessing hot account meta.
