### PR TITLE
local-cluster: fix flaky test_rpc_block_subscribe

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2593,6 +2593,9 @@ fn test_rpc_block_subscribe() {
     let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
         &format!(
             "ws://{}",
+            // It is important that we subscribe to a non leader node as there
+            // is a race condition which can cause leader nodes to not send
+            // BlockUpdate notifications properly. See https://github.com/solana-labs/solana/pull/34421
             &rpc_node_contact_info.rpc_pubsub().unwrap().to_string()
         ),
         RpcBlockSubscribeFilter::All,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2564,33 +2564,37 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
 #[serial]
 #[ignore]
 fn test_rpc_block_subscribe() {
-    let total_stake = 100 * DEFAULT_NODE_STAKE;
-    let leader_stake = total_stake;
-    let node_stakes = vec![leader_stake];
+    let leader_stake = 100 * DEFAULT_NODE_STAKE;
+    let rpc_stake = DEFAULT_NODE_STAKE;
+    let total_stake = leader_stake + rpc_stake;
+    let node_stakes = vec![leader_stake, rpc_stake];
     let mut validator_config = ValidatorConfig::default_for_test();
     validator_config.enable_default_rpc_block_subscribe();
 
     let validator_keys = [
         "28bN3xyvrP4E8LwEgtLjhnkb7cY4amQb6DrYAbAYjgRV4GAGgkVM2K7wnxnAS7WDneuavza7x21MiafLu1HkwQt4",
+        "2saHBBoTkLMmttmPQP8KfBkcCw45S5cwtV3wTdGCscRC8uxdgvHxpHiWXKx4LvJjNJtnNcbSv5NdheokFFqnNDt8",
     ]
     .iter()
     .map(|s| (Arc::new(Keypair::from_base58_string(s)), true))
     .take(node_stakes.len())
     .collect::<Vec<_>>();
+    let rpc_node_pubkey = &validator_keys[1].0.pubkey();
 
     let mut config = ClusterConfig {
         cluster_lamports: total_stake,
         node_stakes,
-        validator_configs: vec![validator_config],
+        validator_configs: make_identical_validator_configs(&validator_config, 2),
         validator_keys: Some(validator_keys),
         skip_warmup_slots: true,
         ..ClusterConfig::default()
     };
     let cluster = LocalCluster::new(&mut config, SocketAddrSpace::Unspecified);
+    let rpc_node_contact_info = cluster.get_contact_info(rpc_node_pubkey).unwrap();
     let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
         &format!(
             "ws://{}",
-            &cluster.entry_point_info.rpc_pubsub().unwrap().to_string()
+            &rpc_node_contact_info.rpc_pubsub().unwrap().to_string()
         ),
         RpcBlockSubscribeFilter::All,
         Some(RpcBlockSubscribeConfig {

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2562,7 +2562,6 @@ fn run_test_load_program_accounts_partition(scan_commitment: CommitmentConfig) {
 
 #[test]
 #[serial]
-#[ignore]
 fn test_rpc_block_subscribe() {
     let leader_stake = 100 * DEFAULT_NODE_STAKE;
     let rpc_stake = DEFAULT_NODE_STAKE;


### PR DESCRIPTION
#### Problem
When a leader creates a bank, it will apply new entries to the working bank and then sends them to broadcast stage to be shredded and stored in blockstore/transmitted.

There is a race between replay and broadcast stage, and sometimes replay will vote on the bank before broadcast stage has a chance to shred the last batch of entries and store them in blockstore.

When replay votes on the bank, it will notify the rpc subscribers of the new block through the `AggregateCommitmentService`:
https://github.com/solana-labs/solana/blob/a2d7be0d07d54578b64dbed79ad482229bb7e25b/core/src/replay_stage.rs#L2249-L2255

However in the case mentioned, blockstore does not yet have all of the data shreds and the subscribers will be sent an `RpcBlockUpdateError` as the `RpcBlockUpdate` cannot be constructed:
https://github.com/solana-labs/solana/blob/a2d7be0d07d54578b64dbed79ad482229bb7e25b/ledger/src/blockstore.rs#L2189

The change https://github.com/solana-labs/solana/pull/34330 seems to exacerbate this race by increasing the # of shreds in the last FEC set. My naive hypothesis is that the extra coding shreds in the last FEC set slows down broadcast stage's blockstore insert such that the replay vote usually occurs first. 

#### Summary of Changes
Subscribe to the RPC of the non leader node, to avoid getting sent errors due to this race.

If we decide the race is necessary to fix, a solution could be to return an `Option<BlockUpdate>` with `None` in the case that `!slot_meta.is_full()` and we are the leader for that slot. This would not notify and not increment the last notified slot, so that it can be sent out on the next iteration:
https://github.com/solana-labs/solana/blob/383aa0451eb19f6d7299bf50effc1dc383054e6c/rpc/src/rpc_subscriptions.rs#L1034-L1050

Alternatively we could delay the leaders vote or rpc notification entirely until the last fec set has been inserted into blockstore.

Fixes #32863 