### PR TITLE
Add metrics for locking the blockhash queue in banking stage

### DIFF
--- a/core/src/banking_stage/committer.rs
+++ b/core/src/banking_stage/committer.rs
@@ -15,7 +15,7 @@ use {
         prioritization_fee_cache::PrioritizationFeeCache,
         transaction_batch::TransactionBatch,
     },
-    solana_sdk::{pubkey::Pubkey, saturating_add_assign},
+    solana_sdk::{hash::Hash, pubkey::Pubkey, saturating_add_assign},
     solana_transaction_status::{
         token_balances::TransactionTokenBalancesSet, TransactionTokenBalance,
     },
@@ -66,6 +66,8 @@ impl Committer {
         batch: &TransactionBatch,
         loaded_transactions: &mut [TransactionLoadResult],
         execution_results: Vec<TransactionExecutionResult>,
+        last_blockhash: Hash,
+        lamports_per_signature: u64,
         starting_transaction_index: Option<usize>,
         bank: &Arc<Bank>,
         pre_balance_info: &mut PreBalanceInfo,
@@ -75,9 +77,6 @@ impl Committer {
         executed_non_vote_transactions_count: usize,
         executed_with_successful_result_count: usize,
     ) -> (u64, Vec<CommitTransactionDetails>) {
-        let (last_blockhash, lamports_per_signature) =
-            bank.last_blockhash_and_lamports_per_signature();
-
         let executed_transactions = execution_results
             .iter()
             .zip(batch.sanitized_transactions())

--- a/core/src/banking_stage/consume_worker.rs
+++ b/core/src/banking_stage/consume_worker.rs
@@ -238,6 +238,7 @@ impl ConsumeWorkerMetrics {
             collect_balances_us,
             load_execute_us,
             freeze_lock_us,
+            last_blockhash_us,
             record_us,
             commit_us,
             find_and_send_votes_us,
@@ -253,6 +254,9 @@ impl ConsumeWorkerMetrics {
         self.timing_metrics
             .freeze_lock_us
             .fetch_add(*freeze_lock_us, Ordering::Relaxed);
+        self.timing_metrics
+            .last_blockhash_us
+            .fetch_add(*last_blockhash_us, Ordering::Relaxed);
         self.timing_metrics
             .record_us
             .fetch_add(*record_us, Ordering::Relaxed);
@@ -422,6 +426,7 @@ struct ConsumeWorkerTimingMetrics {
     collect_balances_us: AtomicU64,
     load_execute_us: AtomicU64,
     freeze_lock_us: AtomicU64,
+    last_blockhash_us: AtomicU64,
     record_us: AtomicU64,
     commit_us: AtomicU64,
     find_and_send_votes_us: AtomicU64,
@@ -450,6 +455,11 @@ impl ConsumeWorkerTimingMetrics {
             (
                 "freeze_lock_us",
                 self.freeze_lock_us.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "last_blockhash_us",
+                self.last_blockhash_us.swap(0, Ordering::Relaxed),
                 i64
             ),
             ("record_us", self.record_us.swap(0, Ordering::Relaxed), i64),

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -587,6 +587,10 @@ impl Consumer {
         let (freeze_lock, freeze_lock_us) = measure_us!(bank.freeze_lock());
         execute_and_commit_timings.freeze_lock_us = freeze_lock_us;
 
+        let ((last_blockhash, lamports_per_signature), last_blockhash_us) =
+            measure_us!(bank.last_blockhash_and_lamports_per_signature());
+        execute_and_commit_timings.last_blockhash_us = last_blockhash_us;
+
         let (record_transactions_summary, record_us) = measure_us!(self
             .transaction_recorder
             .record_transactions(bank.slot(), executed_transactions));
@@ -623,6 +627,8 @@ impl Consumer {
                 batch,
                 &mut loaded_transactions,
                 execution_results,
+                last_blockhash,
+                lamports_per_signature,
                 starting_transaction_index,
                 bank,
                 &mut pre_balance_info,

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -10,6 +10,7 @@ pub struct LeaderExecuteAndCommitTimings {
     pub collect_balances_us: u64,
     pub load_execute_us: u64,
     pub freeze_lock_us: u64,
+    pub last_blockhash_us: u64,
     pub record_us: u64,
     pub commit_us: u64,
     pub find_and_send_votes_us: u64,
@@ -22,6 +23,7 @@ impl LeaderExecuteAndCommitTimings {
         saturating_add_assign!(self.collect_balances_us, other.collect_balances_us);
         saturating_add_assign!(self.load_execute_us, other.load_execute_us);
         saturating_add_assign!(self.freeze_lock_us, other.freeze_lock_us);
+        saturating_add_assign!(self.last_blockhash_us, other.last_blockhash_us);
         saturating_add_assign!(self.record_us, other.record_us);
         saturating_add_assign!(self.commit_us, other.commit_us);
         saturating_add_assign!(self.find_and_send_votes_us, other.find_and_send_votes_us);
@@ -38,6 +40,7 @@ impl LeaderExecuteAndCommitTimings {
             ("collect_balances_us", self.collect_balances_us as i64, i64),
             ("load_execute_us", self.load_execute_us as i64, i64),
             ("freeze_lock_us", self.freeze_lock_us as i64, i64),
+            ("last_blockhash_us", self.last_blockhash_us as i64, i64),
             ("record_us", self.record_us as i64, i64),
             ("commit_us", self.commit_us as i64, i64),
             (


### PR DESCRIPTION
#### Problem
Lack of metrics for blockhash queue locking

#### Summary of Changes
Add said metrics

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
