### PR TITLE
Fix ledger-tool bigtable compare blocks

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -183,16 +183,6 @@ async fn compare_blocks(
     config: solana_storage_bigtable::LedgerStorageConfig,
     ref_config: solana_storage_bigtable::LedgerStorageConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let owned_bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
-        .await
-        .map_err(|err| format!("failed to connect to owned bigtable: {err:?}"))?;
-    let owned_bigtable_slots = owned_bigtable
-        .get_confirmed_blocks(starting_slot, limit)
-        .await?;
-    info!(
-        "owned bigtable {} blocks found ",
-        owned_bigtable_slots.len()
-    );
     let reference_bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(ref_config)
         .await
         .map_err(|err| format!("failed to connect to reference bigtable: {err:?}"))?;
@@ -203,6 +193,22 @@ async fn compare_blocks(
     info!(
         "reference bigtable {} blocks found ",
         reference_bigtable_slots.len(),
+    );
+
+    if reference_bigtable_slots.is_empty() {
+        println!("Reference bigtable is empty after {starting_slot}. Aborting.");
+        return Ok(());
+    }
+
+    let owned_bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
+        .await
+        .map_err(|err| format!("failed to connect to owned bigtable: {err:?}"))?;
+    let owned_bigtable_slots = owned_bigtable
+        .get_confirmed_blocks(starting_slot, limit)
+        .await?;
+    info!(
+        "owned bigtable {} blocks found ",
+        owned_bigtable_slots.len()
     );
 
     println!(

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -211,12 +211,23 @@ async fn compare_blocks(
         owned_bigtable_slots.len()
     );
 
+    // Because the owned bigtable may include superfluous slots, stop checking
+    // the reference set at owned_bigtable_slots.last() or else the remaining
+    // reference slots will show up as missing.
+    let last_reference_block = reference_bigtable_slots
+        .last()
+        .expect("already returned if reference_bigtable_slots is empty");
+    let last_block_checked = owned_bigtable_slots
+        .last()
+        .map(|last_owned_block| min(last_owned_block, last_reference_block))
+        .unwrap_or(last_reference_block);
+
     println!(
         "{}",
         json!({
             "num_reference_slots": json!(reference_bigtable_slots.len()),
             "num_owned_slots": json!(owned_bigtable_slots.len()),
-            "reference_last_block": json!(reference_bigtable_slots.len().checked_sub(1).map(|i| reference_bigtable_slots[i])),
+            "reference_last_block": json!(last_block_checked),
             "missing_blocks":  json!(missing_blocks(&reference_bigtable_slots, &owned_bigtable_slots)),
         })
     );

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1225,8 +1225,6 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
 fn missing_blocks(reference: &[Slot], owned: &[Slot]) -> Vec<Slot> {
     if owned.is_empty() && !reference.is_empty() {
         return reference.to_owned();
-    } else if owned.is_empty() {
-        return vec![];
     }
 
     let owned_hashset: HashSet<_> = owned.iter().collect();

--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -1277,14 +1277,17 @@ fn missing_blocks(
         .cloned()
         .collect();
 
-    let missing_blocks = reference_hashset
+    let mut missing_blocks: Vec<_> = reference_hashset
         .difference(&owned_hashset)
         .cloned()
         .collect();
-    let superfluous_blocks = owned_hashset
+    missing_blocks.sort_unstable(); // Unstable sort is fine, as we've already ensured no duplicates
+
+    let mut superfluous_blocks: Vec<_> = owned_hashset
         .difference(&reference_hashset)
         .cloned()
         .collect();
+    superfluous_blocks.sort_unstable(); // Unstable sort is fine, as we've already ensured no duplicates
 
     MissingBlocksData {
         missing_blocks,


### PR DESCRIPTION
#### Problem
We received a report of `solana-ledger-tool bigtable compare-blocks` returning a list of missing blocks that did actually appear to be present when queried with `solana-ledger-tool bigtable block`.

```
GOOGLE_APPLICATION_CREDENTIALS=<credential> ./solana-ledger-tool bigtable compare-blocks 13330000 10000 --reference-credential <other_credential> --rpc-bigtable-instance-name solana-ledger-hdd
[2023-11-12T10:37:34.112098337Z INFO  solana_ledger_tool] solana-ledger-tool 1.16.18 (src:612616be; feat:4033350765, client:SolanaLabs)
[2023-11-12T10:37:34.113806564Z INFO  solana_storage_bigtable::access_token] Requesting token for BigTableData scope
[2023-11-12T10:37:34.200364731Z INFO  solana_storage_bigtable::access_token] Token expires in 3599 seconds
[2023-11-12T10:37:34.477986775Z INFO  solana_ledger_tool::bigtable] owned bigtable 10000 blocks found
[2023-11-12T10:37:34.478114155Z INFO  solana_storage_bigtable::access_token] Requesting token for BigTableData scope
[2023-11-12T10:37:34.511993782Z INFO  solana_storage_bigtable::access_token] Token expires in 3599 seconds
[2023-11-12T10:37:36.822228338Z INFO  solana_ledger_tool::bigtable] reference bigtable 10000 blocks found
{"missing_blocks":[13344032,13344033,13344034,13344035,13344036,13344037,13344038,13344039,13344040,13344041,13344042,13344043],"num_owned_slots":10000,"num_reference_slots":10000,"reference_last_block":13344043}
```

Upon deeper investigation, we discovered that the owned bigtable contained 12 extra blocks that weren't finalized and uploaded to the reference bigtable.

The reason for the erroneous response is that the `compare-blocks` method assumes that the responses from `get_confirmed_blocks()` against both bigtables represent the same slot range. But this is not the case. `get_confirmed_blocks()` accepts a starting slot and a limit and always returns the same number of blocks if the bigtable instance holds that many. Thus if one bigtable contains blocks that are not present in the other, it will examine a small range of slots.

Also, it's unfortunate that there was no indication about the extra blocks.

#### Summary of Changes
- Use the same `last_block` to limit the lists returned from both bigtables to ensure comparing identical slot ranges. This prevents the error described above.
- Also return data about any superfluous blocks found in the owned bigtable
