### PR TITLE
v1.16: program cache: implement cooperative loading

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1847,6 +1847,9 @@ mod tests {
             1
         );
 
+        // Unlock the cooperative loading lock so that the subsequent prune can do its job
+        cache.finish_cooperative_loading_task(15, program1, new_test_loaded_program(0, 1));
+
         // New root 15 should evict the expired entry for program1
         cache.prune(&fork_graph, 15);
         assert!(cache.entries.get(&program1).is_none());

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2074,10 +2074,9 @@ fn test_program_sbf_invoke_in_same_tx_as_redeployment() {
     );
 
     // load_upgradeable_program sets clock sysvar to 1, which causes the program to be effective
-    // after 2 slots. So we need to advance the bank client by 2 slots here.
-    let bank = bank_client
-        .advance_slot(2, &Pubkey::default())
-        .expect("Failed to advance slot");
+    // after 2 slots. They need to be called individually to create the correct fork graph in between.
+    bank_client.advance_slot(1, &Pubkey::default()).unwrap();
+    let bank = bank_client.advance_slot(1, &Pubkey::default()).unwrap();
 
     // Prepare redeployment
     let buffer_keypair = Keypair::new();
@@ -2171,10 +2170,9 @@ fn test_program_sbf_invoke_in_same_tx_as_undeployment() {
     );
 
     // load_upgradeable_program sets clock sysvar to 1, which causes the program to be effective
-    // after 2 slots. So we need to advance the bank client by 2 slots here.
-    let bank = bank_client
-        .advance_slot(2, &Pubkey::default())
-        .expect("Failed to advance slot");
+    // after 2 slots. They need to be called individually to create the correct fork graph in between.
+    bank_client.advance_slot(1, &Pubkey::default()).unwrap();
+    let bank = bank_client.advance_slot(1, &Pubkey::default()).unwrap();
 
     // Prepare undeployment
     let (programdata_address, _) = Pubkey::find_program_address(


### PR DESCRIPTION
This is a manual backport of the program cache cooperative loading work. With this change anytime LoadedPrograms::extract() is called, if one or more programs aren't loaded, the function will select one to be loaded by the caller and will mark it as being loaded. If a batch thread has no work to do (no programs to load) while some of its programs are still being loaded by other threads, it will go to sleep until the next program completes loading and then retry.