### PR TITLE
TransactionScheduler: CU queueing limit

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -668,7 +668,11 @@ mod tests {
     ) -> Transaction {
         let transfer = system_instruction::transfer(&from_keypair.pubkey(), to_pubkey, lamports);
         let prioritization = ComputeBudgetInstruction::set_compute_unit_price(priority);
-        let message = Message::new(&[transfer, prioritization], Some(&from_keypair.pubkey()));
+        let cu_limit = ComputeBudgetInstruction::set_compute_unit_limit(5_000);
+        let message = Message::new(
+            &[transfer, prioritization, cu_limit],
+            Some(&from_keypair.pubkey()),
+        );
         Transaction::new(&vec![from_keypair], message, recent_blockhash)
     }
 


### PR DESCRIPTION
#### Problem
- Currently no thread-level queue limit for scheduling transactions

#### Summary of Changes
- Prevent queueing of more than `48M CUs / num_threads` in in flight transactions per thread

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
