### PR TITLE
[zk-token-sdk] Fix range proof transcript seed typo

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
@@ -54,7 +54,7 @@ impl BatchedRangeProofContext {
     fn new_transcript(&self) -> Transcript {
         let mut transcript = Transcript::new(b"BatchedRangeProof");
         transcript.append_message(b"commitments", bytes_of(&self.commitments));
-        transcript.append_message(b"bit-legnths", bytes_of(&self.bit_lengths));
+        transcript.append_message(b"bit-lengths", bytes_of(&self.bit_lengths));
         transcript
     }
 


### PR DESCRIPTION
#### Problem
As pointed out in https://github.com/solana-labs/solana/pull/34459#pullrequestreview-1782309068, there is a typo when calculating the hash of the merlin transcript in the range proof calculation. This should be fixed, but it does break compatibility with 1.17 and hence, must be backported to 1.17.

#### Summary of Changes
This PR is a one-line fix for the typo that should be backported to 1.17.

Note: The zk-token-proof program is not yet activated on any of the clusters.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
