### PR TITLE
Update build by source docs to add pre-requisites

### DIFF
--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -215,6 +215,20 @@ Download `protoc` from the
 [GitHub releases page of Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases),
 and add it to your `PATH`.
 
+:::info
+
+Users on Windows 10 or 11 may need to install
+[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install)
+(WSL) in order to be able to build from source. WSL provides a Linux environment
+that runs inside your existing Windows installation. You can then run regular
+Linux software, including the Linux versions of Solana CLI.
+
+After installed, run `wsl` from your Windows terminal, then continue through the
+[Debian and Other Linux Distributions](#for-debian-and-other-linux-distributions)
+above.
+
+:::
+
 ### Building from Source
 
 After installing the prerequisites, proceed with building Solana from source, 

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -4,8 +4,8 @@ sidebar_label: Installation
 sidebar_position: 1
 ---
 
-There are multiple ways to install the Solana tools on your computer
-depending on your preferred workflow:
+There are multiple ways to install the Solana tools on your computer depending
+on your preferred workflow:
 
 - [Use Solana's Install Tool (Simplest option)](#use-solanas-install-tool)
 - [Download Prebuilt Binaries](#download-prebuilt-binaries)
@@ -19,8 +19,8 @@ depending on your preferred workflow:
 - Open your favorite Terminal application
 
 - Install the Solana release
-  [LATEST_SOLANA_RELEASE_VERSION](https://github.com/solana-labs/solana/releases/tag/LATEST_SOLANA_RELEASE_VERSION) on your
-  machine by running:
+  [LATEST_SOLANA_RELEASE_VERSION](https://github.com/solana-labs/solana/releases/tag/LATEST_SOLANA_RELEASE_VERSION)
+  on your machine by running:
 
 ```bash
 sh -c "$(curl -sSfL https://release.solana.com/LATEST_SOLANA_RELEASE_VERSION/install)"
@@ -41,15 +41,14 @@ Active release directory: /home/solana/.local/share/solana/install/active_releas
 Update successful
 ```
 
-- Depending on your system, the end of the installer messaging may prompt you
-  to
+- Depending on your system, the end of the installer messaging may prompt you to
 
 ```bash
 Please update your PATH environment variable to include the solana programs:
 ```
 
-- If you get the above message, copy and paste the recommended command below
-  it to update `PATH`
+- If you get the above message, copy and paste the recommended command below it
+  to update `PATH`
 - Confirm you have the desired version of `solana` installed by running:
 
 ```bash
@@ -65,10 +64,10 @@ solana --version
 
 - Open a Command Prompt (`cmd.exe`) as an Administrator
 
-  - Search for Command Prompt in the Windows search bar. When the Command
-    Prompt app appears, right-click and select “Open as Administrator”.
-    If you are prompted by a pop-up window asking “Do you want to allow this app to
-    make changes to your device?”, click Yes.
+  - Search for Command Prompt in the Windows search bar. When the Command Prompt
+    app appears, right-click and select “Open as Administrator”. If you are
+    prompted by a pop-up window asking “Do you want to allow this app to make
+    changes to your device?”, click Yes.
 
 - Copy and paste the following command, then press Enter to download the Solana
   installer into a temporary directory:
@@ -149,7 +148,7 @@ set PATH=%cd%/bin;%PATH%
 ## Build From Source
 
 If you are unable to use the prebuilt binaries or prefer to build it yourself
-from source, follow these steps, ensuring you have the necessary prerequisites 
+from source, follow these steps, ensuring you have the necessary prerequisites
 installed on your system.
 
 ### Prerequisites
@@ -157,22 +156,24 @@ installed on your system.
 Before building from source, make sure to install the following prerequisites:
 
 #### For Debian and Other Linux Distributions:
-Rust Programming Language:
-Check "Install Rust" at
+
+Rust Programming Language: Check "Install Rust" at
 [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
 which recommends the following command.
+
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 Install build dependencies:
+
 - Build essential
 - Package config
 - Udev & LLM & libclang
 - Protocol buffers
 
 ```bash
-apt-get install \ 
+apt-get install \
     build-essential \
     pkg-config \
     libudev-dev llvm libclang-dev \
@@ -180,40 +181,47 @@ apt-get install \
 ```
 
 #### For Other Linux Distributions:
-Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`, 
+
+Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`,
 `pacman`) and adjust package names as needed.
 
 #### For macOS:
+
 Install Homebrew (if not already installed), check "Install Hombrew" at
 [https://brew.sh/](https://brew.sh/), which recommends the following command:
+
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
+
 Install the necessary tools and libraries using Homebrew:
+
 ```bash
 brew install rust pkg-config libudev protobuf llvm coreutils
 ```
-Follow the instructions given at the end of the brew install command about 
+
+Follow the instructions given at the end of the brew install command about
 `PATH` configurations.
 
 #### For Windows:
-Rust Programming Language:
-Check "Install Rust" at
+
+Rust Programming Language: Check "Install Rust" at
 [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
 which recommends the following command.
+
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
-- Download and install the Build Tools for Visual Studio (2019 or later) from 
-the [Visual Studio downloads page](https://visualstudio.microsoft.com/downloads/).
-Make sure to include the C++ build tools in the installation.
-- Install LLVM: 
-Download and install LLVM from the 
-[official LLVM download page](https://releases.llvm.org/download.html).
-- Install Protocol Buffers Compiler (protoc):
-Download `protoc` from the 
-[GitHub releases page of Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases),
-and add it to your `PATH`.
+
+- Download and install the Build Tools for Visual Studio (2019 or later) from
+  the
+  [Visual Studio downloads page](https://visualstudio.microsoft.com/downloads/).
+  Make sure to include the C++ build tools in the installation.
+- Install LLVM: Download and install LLVM from the
+  [official LLVM download page](https://releases.llvm.org/download.html).
+- Install Protocol Buffers Compiler (protoc): Download `protoc` from the
+  [GitHub releases page of Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases),
+  and add it to your `PATH`.
 
 :::info
 
@@ -231,11 +239,12 @@ above.
 
 ### Building from Source
 
-After installing the prerequisites, proceed with building Solana from source, 
+After installing the prerequisites, proceed with building Solana from source,
 navigate to
 [Solana's GitHub releases page](https://github.com/solana-labs/solana/releases/latest),
-and download the **Source Code** archive.
-Extract the code and build the binaries with:
+and download the **Source Code** archive. Extract the code and build the
+binaries with:
+
 ```bash
 ./scripts/cargo-install-all.sh .
 export PATH=$PWD/bin:$PATH
@@ -250,15 +259,16 @@ solana-install init
 
 ## Use Homebrew
 
-This option requires you to have [Homebrew](https://brew.sh/) package manager on your MacOS or Linux machine.
+This option requires you to have [Homebrew](https://brew.sh/) package manager on
+your MacOS or Linux machine.
 
 ### MacOS & Linux
 
 - Follow instructions at: https://formulae.brew.sh/formula/solana
 
 [Homebrew formulae](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/solana.rb)
-is updated after each `solana` release, however it is possible that
-the Homebrew version is outdated.
+is updated after each `solana` release, however it is possible that the Homebrew
+version is outdated.
 
 - Confirm you have the desired version of `solana` installed by entering:
 

--- a/docs/src/cli/install.md
+++ b/docs/src/cli/install.md
@@ -149,11 +149,79 @@ set PATH=%cd%/bin;%PATH%
 ## Build From Source
 
 If you are unable to use the prebuilt binaries or prefer to build it yourself
-from source, navigate to
-[https://github.com/solana-labs/solana/releases/latest](https://github.com/solana-labs/solana/releases/latest),
-and download the **Source Code** archive. Extract the code and build the
-binaries with:
+from source, follow these steps, ensuring you have the necessary prerequisites 
+installed on your system.
 
+### Prerequisites
+
+Before building from source, make sure to install the following prerequisites:
+
+#### For Debian and Other Linux Distributions:
+Rust Programming Language:
+Check "Install Rust" at
+[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
+which recommends the following command.
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Install build dependencies:
+- Build essential
+- Package config
+- Udev & LLM & libclang
+- Protocol buffers
+
+```bash
+apt-get install \ 
+    build-essential \
+    pkg-config \
+    libudev-dev llvm libclang-dev \
+    protobuf-compiler
+```
+
+#### For Other Linux Distributions:
+Replace `apt` with your distribution's package manager (e.g., `yum`, `dnf`, 
+`pacman`) and adjust package names as needed.
+
+#### For macOS:
+Install Homebrew (if not already installed), check "Install Hombrew" at
+[https://brew.sh/](https://brew.sh/), which recommends the following command:
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+Install the necessary tools and libraries using Homebrew:
+```bash
+brew install rust pkg-config libudev protobuf llvm coreutils
+```
+Follow the instructions given at the end of the brew install command about 
+`PATH` configurations.
+
+#### For Windows:
+Rust Programming Language:
+Check "Install Rust" at
+[https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install),
+which recommends the following command.
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+- Download and install the Build Tools for Visual Studio (2019 or later) from 
+the [Visual Studio downloads page](https://visualstudio.microsoft.com/downloads/).
+Make sure to include the C++ build tools in the installation.
+- Install LLVM: 
+Download and install LLVM from the 
+[official LLVM download page](https://releases.llvm.org/download.html).
+- Install Protocol Buffers Compiler (protoc):
+Download `protoc` from the 
+[GitHub releases page of Protocol Buffers](https://github.com/protocolbuffers/protobuf/releases),
+and add it to your `PATH`.
+
+### Building from Source
+
+After installing the prerequisites, proceed with building Solana from source, 
+navigate to
+[Solana's GitHub releases page](https://github.com/solana-labs/solana/releases/latest),
+and download the **Source Code** archive.
+Extract the code and build the binaries with:
 ```bash
 ./scripts/cargo-install-all.sh .
 export PATH=$PWD/bin:$PATH


### PR DESCRIPTION
#### Problem

I was building the Solana binary after following the [Setup a Solana Validator](https://docs.solana.com/validator/get-started/setup-a-validator) guide. 

I used a recently created VM for this, so I had a clean environment. I ran `./scripts/cargo-install-all.sh .` up to four times because I didn't have the prerequisites to perform the build. **Using a Build from source is encouraged in the guide**

The build requirements are pretty standard and are likely to be maintained, but the failures might discourage non-developers from playing around and creating a validator node. This MR tries to fix this by providing extended information on prerequisites before triggering the build.

#### Summary of Changes

This MR updates the `docs/src/cli/install.md` page from the official documentation, adding the build prerequisites for Linux, macOS, and Windows.