### PR TITLE
CI: add check for explicit spl-token-cli version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,6 +98,7 @@ Alternatively use the Github UI.
 
 ### Miscellaneous Clean up
 
+1. Pin the spl-token-cli version in the newly promoted stable branch by setting `splTokenCliVersion` in scripts/spl-token-cli-version.sh to the latest release that depends on the stable branch (usually this will be the latest spl-token-cli release).
 1. Update [mergify.yml](https://github.com/solana-labs/solana/blob/master/.mergify.yml) to add backport actions for the new branch and remove actions for the obsolete branch.
 1. Adjust the [Github backport labels](https://github.com/solana-labs/solana/labels) to add the new branch label and remove the label for the obsolete branch.
 1. Announce on Discord #development that the release branch exists so people know to use the new backport labels.

--- a/ci/check-install-all.sh
+++ b/ci/check-install-all.sh
@@ -1,0 +1,5 @@
+source scripts/spl-token-cli-version.sh
+if [[ -z $splTokenCliVersion ]]; then
+    echo "On the stable channel, splTokenCliVersion must be set in scripts/spl-token-cli-version.sh"
+    exit 1
+fi

--- a/ci/test-checks.sh
+++ b/ci/test-checks.sh
@@ -84,4 +84,8 @@ _ scripts/cargo-for-all-lock-files.sh -- "+${rust_nightly}" fmt --all -- --check
 
 _ ci/do-audit.sh
 
+if [[ -n $CI ]] && [[ $CHANNEL = "stable" ]]; then
+  _ ci/check-install-all.sh
+fi
+
 echo --- ok

--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -149,11 +149,15 @@ mkdir -p "$installDir/bin"
 
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
+    # shellcheck source=scripts/spl-token-cli-version.sh
+    source "$here"/spl-token-cli-version.sh
+
     # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version
     "$cargo" $maybeRustVersion \
       --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
       --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
+      $maybeSplTokenCliVersionArg \
       install --locked spl-token-cli --root "$installDir"
   fi
 )

--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,0 +1,8 @@
+# populate this on the stable branch
+splTokenCliVersion=
+
+maybeSplTokenCliVersionArg=
+if [[ -n "$splTokenCliVersion" ]]; then
+    # shellcheck disable=SC2034
+    maybeSplTokenCliVersionArg="--version $splTokenCliVersion"
+fi


### PR DESCRIPTION
#### Problem
If https://github.com/solana-labs/solana-program-library releases a new version of `spl-token-cli` that depends on the beta branch, [this cargo-install-all command](https://github.com/solana-labs/solana/blob/39f2866a1084dd073387f47ccb7dc3a67a822ba9/scripts/cargo-install-all.sh#L154) will likely break, due to rust-version and various other mismatches.

#### Summary of Changes
Require the stable channel to set an explicit `$splTokenCliVersion`
Check that this is set in CI
Use `$splTokenCliVersion` to set a `--version` for the spl-token-cli `cargo install` command


Will fix #34429, with backports and (on v1.16) variable population
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
