### PR TITLE
Derives Pod for tiered storage types

### DIFF
--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -29,6 +29,9 @@ pub const FOOTER_MAGIC_NUMBER: u64 = 0x502A2AB5; // SOLALABS -> SOLANA LABS
 #[repr(C)]
 pub struct TieredStorageMagicNumber(pub u64);
 
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<TieredStorageMagicNumber>() == 8);
+
 impl Default for TieredStorageMagicNumber {
     fn default() -> Self {
         Self(FOOTER_MAGIC_NUMBER)

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -15,6 +15,7 @@ use {
             TieredStorageError, TieredStorageFormat, TieredStorageResult,
         },
     },
+    bytemuck::{Pod, Zeroable},
     memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
     solana_sdk::{pubkey::Pubkey, stake_history::Epoch},
@@ -45,7 +46,7 @@ const MAX_HOT_ACCOUNT_OFFSET: usize = u32::MAX as usize * HOT_ACCOUNT_OFFSET_ALI
 
 #[bitfield(bits = 32)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Pod, Zeroable)]
 struct HotMetaPackedFields {
     /// A hot account entry consists of the following elements:
     ///
@@ -61,10 +62,16 @@ struct HotMetaPackedFields {
     owner_offset: B29,
 }
 
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<HotMetaPackedFields>() == 4);
+
 /// The offset to access a hot account.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Pod, Zeroable)]
 pub struct HotAccountOffset(u32);
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<HotAccountOffset>() == 4);
 
 impl AccountOffset for HotAccountOffset {}
 
@@ -99,7 +106,7 @@ impl HotAccountOffset {
 
 /// The storage and in-memory representation of the metadata entry for a
 /// hot account.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Pod, Zeroable)]
 #[repr(C)]
 pub struct HotAccountMeta {
     /// The balance of this account.
@@ -109,6 +116,9 @@ pub struct HotAccountMeta {
     /// Stores boolean flags and existence of each optional field.
     flags: AccountMetaFlags,
 }
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<HotAccountMeta>() == 8 + 4 + 4);
 
 impl TieredAccountMeta for HotAccountMeta {
     /// Construct a HotAccountMeta instance.

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -3,6 +3,7 @@ use {
         file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_type,
         TieredStorageResult,
     },
+    bytemuck::{Pod, Zeroable},
     memmap2::Mmap,
     solana_sdk::pubkey::Pubkey,
 };
@@ -17,13 +18,17 @@ pub struct AccountIndexWriterEntry<'a, Offset: AccountOffset> {
 }
 
 /// The offset to an account.
-pub trait AccountOffset {}
+pub trait AccountOffset: Clone + Copy + Pod + Zeroable {}
 
 /// The offset to an account/address entry in the accounts index block.
 /// This can be used to obtain the AccountOffset and address by looking through
 /// the accounts index block.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Pod, Zeroable)]
 pub struct IndexOffset(pub u32);
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<IndexOffset>() == 4);
 
 /// The index format of a tiered accounts file.
 #[repr(u16)]
@@ -45,6 +50,9 @@ pub enum IndexBlockFormat {
     #[default]
     AddressAndBlockOffsetOnly = 0,
 }
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<IndexBlockFormat>() == 2);
 
 impl IndexBlockFormat {
     /// Persists the specified index_entries to the specified file and returns
@@ -86,7 +94,7 @@ impl IndexBlockFormat {
     }
 
     /// Returns the offset to the account given the specified index.
-    pub fn get_account_offset<Offset: AccountOffset + Copy>(
+    pub fn get_account_offset<Offset: AccountOffset>(
         &self,
         mmap: &Mmap,
         footer: &TieredStorageFooter,

--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -2,6 +2,7 @@
 
 use {
     crate::{accounts_hash::AccountHash, tiered_storage::owners::OwnerOffset},
+    bytemuck::{Pod, Zeroable},
     modular_bitfield::prelude::*,
     solana_sdk::stake_history::Epoch,
 };
@@ -9,7 +10,7 @@ use {
 /// The struct that handles the account meta flags.
 #[bitfield(bits = 32)]
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Pod, Zeroable)]
 pub struct AccountMetaFlags {
     /// whether the account meta has rent epoch
     pub has_rent_epoch: bool,
@@ -18,6 +19,9 @@ pub struct AccountMetaFlags {
     /// the reserved bits.
     reserved: B30,
 }
+
+// Ensure there are no implicit padding bytes
+const _: () = assert!(std::mem::size_of::<AccountMetaFlags>() == 4);
 
 /// A trait that allows different implementations of the account meta that
 /// support different tiers of the accounts storage.


### PR DESCRIPTION
#### Problem

Related to https://github.com/solana-labs/solana/issues/34121, we'd like to eliminate all undefined behavior in Tiered Storage w.r.t. reading and writing bytes from files/mmaps.

The bytemuck crate provides traits for guaranteeing data layout that ensures there will not be undefined behavior. Tiered Storage is missing some of those traits that would make UB go away.


#### Summary of Changes

Derive the appropriate bytemuck traits on the Tiered Storage types that are written to files. Also add constant asserts to ensure the invariants for Pod are not broken.