### PR TITLE
Set root slot/epoch in cache constructor

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -473,21 +473,6 @@ impl<FG: ForkGraph> Debug for LoadedPrograms<FG> {
     }
 }
 
-impl<FG: ForkGraph> Default for LoadedPrograms<FG> {
-    fn default() -> Self {
-        Self {
-            entries: HashMap::new(),
-            latest_root_slot: 0,
-            latest_root_epoch: 0,
-            environments: ProgramRuntimeEnvironments::default(),
-            upcoming_environments: None,
-            programs_to_recompile: Vec::default(),
-            stats: Stats::default(),
-            fork_graph: None,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default)]
 pub struct LoadedProgramsForTxBatch {
     /// Pubkey is the address of a program.
@@ -562,6 +547,19 @@ pub enum LoadedProgramMatchCriteria {
 }
 
 impl<FG: ForkGraph> LoadedPrograms<FG> {
+    pub fn new(root_slot: Slot, root_epoch: Epoch) -> Self {
+        Self {
+            entries: HashMap::new(),
+            latest_root_slot: root_slot,
+            latest_root_epoch: root_epoch,
+            environments: ProgramRuntimeEnvironments::default(),
+            upcoming_environments: None,
+            programs_to_recompile: Vec::default(),
+            stats: Stats::default(),
+            fork_graph: None,
+        }
+    }
+
     pub fn set_fork_graph(&mut self, fork_graph: Arc<RwLock<FG>>) {
         self.fork_graph = Some(fork_graph);
     }
@@ -969,7 +967,7 @@ impl solana_frozen_abi::abi_example::AbiExample for LoadedProgram {
 impl<FG: ForkGraph> solana_frozen_abi::abi_example::AbiExample for LoadedPrograms<FG> {
     fn example() -> Self {
         // LoadedPrograms isn't serializable by definition.
-        Self::default()
+        Self::new(Slot::default(), Epoch::default())
     }
 }
 
@@ -998,7 +996,8 @@ mod tests {
         std::sync::OnceLock::<ProgramRuntimeEnvironment>::new();
 
     fn new_mock_cache<FG: ForkGraph>() -> LoadedPrograms<FG> {
-        let mut cache = LoadedPrograms::default();
+        let mut cache = LoadedPrograms::new(0, 0);
+
         cache.environments.program_runtime_v1 = MOCK_ENVIRONMENT
             .get_or_init(|| Arc::new(BuiltinProgram::new_mock()))
             .clone();

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1032,7 +1032,10 @@ impl Bank {
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             fee_structure: FeeStructure::default(),
-            loaded_programs_cache: Arc::<RwLock<LoadedPrograms<BankForks>>>::default(),
+            loaded_programs_cache: Arc::new(RwLock::new(LoadedPrograms::new(
+                Slot::default(),
+                Epoch::default(),
+            ))),
             check_program_modification_slot: false,
             epoch_reward_status: EpochRewardStatus::default(),
         };
@@ -1880,7 +1883,10 @@ impl Bank {
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             fee_structure: FeeStructure::default(),
-            loaded_programs_cache: Arc::<RwLock<LoadedPrograms<BankForks>>>::default(),
+            loaded_programs_cache: Arc::new(RwLock::new(LoadedPrograms::new(
+                fields.slot,
+                fields.epoch,
+            ))),
             check_program_modification_slot: false,
             epoch_reward_status: EpochRewardStatus::default(),
         };


### PR DESCRIPTION
#### Problem
The root slot/epoch are integral part of the program cache, and must be initialized in `new()`.

#### Summary of Changes
- remove default implementation of cache
- add a constructor `new()` that takes root slot/epoch as parameters and sets it in the cache
- update `bank` to call the new constructor.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
