### PR TITLE
Remove redundant code from Bank::wrap_with_bank_forks_for_tests()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8174,14 +8174,9 @@ impl Bank {
 #[cfg(feature = "dev-context-only-utils")]
 impl Bank {
     pub fn wrap_with_bank_forks_for_tests(self) -> (Arc<Self>, Arc<RwLock<BankForks>>) {
-        let bank_fork = BankForks::new_rw_arc(self);
-        let bank_arc = bank_fork.read().unwrap().root_bank();
-        bank_arc
-            .loaded_programs_cache
-            .write()
-            .unwrap()
-            .set_fork_graph(bank_fork.clone());
-        (bank_arc, bank_fork)
+        let bank_forks = BankForks::new_rw_arc(self);
+        let bank = bank_forks.read().unwrap().root_bank();
+        (bank, bank_forks)
     }
 
     pub fn default_for_tests() -> Self {


### PR DESCRIPTION
#### Problem
The same initialization occurs when the Bank is inserted into a new BankForks, so no need to duplicate the logic in this test function

#### Summary of Changes
Remove redundant code; below is the snippet where this same thing happens in `BankForks::new_from_banks()`:

https://github.com/solana-labs/solana/blob/2a67fa8d13e77d60704f0c522a914b0d259ecc3e/runtime/src/bank_forks.rs#L211-L216