### PR TITLE
replay: feature flag consumption of duplicate proofs from blockstore

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -67,6 +67,7 @@ use {
     },
     solana_sdk::{
         clock::{BankId, Slot, MAX_PROCESSING_AGE, NUM_CONSECUTIVE_LEADER_SLOTS},
+        feature_set,
         genesis_config::ClusterType,
         hash::Hash,
         pubkey::Pubkey,
@@ -2109,7 +2110,11 @@ impl ReplayStage {
         );
 
         // If we previously marked this slot as duplicate in blockstore, let the state machine know
-        if !duplicate_slots_tracker.contains(&slot) && blockstore.get_duplicate_slot(slot).is_some()
+        if !duplicate_slots_tracker.contains(&slot)
+            && blockstore.get_duplicate_slot(slot).is_some()
+            && bank
+                .feature_set
+                .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
         {
             let duplicate_state = DuplicateState::new_from_state(
                 slot,
@@ -2921,6 +2926,9 @@ impl ReplayStage {
                 // If we previously marked this slot as duplicate in blockstore, let the state machine know
                 if !duplicate_slots_tracker.contains(&bank.slot())
                     && blockstore.get_duplicate_slot(bank.slot()).is_some()
+                    && bank
+                        .feature_set
+                        .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
                 {
                     let duplicate_state = DuplicateState::new_from_state(
                         bank.slot(),

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1228,8 +1228,12 @@ impl ReplayStage {
             let duplicate_slots = blockstore
                 .duplicate_slots_iterator(bank_forks.root_bank().slot())
                 .unwrap();
-            let duplicate_slot_hashes = duplicate_slots
-                .filter_map(|slot| bank_forks.bank_hash(slot).map(|hash| (slot, hash)));
+            let duplicate_slot_hashes = duplicate_slots.filter_map(|slot| {
+                let bank = bank_forks.get(slot)?;
+                bank.feature_set
+                    .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
+                    .then_some((slot, bank.hash()))
+            });
             (
                 bank_forks.root_bank(),
                 bank_forks.frozen_banks().values().cloned().collect(),
@@ -2110,11 +2114,11 @@ impl ReplayStage {
         );
 
         // If we previously marked this slot as duplicate in blockstore, let the state machine know
-        if !duplicate_slots_tracker.contains(&slot)
+        if bank
+            .feature_set
+            .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
+            && !duplicate_slots_tracker.contains(&slot)
             && blockstore.get_duplicate_slot(slot).is_some()
-            && bank
-                .feature_set
-                .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
         {
             let duplicate_state = DuplicateState::new_from_state(
                 slot,
@@ -2924,11 +2928,11 @@ impl ReplayStage {
                     SlotStateUpdate::BankFrozen(bank_frozen_state),
                 );
                 // If we previously marked this slot as duplicate in blockstore, let the state machine know
-                if !duplicate_slots_tracker.contains(&bank.slot())
+                if bank
+                    .feature_set
+                    .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
+                    && !duplicate_slots_tracker.contains(&bank.slot())
                     && blockstore.get_duplicate_slot(bank.slot()).is_some()
-                    && bank
-                        .feature_set
-                        .is_active(&feature_set::consume_blockstore_duplicate_proofs::id())
                 {
                     let duplicate_state = DuplicateState::new_from_state(
                         bank.slot(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -740,6 +740,10 @@ pub mod allow_commission_decrease_at_any_time {
     solana_sdk::declare_id!("decoMktMcnmiq6t3u7g5BfgcQu91nKZr6RvMYf9z1Jb");
 }
 
+pub mod consume_blockstore_duplicate_proofs {
+    solana_sdk::declare_id!("6YsBCejwK96GZCkJ6mkZ4b68oP63z2PLoQmWjC7ggTqZ");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -920,6 +924,7 @@ lazy_static! {
         (enable_zk_transfer_with_fee::id(), "enable Zk Token proof program transfer with fee"),
         (drop_legacy_shreds::id(), "drops legacy shreds #34328"),
         (allow_commission_decrease_at_any_time::id(), "Allow commission decrease at any time in epoch #33843"),
+        (consume_blockstore_duplicate_proofs::id(), "consume duplicate proofs from blockstore in consensus #34372")
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/32962 needs to be feature flagged as it could cause a divergence in fork choice.

#### Summary of Changes
Add a feature gate to ensure smooth rollout to 1.17 

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
