### PR TITLE
tokens: fix url clap arg name

### DIFF
--- a/tokens/src/arg_parser.rs
+++ b/tokens/src/arg_parser.rs
@@ -652,7 +652,7 @@ where
 {
     let matches = get_matches(args);
     let config_file = matches.value_of("config_file").unwrap().to_string();
-    let url = matches.value_of("url").map(|x| x.to_string());
+    let url = matches.value_of("json_rpc_url").map(|x| x.to_string());
 
     let command = match matches.subcommand() {
         ("distribute-tokens", Some(matches)) => {


### PR DESCRIPTION
#### Problem
`solana-tokens` versions v1.16 and v1.17 aren't respecting the `--url` arg passed with a command. This is because [this change](https://github.com/solana-labs/solana/pull/29693) updated the name of the url clap arg (to be consistent with `solana-cli` and other tools), but neglected to also update the matches parser.

#### Summary of Changes
Update arg name in matches parser

cc @tigarcia 
