### PR TITLE
Fix `solana-address-lookup-table-program` compilation

### DIFF
--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -5,18 +5,6 @@
 #[cfg(not(target_os = "solana"))]
 pub mod processor;
 
-#[cfg(not(target_os = "solana"))]
-#[deprecated(
-    since = "1.17.0",
-    note = "Please use `solana_sdk::address_lookup_table` instead"
-)]
-pub use solana_sdk::address_lookup_table::{
-    error, instruction,
-    program::{check_id, id, ID},
-    state,
-};
-
-#[cfg(target_os = "solana")]
 #[deprecated(
     since = "1.17.0",
     note = "Please use `solana_program::address_lookup_table` instead"

--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(RUSTC_WITH_SPECIALIZATION, feature(specialization))]
 #![cfg_attr(RUSTC_NEEDS_PROC_MACRO_HYGIENE, feature(proc_macro_hygiene))]
 
+#[cfg(not(target_os = "solana"))]
 pub mod processor;
 
 #[cfg(not(target_os = "solana"))]

--- a/programs/address-lookup-table/src/lib.rs
+++ b/programs/address-lookup-table/src/lib.rs
@@ -4,11 +4,23 @@
 
 pub mod processor;
 
+#[cfg(not(target_os = "solana"))]
 #[deprecated(
     since = "1.17.0",
     note = "Please use `solana_sdk::address_lookup_table` instead"
 )]
 pub use solana_sdk::address_lookup_table::{
+    error, instruction,
+    program::{check_id, id, ID},
+    state,
+};
+
+#[cfg(target_os = "solana")]
+#[deprecated(
+    since = "1.17.0",
+    note = "Please use `solana_program::address_lookup_table` instead"
+)]
+pub use solana_program::address_lookup_table::{
     error, instruction,
     program::{check_id, id, ID},
     state,


### PR DESCRIPTION
#### Problem

`solana-address-lookup-table-program` crate causes compile errors in programs after https://github.com/solana-labs/solana/pull/33165

Problem explained in more detail in #34352

#### Summary of Changes

- Add `#[cfg(target_os = "solana")]` checks to decide which SDK crate to use
- Make `processor` module only available in non-program environments

Fixes #34352
