### PR TITLE
LoadedPrograms: refactor extract() to be able to do incremental work

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -420,7 +420,7 @@ impl LoadedProgramsForTxBatch {
     pub fn merge(&mut self, other: &Self) {
         other.entries.iter().for_each(|(key, entry)| {
             self.replenish(*key, entry.clone());
-        })
+        });
     }
 
     pub fn merge_consuming(&mut self, other: Self) {


### PR DESCRIPTION
Change extract() from returning a list of missing programs to taking an inout list from which the programs that have been found are removed. The existing cache logic is unchanged, this is just preparatory work for cooperative loading. 