### PR TITLE
changelog: Adds --use-snapshot-archives-at-startup to v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.
 ## [1.17.0]
 * Changes
   * Added a changelog.
+  * Added `--use-snapshot-archives-at-startup` for faster validator restarts
 * Upgrade Notes
 
 ## Adding to this Changelog


### PR DESCRIPTION
#### Problem

v1.17 added the `--use-snapshot-archives-at-startup` cli arg, which can make validator restarts much faster. But, validators may not know about this new arg.


#### Summary of Changes

Add the new arg to the v1.17.0 changelog.

Now that we have the changelog, we can begin pointing node operators there for information. We can also include this information to the release notes. Since v1.17 is starting to roll out onto mainnet-beta, I'd like they to know about this new arg sooner-rather-than-later.

I also intend to backport this to v1.17.