### PR TITLE
Implements ReadableAccount for RefMut Account and AccountSharedData

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -16,7 +16,7 @@ use {
     },
     solana_program::{account_info::AccountInfo, debug_account_data::*, sysvar::Sysvar},
     std::{
-        cell::{Ref, RefCell},
+        cell::{Ref, RefCell, RefMut},
         fmt,
         mem::MaybeUninit,
         ptr,
@@ -351,7 +351,53 @@ impl ReadableAccount for Ref<'_, AccountSharedData> {
     }
 }
 
+impl ReadableAccount for RefMut<'_, AccountSharedData> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+    fn to_account_shared_data(&self) -> AccountSharedData {
+        AccountSharedData {
+            lamports: self.lamports(),
+            // avoid data copy here
+            data: Arc::clone(&self.data),
+            owner: *self.owner(),
+            executable: self.executable(),
+            rent_epoch: self.rent_epoch(),
+        }
+    }
+}
+
 impl ReadableAccount for Ref<'_, Account> {
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
+    fn data(&self) -> &[u8] {
+        &self.data
+    }
+    fn owner(&self) -> &Pubkey {
+        &self.owner
+    }
+    fn executable(&self) -> bool {
+        self.executable
+    }
+    fn rent_epoch(&self) -> Epoch {
+        self.rent_epoch
+    }
+}
+
+impl ReadableAccount for RefMut<'_, Account> {
     fn lamports(&self) -> u64 {
         self.lamports
     }


### PR DESCRIPTION
#### Problem

From this comment, https://github.com/solana-labs/solana/pull/34194/files#r1420665797, we'd like to use `RefMut<AccountSharedData>` as a `ReadableAccount`, but cannot directly. There are already implementations for `Ref<_>`, so this is just a gap.


#### Summary of Changes

Implements ReadableAccount for RefMut Account and AccountSharedData.