### PR TITLE
Accounts::new() takes AccountsDb as Into<Arc<_>>

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -19,7 +19,7 @@ use {
     solana_sdk::{
         genesis_config::ClusterType, pubkey::Pubkey, sysvar::epoch_schedule::EpochSchedule,
     },
-    std::{env, fs, path::PathBuf, sync::Arc},
+    std::{env, fs, path::PathBuf},
 };
 
 fn main() {
@@ -75,7 +75,7 @@ fn main() {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     println!("Creating {num_accounts} accounts");
     let mut create_time = Measure::start("create accounts");
     let pubkeys: Vec<_> = (0..num_slots)

--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -118,9 +118,9 @@ pub enum AccountAddressFilter {
 }
 
 impl Accounts {
-    pub fn new(accounts_db: Arc<AccountsDb>) -> Self {
+    pub fn new(accounts_db: impl Into<Arc<AccountsDb>>) -> Self {
         Self {
-            accounts_db,
+            accounts_db: accounts_db.into(),
             account_locks: Mutex::new(AccountLocks::default()),
         }
     }
@@ -883,7 +883,7 @@ mod tests {
     #[test]
     fn test_hold_range_in_memory() {
         let accounts_db = AccountsDb::default_for_tests();
-        let accts = Accounts::new(Arc::new(accounts_db));
+        let accts = Accounts::new(accounts_db);
         let range = Pubkey::from([0; 32])..=Pubkey::from([0xff; 32]);
         accts.hold_range_in_memory(&range, true, &test_thread_pool());
         accts.hold_range_in_memory(&range, false, &test_thread_pool());
@@ -896,7 +896,7 @@ mod tests {
     #[test]
     fn test_hold_range_in_memory2() {
         let accounts_db = AccountsDb::default_for_tests();
-        let accts = Accounts::new(Arc::new(accounts_db));
+        let accts = Accounts::new(accounts_db);
         let range = Pubkey::from([0; 32])..=Pubkey::from([0xff; 32]);
         let idx = &accts.accounts_db.accounts_index;
         let bins = idx.account_maps.len();
@@ -945,7 +945,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let invalid_table_key = Pubkey::new_unique();
         let address_table_lookup = MessageAddressTableLookup {
@@ -973,7 +973,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let invalid_table_key = Pubkey::new_unique();
         let mut invalid_table_account = AccountSharedData::default();
@@ -1005,7 +1005,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let invalid_table_key = Pubkey::new_unique();
         let invalid_table_account =
@@ -1037,7 +1037,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let table_key = Pubkey::new_unique();
         let table_addresses = vec![Pubkey::new_unique(), Pubkey::new_unique()];
@@ -1083,7 +1083,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         // Load accounts owned by various programs into AccountsDb
         let pubkey0 = solana_sdk::pubkey::new_rand();
@@ -1112,7 +1112,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         assert!(accounts.accounts_db.get_bank_hash_stats(0).is_some());
         assert!(accounts.accounts_db.get_bank_hash_stats(1).is_none());
     }
@@ -1125,7 +1125,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let keypair = Keypair::new();
         let message = Message {
@@ -1150,7 +1150,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let keypair = Keypair::new();
 
@@ -1216,7 +1216,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         accounts.store_for_tests(0, &keypair0.pubkey(), &account0);
         accounts.store_for_tests(0, &keypair1.pubkey(), &account1);
         accounts.store_for_tests(0, &keypair2.pubkey(), &account2);
@@ -1326,7 +1326,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         accounts.store_for_tests(0, &keypair0.pubkey(), &account0);
         accounts.store_for_tests(0, &keypair1.pubkey(), &account1);
         accounts.store_for_tests(0, &keypair2.pubkey(), &account2);
@@ -1408,7 +1408,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         accounts.store_for_tests(0, &keypair0.pubkey(), &account0);
         accounts.store_for_tests(0, &keypair1.pubkey(), &account1);
         accounts.store_for_tests(0, &keypair2.pubkey(), &account2);
@@ -1485,7 +1485,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         accounts.store_for_tests(0, &keypair0.pubkey(), &account0);
         accounts.store_for_tests(0, &keypair1.pubkey(), &account1);
         accounts.store_for_tests(0, &keypair2.pubkey(), &account2);
@@ -1645,7 +1645,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         {
             accounts
                 .account_locks
@@ -1697,7 +1697,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         let mut old_pubkey = Pubkey::default();
         let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
         info!("storing..");
@@ -2037,7 +2037,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         let txs = vec![tx];
         let execution_results = vec![new_execution_result(
             Err(TransactionError::InstructionError(
@@ -2151,7 +2151,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         let txs = vec![tx];
         let execution_results = vec![new_execution_result(
             Err(TransactionError::InstructionError(
@@ -2193,7 +2193,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         /* This test assumes pubkey0 < pubkey1 < pubkey2.
          * But the keys created with new_unique() does not gurantee this

--- a/runtime/benches/accounts.rs
+++ b/runtime/benches/accounts.rs
@@ -105,7 +105,7 @@ fn test_accounts_hash_bank_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     let mut pubkeys: Vec<Pubkey> = vec![];
     let num_accounts = 60_000;
     let slot = 0;
@@ -143,7 +143,7 @@ fn test_update_accounts_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 50_000, 0);
     let ancestors = Ancestors::from(vec![0]);
@@ -163,7 +163,7 @@ fn test_accounts_delta_hash(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     let mut pubkeys: Vec<Pubkey> = vec![];
     create_test_accounts(&accounts, &mut pubkeys, 100_000, 0);
     bencher.iter(|| {
@@ -180,7 +180,7 @@ fn bench_delete_dependencies(bencher: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     let mut old_pubkey = Pubkey::default();
     let zero_account = AccountSharedData::new(0, 0, AccountSharedData::default().owner());
     for i in 0..1000 {
@@ -213,7 +213,7 @@ fn store_accounts_with_possible_contention<F: 'static>(
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Arc::new(Accounts::new(Arc::new(accounts_db)));
+    let accounts = Arc::new(Accounts::new(accounts_db));
     let num_keys = 1000;
     let slot = 0;
     accounts.add_root(slot);
@@ -350,7 +350,7 @@ fn setup_bench_dashmap_iter() -> (Arc<Accounts>, DashMap<Pubkey, (AccountSharedD
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Arc::new(Accounts::new(Arc::new(accounts_db)));
+    let accounts = Arc::new(Accounts::new(accounts_db));
 
     let dashmap = DashMap::new();
     let num_keys = std::env::var("NUM_BENCH_KEYS")
@@ -405,7 +405,7 @@ fn bench_load_largest_accounts(b: &mut Bencher) {
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
     );
-    let accounts = Accounts::new(Arc::new(accounts_db));
+    let accounts = Accounts::new(accounts_db);
     let mut rng = rand::thread_rng();
     for _ in 0..10_000 {
         let lamports = rng.gen();

--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -561,7 +561,7 @@ mod tests {
             transaction::{Result, Transaction, TransactionError},
             transaction_context::TransactionAccount,
         },
-        std::{convert::TryFrom, sync::Arc},
+        std::convert::TryFrom,
     };
 
     fn load_accounts_with_fee_and_rent(
@@ -581,7 +581,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         for ka in ka.iter() {
             accounts.accounts_db.store_for_tests(0, &[(&ka.0, &ka.1)]);
         }
@@ -1394,7 +1394,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let instructions_key = solana_sdk::sysvar::instructions::id();
         let keypair = Keypair::new();
@@ -1421,7 +1421,7 @@ mod tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         let mut account_overrides = AccountOverrides::default();
         let slot_history_id = sysvar::slot_history::id();
         let account = AccountSharedData::new(42, 0, &Pubkey::default());

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1109,7 +1109,7 @@ impl Bank {
             accounts_update_notifier,
             exit,
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         let mut bank = Self::default_with_accounts(accounts);
         bank.ancestors = Ancestors::from(vec![bank.slot()]);
         bank.transaction_debug_keys = debug_keys;
@@ -8175,7 +8175,7 @@ impl Bank {
 
     pub fn default_for_tests() -> Self {
         let accounts_db = AccountsDb::default_for_tests();
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         Self::default_with_accounts(accounts)
     }
 

--- a/runtime/src/serde_snapshot.rs
+++ b/runtime/src/serde_snapshot.rs
@@ -620,7 +620,7 @@ where
         bank_fields.incremental_snapshot_persistence.as_ref(),
     )?;
 
-    let bank_rc = BankRc::new(Accounts::new(Arc::new(accounts_db)), bank_fields.slot);
+    let bank_rc = BankRc::new(Accounts::new(accounts_db), bank_fields.slot);
     let runtime_config = Arc::new(runtime_config.clone());
 
     // if limit_load_slot_count_from_snapshot is set, then we need to side-step some correctness checks beneath this call

--- a/runtime/src/serde_snapshot/tests.rs
+++ b/runtime/src/serde_snapshot/tests.rs
@@ -229,7 +229,7 @@ mod serde_snapshot_tests {
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
         );
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
 
         let slot = 0;
         let mut pubkeys: Vec<Pubkey> = vec![];
@@ -261,7 +261,7 @@ mod serde_snapshot_tests {
         let buf = writer.into_inner();
         let mut reader = BufReader::new(&buf[..]);
         let (_accounts_dir, daccounts_paths) = get_temp_accounts_paths(2).unwrap();
-        let daccounts = Accounts::new(Arc::new(
+        let daccounts = Accounts::new(
             accountsdb_from_stream(
                 serde_style,
                 &mut reader,
@@ -269,7 +269,7 @@ mod serde_snapshot_tests {
                 storage_and_next_append_vec_id,
             )
             .unwrap(),
-        ));
+        );
         check_accounts_local(&daccounts, &pubkeys, 100);
         let daccounts_delta_hash = daccounts.accounts_db.calculate_accounts_delta_hash(slot);
         assert_eq!(accounts_delta_hash, daccounts_delta_hash);

--- a/runtime/src/snapshot_package.rs
+++ b/runtime/src/snapshot_package.rs
@@ -160,7 +160,7 @@ impl AccountsPackage {
     /// Only use for tests; many of the fields are invalid!
     pub fn default_for_tests() -> Self {
         let accounts_db = AccountsDb::default_for_tests();
-        let accounts = Accounts::new(Arc::new(accounts_db));
+        let accounts = Accounts::new(accounts_db);
         Self {
             package_kind: AccountsPackageKind::AccountsHashVerifier,
             slot: Slot::default(),


### PR DESCRIPTION
#### Problem

From this conversation, https://github.com/solana-labs/solana/pull/34471#discussion_r1427507739, an improvement to `Accounts::new()` could be made by having it take the AccountsDb as `Into<Arc<AccountsDb>>`.

h/t @apfitzge for the original suggestion!

#### Summary of Changes

Accounts::new() now takes the AccountsDb with Into<>.