### PR TITLE
V1.16 bugfix loaded programs cache set latest root slot

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -355,7 +355,7 @@ pub struct LoadedPrograms {
     entries: HashMap<Pubkey, Vec<Arc<LoadedProgram>>>,
     /// Globally shared RBPF config and syscall registry
     pub program_runtime_environment_v1: Arc<BuiltinProgram<InvokeContext<'static>>>,
-    latest_root: Slot,
+    pub latest_root: Slot,
     pub stats: Stats,
 }
 

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -171,6 +171,7 @@ impl BankForks {
         let mut descendants = HashMap::<_, HashSet<_>>::new();
         for (slot, bank) in &banks {
             descendants.entry(*slot).or_default();
+            bank.loaded_programs_cache.write().unwrap().latest_root = root;
             for parent in bank.proper_ancestors() {
                 descendants.entry(parent).or_default().insert(*slot);
             }


### PR DESCRIPTION
#### Problem
Running ledger-tool, the program cache begins with a latest root of 0 instead of whatever snapshot we loaded from.

#### Summary of Changes
Set latest_root during bank forks initialization

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
