### PR TITLE
v1.16: LoadedPrograms: introduce explicit SecondLevel type, fix prune_by_deployment_slot bug

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -519,21 +519,16 @@ impl LoadedPrograms {
     }
 
     pub fn prune_by_deployment_slot(&mut self, slot: Slot) {
-        self.entries.retain(|_key, second_level| {
-            *second_level = second_level
-                .iter()
-                .filter(|entry| entry.deployment_slot != slot)
-                .cloned()
-                .collect();
-            !second_level.is_empty()
-        });
+        for second_level in self.entries.values_mut() {
+            second_level.retain(|entry| entry.deployment_slot != slot);
+        }
         self.remove_programs_with_no_entries();
     }
 
     /// Before rerooting the blockstore this removes all programs of orphan forks
     pub fn prune<F: ForkGraph>(&mut self, fork_graph: &F, new_root: Slot) {
         let previous_root = self.latest_root;
-        self.entries.retain(|_key, second_level| {
+        for second_level in self.entries.values_mut() {
             let mut first_ancestor_found = false;
             *second_level = second_level
                 .iter()
@@ -556,8 +551,7 @@ impl LoadedPrograms {
                 .cloned()
                 .collect();
             second_level.reverse();
-            !second_level.is_empty()
-        });
+        }
 
         self.remove_expired_entries(new_root);
         self.remove_programs_with_no_entries();


### PR DESCRIPTION
This adds an explicit `SecondLevel` type where we used to use `Vec<Arc<LoadedProgram>>`, in preparation of adding more fields. 

It also fixes a minor issue where `prune_by_deployment_slot` would accidentally remove toplevel entries when it wasn't supposed to.