### PR TITLE
Documentation Improvements: Typos and Grammar Fixes

### DIFF
--- a/ci/docker-rust/README.md
+++ b/ci/docker-rust/README.md
@@ -1,9 +1,9 @@
 Docker image containing rust and some preinstalled packages used in CI.
 
 NOTE: Recreate rust-nightly docker image after this when updating the stable rust
-version! Both of docker images must be updated in tandem.
+version! Both docker images must be updated in tandem.
 
-This image manually maintained:
+This image is manually maintained:
 1. Edit `Dockerfile` to match the desired rust version
 1. Run `docker login` to enable pushing images to Docker Hub, if you're authorized.
 1. Run `./build.sh` to publish the new image, if you are a member of the [Solana

--- a/docs/src/implemented-proposals/tower-bft.md
+++ b/docs/src/implemented-proposals/tower-bft.md
@@ -154,7 +154,7 @@ ancestors.
 
 Each validator maintains a vote tower `T` which follows the rules described above in [Vote Tower](#vote-tower), which is a sequence of blocks it has voted for (initially empty). The variable `l` records the length of the stack. For each entry in the tower, denoted by `B = T(x)` for `x < l` where `B` is the `xth` entry in the tower, we record also a value `confcount(B)`. Define the lock expiration slot `lockexp(B) := slot(B) + 2 ^ confcount(B)`.
 
-The validator `i` runs a voting loop as as follows. Let `B` be the heaviest
+The validator `i` runs a voting loop as follows. Let `B` be the heaviest
 block returned by the fork choice rule above [Fork Choice](#fork-choice). If `i` has not voted for `B` before, then `i` votes for `B` so long as the following conditions are satisfied:
 
 1. Respecting lockouts: For any block `B′` in the tower that is not an ancestor of `B`, `lockexp(B′) ≤ slot(B)`.

--- a/tokens/README.md
+++ b/tokens/README.md
@@ -120,7 +120,7 @@ solana-tokens distribute-stake --stake-account-address <ACCOUNT_ADDRESS> \
     --stake-authority <KEYPAIR> --withdraw-authority <KEYPAIR> --fee-payer <KEYPAIR>
 ```
 
-Currently, this will subtract 1 SOL from each allocation and store it the
+Currently, this will subtract 1 SOL from each allocation and store it in the
 recipient address. That SOL can be used to pay transaction fees on staking
 operations such as delegating stake. The rest of the allocation is put in
 a stake account. The new stake account address is output in the transaction


### PR DESCRIPTION
I've made a few updates to the documentation that correct typos and improve grammar. Below are the details of the changes:

1. **Commit e5c8dc1:** Fixed a duplicate word in the 'Voting Algorithm' section. This change enhances readability and clarity in the documentation.

2. **Commit 7a7f3c6:** Addressed grammatical issues in the documentation. Specifically, I removed an unnecessary 'of' from the phrase 'Both of docker images' and added 'is' to 'This image manually maintained'. These changes ensure that the documentation is more grammatically correct and easier to understand.

3. **Commit 36b49c6:** Corrected a typo from 'store it the recipient address' to 'store it in the recipient address'. This small but crucial fix ensures the sentence is accurate and clear.

These changes are minor but improve the overall quality and readability of the documentation. I hope these contributions are helpful.
