### PR TITLE
Adds read/write/get_pod() fns to tiered storage

### DIFF
--- a/accounts-db/src/tiered_storage/file.rs
+++ b/accounts-db/src/tiered_storage/file.rs
@@ -1,8 +1,11 @@
-use std::{
-    fs::{File, OpenOptions},
-    io::{Read, Result as IoResult, Seek, SeekFrom, Write},
-    mem,
-    path::Path,
+use {
+    bytemuck::{AnyBitPattern, NoUninit},
+    std::{
+        fs::{File, OpenOptions},
+        io::{Read, Result as IoResult, Seek, SeekFrom, Write},
+        mem,
+        path::Path,
+    },
 };
 
 #[derive(Debug)]
@@ -33,14 +36,53 @@ impl TieredStorageFile {
         ))
     }
 
-    pub fn write_type<T>(&self, value: &T) -> IoResult<usize> {
+    /// Writes `value` to the file.
+    ///
+    /// `value` must be plain ol' data.
+    pub fn write_pod<T: NoUninit>(&self, value: &T) -> IoResult<usize> {
+        // SAFETY: Since T is NoUninit, it does not contain any uninitialized bytes.
+        unsafe { self.write_type(value) }
+    }
+
+    /// Writes `value` to the file.
+    ///
+    /// Prefer `write_pod` when possible, because `write_value` may cause
+    /// undefined behavior if `value` contains uninitialized bytes.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure casting T to bytes is safe.
+    /// Refer to the Safety sections in std::slice::from_raw_parts()
+    /// and bytemuck's Pod and NoUninit for more information.
+    pub unsafe fn write_type<T>(&self, value: &T) -> IoResult<usize> {
         let ptr = value as *const _ as *const u8;
         let bytes = unsafe { std::slice::from_raw_parts(ptr, mem::size_of::<T>()) };
         self.write_bytes(bytes)
     }
 
-    pub fn read_type<T>(&self, value: &mut T) -> IoResult<()> {
+    /// Reads a value of type `T` from the file.
+    ///
+    /// Type T must be plain ol' data.
+    pub fn read_pod<T: NoUninit + AnyBitPattern>(&self, value: &mut T) -> IoResult<()> {
+        // SAFETY: Since T is AnyBitPattern, it is safe to cast bytes to T.
+        unsafe { self.read_type(value) }
+    }
+
+    /// Reads a value of type `T` from the file.
+    ///
+    /// Prefer `read_pod()` when possible, because `read_type()` may cause
+    /// undefined behavior.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure casting bytes to T is safe.
+    /// Refer to the Safety sections in std::slice::from_raw_parts()
+    /// and bytemuck's Pod and AnyBitPattern for more information.
+    pub unsafe fn read_type<T>(&self, value: &mut T) -> IoResult<()> {
         let ptr = value as *mut _ as *mut u8;
+        // SAFETY: The caller ensures it is safe to cast bytes to T,
+        // we ensure the size is safe by querying T directly,
+        // and Rust ensures ptr is aligned.
         let bytes = unsafe { std::slice::from_raw_parts_mut(ptr, mem::size_of::<T>()) };
         self.read_bytes(bytes)
     }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -10,7 +10,7 @@ use {
             },
             index::{AccountOffset, IndexBlockFormat, IndexOffset},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-            mmap_utils::get_type,
+            mmap_utils::get_pod,
             owners::{OwnerOffset, OwnersBlock},
             TieredStorageError, TieredStorageFormat, TieredStorageResult,
         },
@@ -204,7 +204,7 @@ impl TieredAccountMeta for HotAccountMeta {
             .then(|| {
                 let offset = self.optional_fields_offset(account_block)
                     + AccountMetaOptionalFields::rent_epoch_offset(self.flags());
-                byte_block::read_type::<Epoch>(account_block, offset).copied()
+                byte_block::read_pod::<Epoch>(account_block, offset).copied()
             })
             .flatten()
     }
@@ -217,7 +217,7 @@ impl TieredAccountMeta for HotAccountMeta {
             .then(|| {
                 let offset = self.optional_fields_offset(account_block)
                     + AccountMetaOptionalFields::account_hash_offset(self.flags());
-                byte_block::read_type::<AccountHash>(account_block, offset)
+                byte_block::read_pod::<AccountHash>(account_block, offset)
             })
             .flatten()
     }
@@ -283,7 +283,7 @@ impl HotStorageReader {
     ) -> TieredStorageResult<&HotAccountMeta> {
         let internal_account_offset = account_offset.offset();
 
-        let (meta, _) = get_type::<HotAccountMeta>(&self.mmap, internal_account_offset)?;
+        let (meta, _) = get_pod::<HotAccountMeta>(&self.mmap, internal_account_offset)?;
         Ok(meta)
     }
 
@@ -429,13 +429,16 @@ pub mod tests {
             .with_flags(&flags);
 
         let mut writer = ByteBlockWriter::new(AccountBlockFormat::AlignedRaw);
-        writer.write_type(&expected_meta).unwrap();
-        writer.write_type(&account_data).unwrap();
-        writer.write_type(&padding).unwrap();
+        writer.write_pod(&expected_meta).unwrap();
+        // SAFETY: These values are POD, so they are safe to write.
+        unsafe {
+            writer.write_type(&account_data).unwrap();
+            writer.write_type(&padding).unwrap();
+        }
         writer.write_optional_fields(&optional_fields).unwrap();
         let buffer = writer.finish().unwrap();
 
-        let meta = byte_block::read_type::<HotAccountMeta>(&buffer, 0).unwrap();
+        let meta = byte_block::read_pod::<HotAccountMeta>(&buffer, 0).unwrap();
         assert_eq!(expected_meta, *meta);
         assert!(meta.flags().has_rent_epoch());
         assert!(meta.flags().has_account_hash());
@@ -525,7 +528,7 @@ pub mod tests {
                 .iter()
                 .map(|meta| {
                     let prev_offset = current_offset;
-                    current_offset += file.write_type(meta).unwrap();
+                    current_offset += file.write_pod(meta).unwrap();
                     HotAccountOffset::new(prev_offset).unwrap()
                 })
                 .collect();

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_type,
+        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_pod,
         TieredStorageResult,
     },
     bytemuck::{Pod, Zeroable},
@@ -66,10 +66,10 @@ impl IndexBlockFormat {
             Self::AddressAndBlockOffsetOnly => {
                 let mut bytes_written = 0;
                 for index_entry in index_entries {
-                    bytes_written += file.write_type(index_entry.address)?;
+                    bytes_written += file.write_pod(index_entry.address)?;
                 }
                 for index_entry in index_entries {
-                    bytes_written += file.write_type(&index_entry.offset)?;
+                    bytes_written += file.write_pod(&index_entry.offset)?;
                 }
                 Ok(bytes_written)
             }
@@ -89,7 +89,7 @@ impl IndexBlockFormat {
                     + std::mem::size_of::<Pubkey>() * (index_offset.0 as usize)
             }
         };
-        let (address, _) = get_type::<Pubkey>(mmap, account_offset)?;
+        let (address, _) = get_pod::<Pubkey>(mmap, account_offset)?;
         Ok(address)
     }
 
@@ -105,7 +105,7 @@ impl IndexBlockFormat {
                 let offset = footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
                     + std::mem::size_of::<Offset>() * index_offset.0 as usize;
-                let (account_offset, _) = get_type::<Offset>(mmap, offset)?;
+                let (account_offset, _) = get_pod::<Offset>(mmap, offset)?;
 
                 Ok(*account_offset)
             }

--- a/accounts-db/src/tiered_storage/mmap_utils.rs
+++ b/accounts-db/src/tiered_storage/mmap_utils.rs
@@ -5,10 +5,30 @@ use {
     std::io::Result as IoResult,
 };
 
-pub fn get_type<T>(map: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
-    let (data, next) = get_slice(map, offset, std::mem::size_of::<T>())?;
+/// Borrows a value of type `T` from `mmap`
+///
+/// Type T must be plain ol' data to ensure no undefined behavior.
+pub fn get_pod<T: bytemuck::AnyBitPattern>(mmap: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
+    // SAFETY: Since T is AnyBitPattern, it is safe to cast bytes to T.
+    unsafe { get_type::<T>(mmap, offset) }
+}
+
+/// Borrows a value of type `T` from `mmap`
+///
+/// Prefer `get_pod()` when possible, because `get_type()` may cause undefined behavior.
+///
+/// # Safety
+///
+/// Caller must ensure casting bytes to T is safe.
+/// Refer to the Safety sections in std::slice::from_raw_parts()
+/// and bytemuck's Pod and AnyBitPattern for more information.
+pub unsafe fn get_type<T>(mmap: &Mmap, offset: usize) -> IoResult<(&T, usize)> {
+    let (data, next) = get_slice(mmap, offset, std::mem::size_of::<T>())?;
     let ptr = data.as_ptr() as *const T;
     debug_assert!(ptr as usize % std::mem::align_of::<T>() == 0);
+    // SAFETY: The caller ensures it is safe to cast bytes to T,
+    // we ensure the size is safe by querying T directly,
+    // and we just checked above to ensure the ptr is aligned for T.
     Ok((unsafe { &*ptr }, next))
 }
 
@@ -34,5 +54,7 @@ pub fn get_slice(mmap: &Mmap, offset: usize, size: usize) -> IoResult<(&[u8], us
     let next = u64_align!(next);
     let ptr = data.as_ptr();
 
+    // SAFETY: The Mmap ensures the bytes are safe the read, and we just checked
+    // to ensure we don't read past the end of the internal buffer.
     Ok((unsafe { std::slice::from_raw_parts(ptr, size) }, next))
 }

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -1,6 +1,6 @@
 use {
     crate::tiered_storage::{
-        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_type,
+        file::TieredStorageFile, footer::TieredStorageFooter, mmap_utils::get_pod,
         TieredStorageResult,
     },
     memmap2::Mmap,
@@ -32,7 +32,7 @@ impl OwnersBlock {
     ) -> TieredStorageResult<usize> {
         let mut bytes_written = 0;
         for address in addresses {
-            bytes_written += file.write_type(address)?;
+            bytes_written += file.write_pod(address)?;
         }
 
         Ok(bytes_written)
@@ -47,7 +47,7 @@ impl OwnersBlock {
     ) -> TieredStorageResult<&'a Pubkey> {
         let offset = footer.owners_block_offset as usize
             + (std::mem::size_of::<Pubkey>() * owner_offset.0 as usize);
-        let (pubkey, _) = get_type::<Pubkey>(mmap, offset)?;
+        let (pubkey, _) = get_pod::<Pubkey>(mmap, offset)?;
 
         Ok(pubkey)
     }


### PR DESCRIPTION
#### Problem

Related to https://github.com/solana-labs/solana/issues/34121, we'd like to eliminate all undefined behavior in Tiered Storage w.r.t. reading and writing bytes from files/mmaps.

Tiered Storage types are now Pod (as of #34414), but we do not use that knowledge to avoid potential undefined behavior.


#### Summary of Changes

Add `get/read/write_pod()` functions to the various ways that Tiered Storage reads/writes from files/mmaps.

This also properly marks the `get/read/write_type()` functions as `unsafe`, and adds documentation to all these functions and callers.