### PR TITLE
Only allow BankForks creation with single bank

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4914,8 +4914,8 @@ pub(crate) mod tests {
             bank0.register_default_tick_for_test();
         }
         bank0.freeze();
-        let arc_bank0 = Arc::new(bank0);
-        let bank_forks = BankForks::new_from_banks(&[arc_bank0], 0);
+        //let slot = bank0.slot();
+        let bank_forks = BankForks::new_rw_arc(bank0);
 
         let exit = Arc::new(AtomicBool::new(false));
         let block_commitment_cache = Arc::new(RwLock::new(BlockCommitmentCache::default()));

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -4914,7 +4914,6 @@ pub(crate) mod tests {
             bank0.register_default_tick_for_test();
         }
         bank0.freeze();
-        //let slot = bank0.slot();
         let bank_forks = BankForks::new_rw_arc(bank0);
 
         let exit = Arc::new(AtomicBool::new(false));

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -128,12 +128,11 @@ impl BankForks {
             scheduler_pool: None,
         }));
 
-        for bank in bank_forks.read().unwrap().banks.values() {
-            bank.loaded_programs_cache
-                .write()
-                .unwrap()
-                .set_fork_graph(bank_forks.clone());
-        }
+        root_bank
+            .loaded_programs_cache
+            .write()
+            .unwrap()
+            .set_fork_graph(bank_forks.clone());
 
         bank_forks
     }

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -110,12 +110,11 @@ impl BankForks {
         }
 
         let mut descendants = HashMap::<_, HashSet<_>>::new();
-        for (slot, bank) in &banks {
-            descendants.entry(*slot).or_default();
-            for parent in bank.proper_ancestors() {
-                descendants.entry(parent).or_default().insert(*slot);
-            }
+        descendants.entry(root_slot).or_default();
+        for parent in root_bank.proper_ancestors() {
+            descendants.entry(parent).or_default().insert(root_slot);
         }
+
         let bank_forks = Arc::new(RwLock::new(Self {
             root: Arc::new(AtomicSlot::new(root_slot)),
             banks,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -85,16 +85,17 @@ impl Index<u64> for BankForks {
 }
 
 impl BankForks {
-    pub fn new_rw_arc(bank: Bank) -> Arc<RwLock<Self>> {
-        let bank = Arc::new(bank);
-        let root = bank.slot();
+    pub fn new_rw_arc(root_bank: Bank) -> Arc<RwLock<Self>> {
+        let root_bank = Arc::new(root_bank);
+        let root_slot = root_bank.slot();
 
         let mut banks = HashMap::new();
         banks.insert(
-            bank.slot(),
-            BankWithScheduler::new_without_scheduler(bank.clone()),
+            root_slot,
+            BankWithScheduler::new_without_scheduler(root_bank.clone()),
         );
-        let parents = bank.parents();
+
+        let parents = root_bank.parents();
         for parent in parents {
             if banks
                 .insert(
@@ -116,12 +117,12 @@ impl BankForks {
             }
         }
         let bank_forks = Arc::new(RwLock::new(Self {
-            root: Arc::new(AtomicSlot::new(root)),
+            root: Arc::new(AtomicSlot::new(root_slot)),
             banks,
             descendants,
             snapshot_config: None,
             accounts_hash_interval_slots: std::u64::MAX,
-            last_accounts_hash_slot: root,
+            last_accounts_hash_slot: root_slot,
             in_vote_only_mode: Arc::new(AtomicBool::new(false)),
             highest_slot_at_startup: 0,
             scheduler_pool: None,


### PR DESCRIPTION
#### Problem
BankForks has two constructors; one that takes a single Bank (the root) and one that can take an arbitrary number of Banks plus the root slot. However, the constructor that accepts multiple banks is unnecessary; it isn't used in production and is only used in several tests.

#### Summary of Changes
- Remove the BankForks constructor that allows multiple bank
- Update unit tests that used the multi-bank constructor
