### PR TITLE
Unhide --block-production-method

### DIFF
--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1366,7 +1366,6 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
         .arg(
             Arg::with_name("block_production_method")
                 .long("block-production-method")
-                .hidden(hidden_unless_forced())
                 .value_name("METHOD")
                 .takes_value(true)
                 .possible_values(BlockProductionMethod::cli_names())


### PR DESCRIPTION
#### Problem
- New scheduler is in, there's more than one option here, it shouldn't be hidden.
- I forgot to do this previously

#### Summary of Changes
- Don't hide the `--block-production-method` cli arg for validator

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
