### PR TITLE
Set root in program cache on bootup

### DIFF
--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -87,7 +87,9 @@ impl Index<u64> for BankForks {
 impl BankForks {
     pub fn new_rw_arc(bank: Bank) -> Arc<RwLock<Self>> {
         let root = bank.slot();
-        Self::new_from_banks(&[Arc::new(bank)], root)
+        let bank_forks = Self::new_from_banks(&[Arc::new(bank)], root);
+        bank_forks.read().unwrap().prune_program_cache(root);
+        bank_forks
     }
 
     pub fn banks(&self) -> &HashMap<Slot, BankWithScheduler> {


### PR DESCRIPTION
#### Problem
`LoadedProgram` cache doesn't get configured with a root slot at startup. This causes  `extract()` to fail the comparison of program's deployment slot with the latest_root slot.

#### Summary of Changes
Call `prune()` when `bank_forks` is created with a bank.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
