### PR TITLE
Remove feature set from compute budget processor

### DIFF
--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -133,10 +133,8 @@ impl CostModel {
 
         // if failed to process compute_budget instructions, the transaction will not be executed
         // by `bank`, therefore it should be considered as no execution cost by cost model.
-        match process_compute_budget_instructions(
-            transaction.message().program_instructions_iter(),
-            feature_set,
-        ) {
+        match process_compute_budget_instructions(transaction.message().program_instructions_iter())
+        {
             Ok(compute_budget_limits) => {
                 // if tx contained user-space instructions and a more accurate estimate available correct it,
                 // where "user-space instructions" must be specifically checked by

--- a/program-runtime/src/compute_budget.rs
+++ b/program-runtime/src/compute_budget.rs
@@ -1,9 +1,6 @@
 use {
     crate::compute_budget_processor::{self, process_compute_budget_instructions},
-    solana_sdk::{
-        feature_set::FeatureSet, instruction::CompiledInstruction, pubkey::Pubkey,
-        transaction::Result,
-    },
+    solana_sdk::{instruction::CompiledInstruction, pubkey::Pubkey, transaction::Result},
 };
 
 #[cfg(RUSTC_WITH_SPECIALIZATION)]
@@ -183,9 +180,8 @@ impl ComputeBudget {
 
     pub fn try_from_instructions<'a>(
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-        feature_set: &FeatureSet,
     ) -> Result<Self> {
-        let compute_budget_limits = process_compute_budget_instructions(instructions, feature_set)?;
+        let compute_budget_limits = process_compute_budget_instructions(instructions)?;
         Ok(ComputeBudget {
             compute_unit_limit: u64::from(compute_budget_limits.compute_unit_limit),
             heap_size: compute_budget_limits.updated_heap_bytes,

--- a/program-runtime/src/compute_budget_processor.rs
+++ b/program-runtime/src/compute_budget_processor.rs
@@ -1,4 +1,3 @@
-//! Process compute_budget instructions to extract and sanitize limits.
 use {
     crate::{
         compute_budget::DEFAULT_HEAP_COST,
@@ -8,7 +7,6 @@ use {
         borsh1::try_from_slice_unchecked,
         compute_budget::{self, ComputeBudgetInstruction},
         entrypoint::HEAP_LENGTH as MIN_HEAP_FRAME_BYTES,
-        feature_set::FeatureSet,
         fee::FeeBudgetLimits,
         instruction::{CompiledInstruction, InstructionError},
         pubkey::Pubkey,
@@ -69,7 +67,6 @@ impl From<ComputeBudgetLimits> for FeeBudgetLimits {
 /// are retrieved and returned,
 pub fn process_compute_budget_instructions<'a>(
     instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
-    _feature_set: &FeatureSet,
 ) -> Result<ComputeBudgetLimits, TransactionError> {
     let mut num_non_compute_budget_instructions: u32 = 0;
     let mut updated_compute_unit_limit = None;
@@ -178,11 +175,8 @@ mod tests {
                 Message::new($instructions, Some(&payer_keypair.pubkey())),
                 Hash::default(),
             ));
-            let feature_set = FeatureSet::default();
-            let result = process_compute_budget_instructions(
-                tx.message().program_instructions_iter(),
-                &feature_set,
-            );
+            let result =
+                process_compute_budget_instructions(tx.message().program_instructions_iter());
             assert_eq!($expected_result, result);
         };
     }
@@ -489,12 +483,8 @@ mod tests {
                 Hash::default(),
             ));
 
-        let feature_set = FeatureSet::default();
-
-        let result = process_compute_budget_instructions(
-            transaction.message().program_instructions_iter(),
-            &feature_set,
-        );
+        let result =
+            process_compute_budget_instructions(transaction.message().program_instructions_iter());
 
         // assert process_instructions will be successful with default,
         // and the default compute_unit_limit is 2 times default: one for bpf ix, one for

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3868,18 +3868,13 @@ fn test_program_fees() {
         Some(&mint_keypair.pubkey()),
     );
 
-    let feature_set = FeatureSet::all_enabled();
-
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
     let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
-        &process_compute_budget_instructions(
-            sanitized_message.program_instructions_iter(),
-            &feature_set,
-        )
-        .unwrap_or_default()
-        .into(),
+        &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
+            .unwrap_or_default()
+            .into(),
         true,
         false,
     );
@@ -3898,16 +3893,12 @@ fn test_program_fees() {
         Some(&mint_keypair.pubkey()),
     );
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
-    let feature_set = FeatureSet::all_enabled();
     let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
-        &process_compute_budget_instructions(
-            sanitized_message.program_instructions_iter(),
-            &feature_set,
-        )
-        .unwrap_or_default()
-        .into(),
+        &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
+            .unwrap_or_default()
+            .into(),
         true,
         false,
     );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4067,12 +4067,9 @@ impl Bank {
         self.fee_structure.calculate_fee(
             message,
             lamports_per_signature,
-            &process_compute_budget_instructions(
-                message.program_instructions_iter(),
-                &self.feature_set,
-            )
-            .unwrap_or_default()
-            .into(),
+            &process_compute_budget_instructions(message.program_instructions_iter())
+                .unwrap_or_default()
+                .into(),
             self.feature_set
                 .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
             self.feature_set
@@ -5214,7 +5211,6 @@ impl Bank {
                                 Measure::start("compute_budget_process_transaction_time");
                             let maybe_compute_budget = ComputeBudget::try_from_instructions(
                                 tx.message().program_instructions_iter(),
-                                &self.feature_set,
                             );
                             compute_budget_process_transaction_time.stop();
                             saturating_add_assign!(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10012,10 +10012,9 @@ fn calculate_test_fee(
         );
     }
 
-    let budget_limits =
-        process_compute_budget_instructions(message.program_instructions_iter(), &feature_set)
-            .unwrap_or_default()
-            .into();
+    let budget_limits = process_compute_budget_instructions(message.program_instructions_iter())
+        .unwrap_or_default()
+        .into();
 
     fee_structure.calculate_fee(
         message,

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -1,7 +1,6 @@
 use {
     solana_program_runtime::compute_budget_processor::process_compute_budget_instructions,
     solana_sdk::{
-        feature_set::FeatureSet,
         instruction::CompiledInstruction,
         pubkey::Pubkey,
         transaction::{SanitizedTransaction, SanitizedVersionedTransaction},
@@ -24,10 +23,7 @@ pub trait GetTransactionPriorityDetails {
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
         _round_compute_unit_price_enabled: bool,
     ) -> Option<TransactionPriorityDetails> {
-        let feature_set = FeatureSet::default();
-
-        let compute_budget_limits =
-            process_compute_budget_instructions(instructions, &feature_set).ok()?;
+        let compute_budget_limits = process_compute_budget_instructions(instructions).ok()?;
         Some(TransactionPriorityDetails {
             priority: compute_budget_limits.compute_unit_price,
             compute_unit_limit: u64::from(compute_budget_limits.compute_unit_limit),


### PR DESCRIPTION
#### Problem
after all features related to `compute_budget_processor()` are activated everywhere, it no longer needs feature-set as parameter

#### Summary of Changes
- remove feature-set as parameter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
