### PR TITLE
blockstore: Allow fallback for AddressSignature index()

### DIFF
--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -875,7 +875,8 @@ impl Column for columns::AddressSignatures {
     }
 
     fn index(key: &[u8]) -> (u64, Pubkey, Slot, Signature) {
-        <columns::AddressSignatures as ColumnIndexDeprecation>::try_current_index(key).unwrap()
+        <columns::AddressSignatures as ColumnIndexDeprecation>::try_current_index(key)
+            .unwrap_or_else(|_| Self::as_index(0))
     }
 
     fn primary_index(index: Self::Index) -> u64 {


### PR DESCRIPTION
#### Problem
A change landed somewhat recently in master that changed the key format of the transaction metadata columns. A compatibility backport was introduced to allow a blockstore that had been populated with this newer version to still be readable by v1.17 (backwards software compat).

However, there was an oversight in the backport. Namely, the `index()` function for AddressSignatures column did a regular `unwrap()` in `try_current_index()`. `try_current_index()` can fail if a key with an unknown size is encountered. This would be exactly the case for encountering a key that was populated by the newer software version with the different key format.

Namely, the following panic was observed when downgrading from recent tip of master to v1.17 with `--enable-rpc-transaction-history` flag:
```
thread '<unnamed>' panicked at ledger/src/blockstore_db.rs:878:88:
called `Result::unwrap()` on an `Err` value: UnpackError
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/std/src/panicking.rs:595:5
   1: core::panicking::panic_fmt
             at ./rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at ./rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library/core/src/result.rs:1652:5
   3: rocksdb::compaction_filter::filter_callback
   4: _ZNK26rocksdb_compactionfilter_t6FilterEiRKN7rocksdb5SliceES3_PNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPb
   5: _ZN7rocksdb18CompactionIterator20InvokeFilterIfNeededEPbPNS_5SliceE
   6: _ZN7rocksdb18CompactionIterator13NextFromInputEv
   7: _ZN7rocksdb18CompactionIterator11SeekToFirstEv
   8: _ZN7rocksdb13CompactionJob25ProcessKeyValueCompactionEPNS_18SubcompactionStateE
   9: _ZN7rocksdb13CompactionJob3RunEv
  10: _ZN7rocksdb6DBImpl20BackgroundCompactionEPbPNS_10JobContextEPNS_9LogBufferEPNS0_19PrepickedCompactionENS_3Env8PriorityE
  11: _ZN7rocksdb6DBImpl24BackgroundCallCompactionEPNS0_19PrepickedCompactionENS_3Env8PriorityE
  12: _ZN7rocksdb6DBImpl16BGWorkCompactionEPv
  13: _ZN7rocksdb14ThreadPoolImpl4Impl8BGThreadEm
  14: _ZN7rocksdb14ThreadPoolImpl4Impl15BGThreadWrapperEPv
  15: <unknown>
  16: start_thread
  17: clone
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
[2023-12-11T20:53:23.073363622Z ERROR solana_metrics::metrics] datapoint: panic program="validator" thread="?" one=1i message="panicked at ledger/src/blockstore_db.rs:878:88:
    called `Result::unwrap()` on an `Err` value: UnpackError" location="ledger/src/blockstore_db.rs:878:88" version="1.17.9 (src:daf37308; feat:1428472342, client:SolanaLabs)"
```

And here is the line for v1.17.9 mentioned in the panic message:
https://github.com/solana-labs/solana/blob/8b2c1a547d283bcd813a039982e3f8b18f37c0bd/ledger/src/blockstore_db.rs#L878

#### Summary of Changes
So, use `.unwrap_or_else()` in the `index()` implementation for AddressSignatures; this will now be consistent with the implementation of index() for TransactionStatus column.