### PR TITLE
Fix pubkey-macro args

### DIFF
--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -108,7 +108,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("OUR_VALIDATOR_PUBKEY")
                         .required(false),
-                    "Identity pubkey of the validator."
+                    "Identity of the validator."
                 ))
                 .arg(
                     Arg::with_name("node_json_rpc_url")
@@ -297,8 +297,8 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 .about("Stream transaction logs")
                 .arg(pubkey!(
                     Arg::with_name("address").index(1).value_name("ADDRESS"),
-                    "Account address to monitor [default: monitor all transactions except for \
-                     votes]."
+                    "Account to monitor \
+                    [default: monitor all transactions except for votes]."
                 ))
                 .arg(
                     Arg::with_name("include_votes")
@@ -347,7 +347,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .multiple(true),
-                    "Only show stake accounts delegated to the provided vote accounts."
+                    "Only show stake accounts delegated to the provided vote account."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("withdraw_authority")
@@ -430,7 +430,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ADDRESS")
                         .required(true),
-                    "Account address."
+                    "Account."
                 ))
                 .arg(
                     Arg::with_name("limit")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -430,7 +430,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ADDRESS")
                         .required(true),
-                    "Account."
+                    "Account to query for transactions."
                 ))
                 .arg(
                     Arg::with_name("limit")

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -108,7 +108,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("OUR_VALIDATOR_PUBKEY")
                         .required(false),
-                    "Identity pubkey of the validator"
+                    "Identity pubkey of the validator."
                 ))
                 .arg(
                     Arg::with_name("node_json_rpc_url")
@@ -298,7 +298,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                 .arg(pubkey!(
                     Arg::with_name("address").index(1).value_name("ADDRESS"),
                     "Account address to monitor [default: monitor all transactions except for \
-                     votes] "
+                     votes]."
                 ))
                 .arg(
                     Arg::with_name("include_votes")
@@ -347,13 +347,13 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_PUBKEYS")
                         .multiple(true),
-                    "Only show stake accounts delegated to the provided vote accounts. "
+                    "Only show stake accounts delegated to the provided vote accounts."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("withdraw_authority")
                         .value_name("PUBKEY")
                         .long("withdraw-authority"),
-                    "Only show stake accounts with the provided withdraw authority. "
+                    "Only show stake accounts with the provided withdraw authority."
                 )),
         )
         .subcommand(
@@ -430,7 +430,7 @@ impl ClusterQuerySubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ADDRESS")
                         .required(true),
-                    "Account address"
+                    "Account address."
                 ))
                 .arg(
                     Arg::with_name("limit")

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -39,7 +39,7 @@ impl InflationSubCommands for App<'_, '_> {
                                 .index(1)
                                 .multiple(true)
                                 .required(true),
-                            "Address of account to query for rewards."
+                            "Account to query for rewards."
                         ))
                         .arg(
                             Arg::with_name("rewards_epoch")

--- a/cli/src/inflation.rs
+++ b/cli/src/inflation.rs
@@ -39,7 +39,7 @@ impl InflationSubCommands for App<'_, '_> {
                                 .index(1)
                                 .multiple(true)
                                 .required(true),
-                            "Address of account to query for rewards. "
+                            "Address of account to query for rewards."
                         ))
                         .arg(
                             Arg::with_name("rewards_epoch")

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 macro_rules! ACCOUNT_STRING {
     () => {
-        r#", one of:
+        r#" Address is one of:
   * a base58-encoded public key
   * a path to a keypair file
   * a hyphen; signals a JSON-encoded keypair on stdin

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -53,14 +53,14 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account. "
+                    "Address of the nonce account."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("new_authority")
                         .index(2)
                         .value_name("AUTHORITY_PUBKEY")
                         .required(true),
-                    "Account to be granted authority of the nonce account. "
+                    "Account to be granted authority of the nonce account."
                 ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
@@ -94,7 +94,7 @@ impl NonceSubCommands for App<'_, '_> {
                     Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
                         .value_name("PUBKEY"),
-                    "Assign noncing authority to another entity. "
+                    "Assign noncing authority to another entity."
                 ))
                 .arg(
                     Arg::with_name("seed")
@@ -118,7 +118,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account to display. "
+                    "Address of the nonce account to display."
                 )),
         )
         .subcommand(
@@ -129,7 +129,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account. "
+                    "Address of the nonce account."
                 ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
@@ -144,7 +144,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account to display. "
+                    "Address of the nonce account to display."
                 ))
                 .arg(
                     Arg::with_name("lamports")
@@ -161,14 +161,14 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Nonce account to withdraw from. "
+                    "Nonce account to withdraw from."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The account to which the SOL should be transferred. "
+                    "The account to which the SOL should be transferred."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -194,7 +194,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Nonce account to upgrade. "
+                    "Nonce account to upgrade."
                 ))
                 .arg(memo_arg())
                 .arg(compute_unit_price_arg()),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -168,7 +168,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "Account to which the SOL should be transferred."
+                    "Recipient of withdrawn SOL."
                 ))
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -53,7 +53,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account."
+                    "Nonce account."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("new_authority")
@@ -94,7 +94,7 @@ impl NonceSubCommands for App<'_, '_> {
                     Arg::with_name(NONCE_AUTHORITY_ARG.name)
                         .long(NONCE_AUTHORITY_ARG.long)
                         .value_name("PUBKEY"),
-                    "Assign noncing authority to another entity."
+                    "Assign noncing authority to this other entity."
                 ))
                 .arg(
                     Arg::with_name("seed")
@@ -118,7 +118,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account to display."
+                    "Nonce account to display."
                 )),
         )
         .subcommand(
@@ -129,7 +129,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account."
+                    "Nonce account."
                 ))
                 .arg(nonce_authority_arg())
                 .arg(memo_arg())
@@ -144,7 +144,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("NONCE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Address of the nonce account to display."
+                    "Nonce account to display."
                 ))
                 .arg(
                     Arg::with_name("lamports")
@@ -168,7 +168,7 @@ impl NonceSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The account to which the SOL should be transferred."
+                    "Account to which the SOL should be transferred."
                 ))
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -444,7 +444,7 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("recipient_account")
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
-                            "Account to deposit the closed account's lamports \
+                            "Recipient of closed account's lamports \
                              [default: the default configured keypair]."
                         ))
                         .arg(

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -190,8 +190,8 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("program_id")
                                 .long("program-id")
                                 .value_name("PROGRAM_ID"),
-                            "Executable program's address, must be a keypair for initial deploys, \
-                             can be a pubkey for upgrades [default: address of keypair at \
+                            "Executable program; must be a signer for initial deploys, \
+                             can be an address for upgrades [default: address of keypair at \
                              /path/to/program-keypair.json if present, otherwise a random address]."
                         ))
                         .arg(
@@ -286,7 +286,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
                                 .required(true),
-                            "Address of the new buffer authority."
+                            "New buffer authority."
                         )),
                 )
                 .subcommand(
@@ -444,7 +444,7 @@ impl ProgramSubCommands for App<'_, '_> {
                             Arg::with_name("recipient_account")
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
-                            "Address of the account to deposit the closed account's lamports \
+                            "Account to deposit the closed account's lamports \
                              [default: the default configured keypair]."
                         ))
                         .arg(

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -192,7 +192,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .value_name("PROGRAM_ID"),
                             "Executable program's address, must be a keypair for initial deploys, \
                              can be a pubkey for upgrades [default: address of keypair at \
-                             /path/to/program-keypair.json if present, otherwise a random address]"
+                             /path/to/program-keypair.json if present, otherwise a random address]."
                         ))
                         .arg(
                             Arg::with_name("final")
@@ -286,7 +286,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("new-buffer-authority")
                                 .value_name("NEW_BUFFER_AUTHORITY")
                                 .required(true),
-                            "Address of the new buffer authority"
+                            "Address of the new buffer authority."
                         )),
                 )
                 .subcommand(
@@ -382,7 +382,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("buffer-authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                            "Authority [default: the default configured keypair]"
+                            "Authority [default: the default configured keypair]."
                         ))
                         .arg(
                             Arg::with_name("lamports")
@@ -445,7 +445,7 @@ impl ProgramSubCommands for App<'_, '_> {
                                 .long("recipient")
                                 .value_name("RECIPIENT_ADDRESS"),
                             "Address of the account to deposit the closed account's lamports \
-                             [default: the default configured keypair]"
+                             [default: the default configured keypair]."
                         ))
                         .arg(
                             Arg::with_name("lamports")

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -233,7 +233,7 @@ impl ProgramV4SubCommands for App<'_, '_> {
                                 .long("authority")
                                 .value_name("AUTHORITY")
                                 .conflicts_with("all"),
-                            "Authority [default: the default configured keypair]"
+                            "Authority [default: the default configured keypair]."
                         )),
                 )
                 .subcommand(

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -597,7 +597,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "Recipient of withdrawn SOL."
+                    "Recipient of withdrawn stake."
                 ))
                 .arg(
                     Arg::with_name("amount")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -164,7 +164,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("custodian")
                         .long("custodian")
                         .value_name("PUBKEY"),
-                    "Authority to modify lockups"
+                    "Authority to modify lockups."
                 ))
                 .arg(
                     Arg::with_name("seed")
@@ -308,14 +308,14 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Stake account to delegate"
+                    "Stake account to delegate."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The vote account to which the stake will be delegated"
+                    "The vote account to which the stake will be delegated."
                 ))
                 .arg(stake_authority_arg())
                 .offline_args()
@@ -341,14 +341,14 @@ impl StakeSubCommands for App<'_, '_> {
                         .required(true),
                     "Existing delegated stake account that has been fully activated. On success \
                      this stake account will be scheduled for deactivation and the rent-exempt \
-                     balance may be withdrawn once fully deactivated"
+                     balance may be withdrawn once fully deactivated."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("vote_account_pubkey")
                         .index(2)
                         .value_name("REDELEGATED_VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The vote account to which the stake will be redelegated"
+                    "The vote account to which the stake will be redelegated."
                 ))
                 .arg(
                     Arg::with_name("redelegation_stake_account")
@@ -378,21 +378,21 @@ impl StakeSubCommands for App<'_, '_> {
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                    "Stake account in which to set a new authority. "
+                    "Stake account in which to set a new authority."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("new_stake_authority")
                         .long("new-stake-authority")
                         .required_unless("new_withdraw_authority")
                         .value_name("PUBKEY"),
-                    "New authorized staker"
+                    "New authorized staker."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("new_withdraw_authority")
                         .long("new-withdraw-authority")
                         .required_unless("new_stake_authority")
                         .value_name("PUBKEY"),
-                    "New authorized withdrawer. "
+                    "New authorized withdrawer."
                 ))
                 .arg(stake_authority_arg())
                 .arg(withdraw_authority_arg())
@@ -423,7 +423,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .required(true)
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS"),
-                    "Stake account in which to set a new authority. "
+                    "Stake account in which to set a new authority."
                 ))
                 .arg(
                     Arg::with_name("new_stake_authority")
@@ -470,7 +470,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
                     "Stake account to be deactivated (or base of derived address if --seed is \
-                     used). "
+                     used)."
                 ))
                 .arg(
                     Arg::with_name("seed")
@@ -507,7 +507,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Stake account to split (or base of derived address if --seed is used). "
+                    "Stake account to split (or base of derived address if --seed is used)."
                 ))
                 .arg(
                     Arg::with_name("split_stake_account")
@@ -564,7 +564,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Stake account to merge into"
+                    "Stake account to merge into."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("source_stake_account_pubkey")
@@ -572,7 +572,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("SOURCE_STAKE_ACCOUNT_ADDRESS")
                         .required(true),
                     "Source stake account for the merge.  If successful, this stake account will \
-                     no longer exist after the merge"
+                     no longer exist after the merge."
                 ))
                 .arg(stake_authority_arg())
                 .offline_args()
@@ -590,14 +590,14 @@ impl StakeSubCommands for App<'_, '_> {
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
                     "Stake account from which to withdraw (or base of derived address if --seed \
-                     is used). "
+                     is used)."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "Recipient of withdrawn SOL"
+                    "Recipient of withdrawn SOL."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -637,7 +637,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Stake account for which to set lockup parameters. "
+                    "Stake account for which to set lockup parameters."
                 ))
                 .arg(
                     Arg::with_name("lockup_epoch")
@@ -664,7 +664,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("new_custodian")
                         .long("new-custodian")
                         .value_name("PUBKEY"),
-                    "Identity of a new lockup custodian. "
+                    "Identity of a new lockup custodian."
                 ))
                 .group(
                     ArgGroup::with_name("lockup_details")
@@ -694,7 +694,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Stake account for which to set lockup parameters. "
+                    "Stake account for which to set lockup parameters."
                 ))
                 .arg(
                     Arg::with_name("lockup_epoch")
@@ -754,7 +754,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The stake account to display. "
+                    "The stake account to display."
                 ))
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -315,7 +315,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The vote account to which the stake will be delegated."
+                    "Vote account to which the stake will be delegated."
                 ))
                 .arg(stake_authority_arg())
                 .offline_args()
@@ -348,7 +348,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("REDELEGATED_VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The vote account to which the stake will be redelegated."
+                    "Vote account to which the stake will be redelegated."
                 ))
                 .arg(
                     Arg::with_name("redelegation_stake_account")
@@ -571,7 +571,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(2)
                         .value_name("SOURCE_STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Source stake account for the merge.  If successful, this stake account will \
+                    "Source stake account for the merge. If successful, this stake account will \
                      no longer exist after the merge."
                 ))
                 .arg(stake_authority_arg())
@@ -664,7 +664,7 @@ impl StakeSubCommands for App<'_, '_> {
                     Arg::with_name("new_custodian")
                         .long("new-custodian")
                         .value_name("PUBKEY"),
-                    "Identity of a new lockup custodian."
+                    "New lockup custodian."
                 ))
                 .group(
                     ArgGroup::with_name("lockup_details")
@@ -754,7 +754,7 @@ impl StakeSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("STAKE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "The stake account to display."
+                    "Stake account to display."
                 ))
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -77,7 +77,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .long("authorized-withdrawer"),
-                    "Public key of the authorized withdrawer."
+                    "Authorized withdrawer."
                 ))
                 .arg(
                     Arg::with_name("commission")
@@ -91,7 +91,7 @@ impl VoteSubCommands for App<'_, '_> {
                     Arg::with_name("authorized_voter")
                         .long("authorized-voter")
                         .value_name("VOTER_PUBKEY"),
-                    "Public key of the authorized voter [default: validator identity pubkey]."
+                    "Authorized voter [default: validator identity pubkey]."
                 ))
                 .arg(
                     Arg::with_name("allow_unsafe_authorized_withdrawer")
@@ -328,7 +328,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account pubkey."
+                    "Vote account."
                 ))
                 .arg(
                     Arg::with_name("lamports")

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -77,7 +77,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .takes_value(true)
                         .required(true)
                         .long("authorized-withdrawer"),
-                    "Public key of the authorized withdrawer"
+                    "Public key of the authorized withdrawer."
                 ))
                 .arg(
                     Arg::with_name("commission")
@@ -91,7 +91,7 @@ impl VoteSubCommands for App<'_, '_> {
                     Arg::with_name("authorized_voter")
                         .long("authorized-voter")
                         .value_name("VOTER_PUBKEY"),
-                    "Public key of the authorized voter [default: validator identity pubkey]. "
+                    "Public key of the authorized voter [default: validator identity pubkey]."
                 ))
                 .arg(
                     Arg::with_name("allow_unsafe_authorized_withdrawer")
@@ -127,7 +127,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account in which to set the authorized voter. "
+                    "Vote account in which to set the authorized voter."
                 ))
                 .arg(
                     Arg::with_name("authorized")
@@ -142,7 +142,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(3)
                         .value_name("NEW_AUTHORIZED_PUBKEY")
                         .required(true),
-                    "New authorized vote signer. "
+                    "New authorized vote signer."
                 ))
                 .offline_args()
                 .nonce_args(false)
@@ -158,7 +158,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account in which to set the authorized withdrawer. "
+                    "Vote account in which to set the authorized withdrawer."
                 ))
                 .arg(
                     Arg::with_name("authorized")
@@ -173,7 +173,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(3)
                         .value_name("AUTHORIZED_PUBKEY")
                         .required(true),
-                    "New authorized withdrawer. "
+                    "New authorized withdrawer."
                 ))
                 .offline_args()
                 .nonce_args(false)
@@ -192,7 +192,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account in which to set the authorized voter. "
+                    "Vote account in which to set the authorized voter."
                 ))
                 .arg(
                     Arg::with_name("authorized")
@@ -227,7 +227,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account in which to set the authorized withdrawer. "
+                    "Vote account in which to set the authorized withdrawer."
                 ))
                 .arg(
                     Arg::with_name("authorized")
@@ -259,7 +259,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account to update. "
+                    "Vote account to update."
                 ))
                 .arg(
                     Arg::with_name("new_identity_account")
@@ -293,7 +293,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account to update. "
+                    "Vote account to update."
                 ))
                 .arg(
                     Arg::with_name("commission")
@@ -328,7 +328,7 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account pubkey. "
+                    "Vote account pubkey."
                 ))
                 .arg(
                     Arg::with_name("lamports")
@@ -370,14 +370,14 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account from which to withdraw. "
+                    "Vote account from which to withdraw."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The recipient of withdrawn SOL. "
+                    "The recipient of withdrawn SOL."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -413,14 +413,14 @@ impl VoteSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("VOTE_ACCOUNT_ADDRESS")
                         .required(true),
-                    "Vote account to be closed. "
+                    "Vote account to be closed."
                 ))
                 .arg(pubkey!(
                     Arg::with_name("destination_account_pubkey")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The recipient of all withdrawn SOL. "
+                    "The recipient of all withdrawn SOL."
                 ))
                 .arg(
                     Arg::with_name("authorized_withdrawer")

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -65,7 +65,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
                         .required(true),
-                    "Account key URI."
+                    "Account."
                 ))
                 .arg(
                     Arg::with_name("output_file")

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -65,7 +65,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
                         .required(true),
-                    "Account."
+                    "Account contents to show."
                 ))
                 .arg(
                     Arg::with_name("output_file")

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -65,7 +65,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS")
                         .required(true),
-                    "Account key URI. "
+                    "Account key URI."
                 ))
                 .arg(
                     Arg::with_name("output_file")
@@ -108,7 +108,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("to")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS"),
-                    "The account address of airdrop recipient. "
+                    "The account address of airdrop recipient."
                 )),
         )
         .subcommand(
@@ -118,7 +118,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS"),
-                    "The account address of the balance to check. "
+                    "The account address of the balance to check."
                 ))
                 .arg(
                     Arg::with_name("lamports")
@@ -183,7 +183,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .long("from")
                         .value_name("FROM_PUBKEY")
                         .required(false),
-                    "From (base) key, [default: cli config keypair]. "
+                    "From (base) key, [default: cli config keypair]."
                 )),
         )
         .subcommand(
@@ -265,7 +265,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The account address of recipient. "
+                    "The account address of recipient."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -280,7 +280,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_ADDRESS"),
-                    "Source account of funds (if different from client local account). "
+                    "Source account of funds (if different from client local account)."
                 ))
                 .arg(
                     Arg::with_name("no_wait")
@@ -382,7 +382,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .long("signer")
                         .value_name("PUBKEY")
                         .required(false),
-                    "The pubkey of the message signer (if different from config default)"
+                    "The pubkey of the message signer (if different from config default)."
                 )),
         )
     }

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -108,7 +108,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("to")
                         .index(2)
                         .value_name("RECIPIENT_ADDRESS"),
-                    "The account address of airdrop recipient."
+                    "Account of airdrop recipient."
                 )),
         )
         .subcommand(
@@ -118,7 +118,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("pubkey")
                         .index(1)
                         .value_name("ACCOUNT_ADDRESS"),
-                    "The account address of the balance to check."
+                    "Account balance to check."
                 ))
                 .arg(
                     Arg::with_name("lamports")
@@ -265,7 +265,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .index(1)
                         .value_name("RECIPIENT_ADDRESS")
                         .required(true),
-                    "The account address of recipient."
+                    "Account of recipient."
                 ))
                 .arg(
                     Arg::with_name("amount")
@@ -280,7 +280,7 @@ impl WalletSubCommands for App<'_, '_> {
                     Arg::with_name("from")
                         .long("from")
                         .value_name("FROM_ADDRESS"),
-                    "Source account of funds (if different from client local account)."
+                    "Source account of funds [default: cli config keypair]."
                 ))
                 .arg(
                     Arg::with_name("no_wait")
@@ -382,7 +382,7 @@ impl WalletSubCommands for App<'_, '_> {
                         .long("signer")
                         .value_name("PUBKEY")
                         .required(false),
-                    "The pubkey of the message signer (if different from config default)."
+                    "Message signer [default: cli config keypair]."
                 )),
         )
     }


### PR DESCRIPTION
#### Problem
In https://github.com/solana-labs/solana/pull/34288, we discovered there are a bunch of uses of the `solana_cli::pubkey` macro that add unnecessary punctuation, which ends up goofy. Eg:
```
$ solana inflation rewards -h
...
ARGS:
    <ADDRESS>...    Address of account to query for rewards. , one of:
                      * a base58-encoded public key
                      * a path to a keypair file
                      * a hyphen; signals a JSON-encoded keypair on stdin
                      * the 'ASK' keyword; to recover a keypair via its seed phrase
                      * a hardware wallet keypair URL (i.e. usb://ledger)
```

#### Summary of Changes
~~Remove periods and spaces. In a couple cases, we include extra information about the address -- I made these into parentheticals, so the punctuation still works. Open to other suggestions, though, as I don't love how it demotes the information.~~
Update macro to be a complete sentence and adjust args accordingly.
I also fixed one argument definition that was confusing

(edit) Updated example below to match new approach
Fixed pubkeys look like:
```
$ cargo run -- inflation rewards -h
...
ARGS:
    <ADDRESS>...    Account to query for rewards. Address is one of:
                      * a base58-encoded public key
                      * a path to a keypair file
                      * a hyphen; signals a JSON-encoded keypair on stdin
                      * the 'ASK' keyword; to recover a keypair via its seed phrase
                      * a hardware wallet keypair URL (i.e. usb://ledger)
```
