### PR TITLE
[TieredStorage] Unit-tests for checking invalid HotAccountOffset

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -316,6 +316,7 @@ pub mod tests {
             index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
         },
+        assert_matches::assert_matches,
         memoffset::offset_of,
         rand::Rng,
         solana_sdk::{hash::Hash, pubkey::Pubkey, stake_history::Epoch},
@@ -362,20 +363,24 @@ pub mod tests {
 
     #[test]
     fn test_max_hot_account_offset() {
-        HotAccountOffset::new(0).unwrap();
-        HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET).unwrap();
+        assert_matches!(HotAccountOffset::new(0), Ok(_));
+        assert_matches!(HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET), Ok(_));
     }
 
     #[test]
-    #[should_panic(expected = "OffsetOutOfBounds(34359738368, 34359738360)")]
     fn test_max_hot_account_offset_out_of_bounds() {
-        HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET + HOT_ACCOUNT_OFFSET_ALIGNMENT).unwrap();
+        assert_matches!(
+            HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET + HOT_ACCOUNT_OFFSET_ALIGNMENT),
+            Err(TieredStorageError::OffsetOutOfBounds(_, _))
+        );
     }
 
     #[test]
-    #[should_panic(expected = "OffsetAlignmentError(7, 8)")]
     fn test_max_hot_account_offset_alignment_error() {
-        HotAccountOffset::new(HOT_ACCOUNT_OFFSET_ALIGNMENT - 1).unwrap();
+        assert_matches!(
+            HotAccountOffset::new(HOT_ACCOUNT_OFFSET_ALIGNMENT - 1),
+            Err(TieredStorageError::OffsetAlignmentError(_, _))
+        );
     }
 
     #[test]

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -361,6 +361,24 @@ pub mod tests {
     }
 
     #[test]
+    fn test_max_hot_account_offset() {
+        HotAccountOffset::new(0).unwrap();
+        HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "OffsetOutOfBounds(34359738368, 34359738360)")]
+    fn test_max_hot_account_offset_out_of_bounds() {
+        HotAccountOffset::new(MAX_HOT_ACCOUNT_OFFSET + HOT_ACCOUNT_OFFSET_ALIGNMENT).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "OffsetAlignmentError(7, 8)")]
+    fn test_max_hot_account_offset_alignment_error() {
+        HotAccountOffset::new(HOT_ACCOUNT_OFFSET_ALIGNMENT - 1).unwrap();
+    }
+
+    #[test]
     #[should_panic(expected = "padding exceeds MAX_HOT_PADDING")]
     fn test_hot_meta_padding_exceeds_limit() {
         HotAccountMeta::new().with_account_data_padding(MAX_HOT_PADDING + 1);


### PR DESCRIPTION
#### Problem
HotAccountOffset::new() might return Err for invalid offset, and this
part needs some test coverage.

#### Summary of Changes
Add unit-tests for checking invalid HotAccountOffset.
