### PR TITLE
ledger-tool: Bubble up error enum instead of eprintln!() and exit()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6433,6 +6433,7 @@ dependencies = [
  "solana-version",
  "solana-vote-program",
  "solana_rbpf",
+ "thiserror",
  "tikv-jemallocator",
  "tokio",
 ]

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -48,6 +48,7 @@ solana-transaction-status = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 solana_rbpf = { workspace = true, features = ["debugger"] }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]


### PR DESCRIPTION
#### Problem
The ledger-tool `load_and_process_ledger()` function performs many sub-operations that can fail. The current error handling of printing text and exiting inline adds extra noise to the code that actually does work. ~Additionally, all of the separate exit points mean that there might be slightly different variations the common text when an unrecoverable error occurs.~

#### Summary of Changes
- Introduce `LoadAndProcessLedgerError` enum for `load_and_process_ledger()` error conditions
- Remove early exits and instead bubble up a `Result<_, LoadAndProcessLedgerError>`
- ~Introduce and use wrapper that unwraps or exits `load_and_process_ledger()`~
- ~Use the wrapper for all previous callers of `load_and_process_ledger()` to remove boilerplate code~

~The diff on this one is massive because some match statements were removed and `cargo fmt` reduced a lot of indentation. All of the changes introduced by `cargo fmt` are in a single commit, so viewing this PR commit-by-commit OR with whitespace hidden (or both) would be my advice.~

All of the struckthrough items will be handled in a separate PR