### PR TITLE
docs: write-buffer clarifications

### DIFF
--- a/docs/src/cli/deploy-a-program.md
+++ b/docs/src/cli/deploy-a-program.md
@@ -282,14 +282,24 @@ intermediary buffer contents and then vote to allow an upgrade using it.
 solana program write-buffer <PROGRAM_FILEPATH>
 ```
 
-Buffer accounts support authorities like program accounts:
+Buffer accounts are managed by some authority - default signer, or signer specified with 
+`--buffer-authority` option:
+
+```bash
+solana program write-buffer <PROGRAM_FILEPATH> --buffer-authority <BUFFER_AUTHORITY_SIGNER>
+```
+
+Note, `--buffer-authority` from above must be a **Signer** - this prevents a developer from giving 
+upgrade authority to a key that they do not have access to. That means you can't set `--buffer-authority` 
+in `solana program write-buffer` to a Pubkey, and hence for certain use-cases (like offline signing) you 
+might want to use `solana program set-buffer-authority` command to set the authority for existing buffer 
+(which supports authority in the form of Pubkey, or even a program account):
 
 ```bash
 solana program set-buffer-authority <BUFFER_ADDRESS> --new-buffer-authority <NEW_BUFFER_AUTHORITY>
 ```
 
-One exception is that buffer accounts cannot be marked immutable like program
-accounts can, so they don't support `--final`.
+Unlike program accounts buffer accounts cannot be marked immutable, so they don't support `--final` option.
 
 The buffer account, once entirely written, can be passed to `deploy` to deploy
 the program:

--- a/docs/src/cli/deploy-a-program.md
+++ b/docs/src/cli/deploy-a-program.md
@@ -282,24 +282,24 @@ intermediary buffer contents and then vote to allow an upgrade using it.
 solana program write-buffer <PROGRAM_FILEPATH>
 ```
 
-Buffer accounts are managed by some authority - default signer, or signer specified with 
-`--buffer-authority` option:
+Buffer accounts are managed by an authority. To create a buffer and specify a different
+authority than the default:
 
 ```bash
 solana program write-buffer <PROGRAM_FILEPATH> --buffer-authority <BUFFER_AUTHORITY_SIGNER>
 ```
 
-Note, `--buffer-authority` from above must be a **Signer** - this prevents a developer from giving 
-upgrade authority to a key that they do not have access to. That means you can't set `--buffer-authority` 
-in `solana program write-buffer` to a Pubkey, and hence for certain use-cases (like offline signing) you 
-might want to use `solana program set-buffer-authority` command to set the authority for existing buffer 
-(which supports authority in the form of Pubkey, or even a program account):
+Only the buffer authority may write to the buffer, so the `--buffer-authority` above must be a
+**signer**, and not an address.  This requirement limits usage with offline signers.
+To use an offline address as a buffer authority, the buffer account must be initialized and
+written with an online keypair, and then the buffer authority must be assigned using
+`solana program set-buffer-authority`:
 
 ```bash
 solana program set-buffer-authority <BUFFER_ADDRESS> --new-buffer-authority <NEW_BUFFER_AUTHORITY>
 ```
 
-Unlike program accounts buffer accounts cannot be marked immutable, so they don't support `--final` option.
+Unlike program accounts buffer accounts cannot be marked immutable, so they don't support the `--final` option.
 
 The buffer account, once entirely written, can be passed to `deploy` to deploy
 the program:


### PR DESCRIPTION
#### Problem

`solana program write-buffer` could use some clarifications regarding what **authority** types it expects/supports.

#### Summary of Changes

This PR is a spinoff from https://github.com/solana-labs/solana/pull/33860 (see https://github.com/solana-labs/solana/pull/33860#discussion_r1412477126 for details). It extends `solana program write-buffer` docs to elaborate on some buffer **authority** specifics. Rendered version: https://github.com/norwnd/solana/blob/docs-write-buffer-clarifications/docs/src/cli/deploy-a-program.md#using-an-intermediary-buffer-account
