### PR TITLE
Comment sysvar and builtin lists as deprecated and remove new keys

### DIFF
--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -26,7 +26,7 @@ use {
 };
 
 lazy_static! {
-    // Copied keys over since direct references create cyclical dependency.
+    // This will be deprecated and so this list shouldn't be modified
     pub static ref BUILTIN_PROGRAMS_KEYS: [Pubkey; 10] = {
         let parse = |s| Pubkey::from_str(s).unwrap();
         [

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -100,6 +100,7 @@ pub mod slot_history;
 pub mod stake_history;
 
 lazy_static! {
+    // This will be deprecated and so this list shouldn't be modified
     pub static ref ALL_IDS: Vec<Pubkey> = vec![
         clock::id(),
         epoch_schedule::id(),
@@ -113,8 +114,6 @@ lazy_static! {
         slot_history::id(),
         stake_history::id(),
         instructions::id(),
-        epoch_rewards::id(),
-        last_restart_slot::id(),
     ];
 }
 
@@ -138,12 +137,6 @@ macro_rules! declare_sysvar_id(
                 check_id(pubkey)
             }
         }
-
-        #[cfg(test)]
-        #[test]
-        fn test_sysvar_id() {
-            assert!($crate::sysvar::is_sysvar_id(&id()), "sysvar::is_sysvar_id() doesn't know about {}", $name);
-        }
     )
 );
 
@@ -163,12 +156,6 @@ macro_rules! declare_deprecated_sysvar_id(
                 #[allow(deprecated)]
                 check_id(pubkey)
             }
-        }
-
-        #[cfg(test)]
-        #[test]
-        fn test_sysvar_id() {
-            assert!($crate::sysvar::is_sysvar_id(&id()), "sysvar::is_sysvar_id() doesn't know about {}", $name);
         }
     )
 );


### PR DESCRIPTION
#### Problem
Sysvar and builtin key lists shouldn't be exposed in the public API

#### Summary of Changes
- Add comment saying that the lists will be deprecated and shouldn't be modified
- Remove recently added sysvar keys from the sysvar list
- Remove overly restrictive sysvar list inclusion test

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
