### PR TITLE
Improve cache eviction policy for LoadedPrograms

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1043,9 +1043,9 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
             let (index2, usage_counter2) = random_index_and_usage_counter(&candidates, now);
 
             let (program, entry) = if usage_counter1 < usage_counter2 {
-                candidates.remove(index1)
+                candidates.swap_remove(index1)
             } else {
-                candidates.remove(index2)
+                candidates.swap_remove(index2)
             };
             self.unload_program_entry(&program, &entry);
         }

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1696,12 +1696,7 @@ mod tests {
             rent::Rent,
             system_program, sysvar,
         },
-        std::{
-            fs::File,
-            io::Read,
-            ops::Range,
-            sync::{atomic::AtomicU64, RwLock},
-        },
+        std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
     };
 
     struct TestContextObject {
@@ -4026,7 +4021,7 @@ mod tests {
             maybe_expiration_slot: None,
             tx_usage_counter: AtomicU64::new(100),
             ix_usage_counter: AtomicU64::new(100),
-            latest_access_slot: RwLock::new(0),
+            latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
             .programs_modified_by_tx
@@ -4067,7 +4062,7 @@ mod tests {
             maybe_expiration_slot: None,
             tx_usage_counter: AtomicU64::new(100),
             ix_usage_counter: AtomicU64::new(100),
-            latest_access_slot: RwLock::new(0),
+            latest_access_slot: AtomicU64::new(0),
         };
         invoke_context
             .programs_modified_by_tx

--- a/programs/bpf_loader/src/lib.rs
+++ b/programs/bpf_loader/src/lib.rs
@@ -1696,7 +1696,12 @@ mod tests {
             rent::Rent,
             system_program, sysvar,
         },
-        std::{fs::File, io::Read, ops::Range, sync::atomic::AtomicU64},
+        std::{
+            fs::File,
+            io::Read,
+            ops::Range,
+            sync::{atomic::AtomicU64, RwLock},
+        },
     };
 
     struct TestContextObject {
@@ -4021,6 +4026,7 @@ mod tests {
             maybe_expiration_slot: None,
             tx_usage_counter: AtomicU64::new(100),
             ix_usage_counter: AtomicU64::new(100),
+            latest_access_slot: RwLock::new(0),
         };
         invoke_context
             .programs_modified_by_tx
@@ -4061,6 +4067,7 @@ mod tests {
             maybe_expiration_slot: None,
             tx_usage_counter: AtomicU64::new(100),
             ix_usage_counter: AtomicU64::new(100),
+            latest_access_slot: RwLock::new(0),
         };
         invoke_context
             .programs_modified_by_tx

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5287,7 +5287,10 @@ impl Bank {
         self.loaded_programs_cache
             .write()
             .unwrap()
-            .sort_and_unload(Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE));
+            .evict_using_2s_random_selection(
+                Percentage::from(SHRINK_LOADED_PROGRAMS_TO_PERCENTAGE),
+                self.slot(),
+            );
 
         debug!(
             "check: {}us load: {}us execute: {}us txs_len={}",

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1476,10 +1476,10 @@ impl Bank {
                 }
                 loaded_programs_cache.upcoming_environments = Some(upcoming_environments);
                 loaded_programs_cache.programs_to_recompile = loaded_programs_cache
-                    .get_entries_sorted_by_tx_usage(
-                        changed_program_runtime_v1,
-                        changed_program_runtime_v2,
-                    );
+                    .get_flattened_entries(changed_program_runtime_v1, changed_program_runtime_v2);
+                loaded_programs_cache
+                    .programs_to_recompile
+                    .sort_by_cached_key(|(_id, program)| program.decayed_usage_counter(slot));
             }
         });
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4799,6 +4799,7 @@ impl Bank {
             loaded_program.ix_usage_counter =
                 AtomicU64::new(recompile.ix_usage_counter.load(Ordering::Relaxed));
         }
+        loaded_program.update_access_slot(self.slot());
         Arc::new(loaded_program)
     }
 


### PR DESCRIPTION
#### Problem
Current eviction policy for `LoadedPrograms` cache relies on program's `usage_counter` to decide which entry to evict. The `usage_counter` increases monotonically. This means if an old program which was frequently used in the past, but not used anymore, has higher chance of staying in the cache. This can make it harder for new programs to stay in the cache once the cache depth limits are reached. 

#### Summary of Changes
- Decay the `usage_counter` of a program if the program does not get used.
- Use 2's random selection to pick a program entry to be evicted from the cache.
- Add unit tests for the new code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
