### PR TITLE
fix: update the rust version for 1.16.23 in scripts

### DIFF
--- a/ci/docker-rust-nightly/Dockerfile
+++ b/ci/docker-rust-nightly/Dockerfile
@@ -1,4 +1,5 @@
-FROM solanalabs/rust:1.69.0
+FROM solanalabs/rust:1.74.0
+
 ARG date
 
 RUN set -x \

--- a/ci/docker-rust/Dockerfile
+++ b/ci/docker-rust/Dockerfile
@@ -2,41 +2,106 @@
 # ci/rust-version.sh to pick up the new image tag
 FROM rust:1.69.0
 
-RUN set -x \
- && apt update \
- && apt-get install apt-transport-https \
- && echo deb https://apt.buildkite.com/buildkite-agent stable main > /etc/apt/sources.list.d/buildkite-agent.list \
- && apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 32A37959C2FA5C3C99EFBC32A79206696452D198 \
- && curl -fsSL https://deb.nodesource.com/setup_current.x | bash - \
- && apt update \
- && apt install -y \
-      buildkite-agent \
-      clang \
-      cmake \
-      lcov \
-      libudev-dev \
-      mscgen \
-      nodejs \
-      net-tools \
-      rsync \
-      sudo \
-      golang \
-      unzip \
-      lld \
-      \
- && apt remove -y libcurl4-openssl-dev \
- && rm -rf /var/lib/apt/lists/* \
- && node --version \
- && npm --version \
- && rustup component add rustfmt \
- && rustup component add clippy \
- && rustup target add wasm32-unknown-unknown \
- && cargo install cargo-audit \
- && cargo install cargo-sort \
- && cargo install mdbook \
- && cargo install mdbook-linkcheck \
- && cargo install svgbob_cli \
- && cargo install wasm-pack \
- && cargo install sccache \
- && rustc --version \
- && cargo --version
+ARG \
+  RUST_VERSION=1.74.0 \
+  GOLANG_VERSION=1.21.3 \
+  NODE_MAJOR=18 \
+  SCCACHE_VERSION=v0.5.4
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV \
+  DEBIAN_FRONTEND=noninteractive \
+  TZ=UTC
+
+# golang
+ENV PATH="/usr/local/go/bin:$PATH"
+
+# rust
+ENV \
+  RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH="$PATH:/usr/local/cargo/bin"
+
+RUN apt-get update && \
+  apt-get install --no-install-recommends -y \
+  # basic
+  tzdata \
+  apt-transport-https \
+  sudo \
+  build-essential \
+  git \
+  vim \
+  jq \
+  ca-certificates \
+  curl \
+  gnupg \
+  lld \
+  cmake \
+  # docs
+  mscgen \
+  # solana compiling
+  libssl-dev \
+  libudev-dev \
+  pkg-config \
+  zlib1g-dev \
+  llvm \
+  clang \
+  cmake \
+  make \
+  libprotobuf-dev \
+  protobuf-compiler \
+  && \
+  # buildkite
+  curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | tee /etc/apt/sources.list.d/buildkite-agent.list && \
+  apt-get update && \
+  apt-get install -y buildkite-agent && \
+  # gh
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+  sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+  apt-get update && \
+  apt-get install -y gh && \
+  # rust
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs/ | sh -s -- --no-modify-path --profile minimal --default-toolchain $RUST_VERSION -y && \
+  rustup component add rustfmt && \
+  rustup component add clippy && \
+  rustup target add wasm32-unknown-unknown && \
+  cargo install cargo-audit && \
+  cargo install cargo-hack && \
+  cargo install cargo-sort && \
+  cargo install mdbook && \
+  cargo install mdbook-linkcheck && \
+  cargo install svgbob_cli && \
+  cargo install wasm-pack && \
+  cargo install rustfilt && \
+  chmod -R a+w $CARGO_HOME $RUSTUP_HOME && \
+  rm -rf $CARGO_HOME/registry && \
+  # sccache
+  curl -LOsS "https://github.com/mozilla/sccache/releases/download/$SCCACHE_VERSION/sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" && \
+  tar -xzf "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" && \
+  mv "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl"/sccache "$CARGO_HOME/bin/" && \
+  rm "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl.tar.gz" && \
+  rm -rf "sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl" && \
+  # nextest
+  curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C "$CARGO_HOME/bin" && \
+  # golang
+  curl -LOsS "https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz" && \
+  tar -C /usr/local -xzf "go$GOLANG_VERSION.linux-amd64.tar.gz" && \
+  rm "go$GOLANG_VERSION.linux-amd64.tar.gz" && \
+  # nodejs
+  sudo mkdir -p /etc/apt/keyrings && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list && \
+  sudo apt-get update && \
+  sudo apt-get install -y nodejs && \
+  # setup path
+  mkdir /.cache && \
+  chmod -R a+w /.cache && \
+  mkdir /.config && \
+  chmod -R a+w /.config && \
+  mkdir /.npm && \
+  chmod -R a+w /.npm && \
+  # clean lists
+  rm -rf /var/lib/apt/lists/*

--- a/ci/rust-version.sh
+++ b/ci/rust-version.sh
@@ -29,7 +29,7 @@ fi
 if [[ -n $RUST_NIGHTLY_VERSION ]]; then
   nightly_version="$RUST_NIGHTLY_VERSION"
 else
-  nightly_version=2023-04-19
+  nightly_version=2023-11-16
 fi
 
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.74.0"


### PR DESCRIPTION
#### Problem

When I try to build a docker image for solana 1.16.23 with the following script `./sdk/docker-solana/build.sh` I get compilation errors.

```
error[E0658]: use of unstable library feature 'once_cell'
  --> /home/.cargo/registry/src/github.com-1ecc6299db9ec823/solana_rbpf-0.8.0/src/vm.rs:31:33
   |
31 | static RUNTIME_ENVIRONMENT_KEY: std::sync::OnceLock<i32> = std::sync::OnceLock::<i32>::new();
   |                                 ^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #74465 <https://github.com/rust-lang/rust/issues/74465> for more information
   
Some errors have detailed explanations: E0599, E0658.
For more information about an error, try `rustc --explain E0599`.
error: could not compile `solana_rbpf` due to 12 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `spl-token-cli v3.3.0`, intermediate artifacts can be found at `/tmp/cargo-installPixazg`
Error: Process completed with exit code 101.
```

After looking to the commits history, I think we have to cherry-pick the following commit : [f9b96fa](https://github.com/solana-labs/solana/commit/f9b96fa1120adfcdb77faf00d696a0516950ed24) and backport those changes in the 1.16.23


#### Summary of Changes
- cherry-pick commit : [f9b96fa](https://github.com/solana-labs/solana/commit/f9b96fa1120adfcdb77faf00d696a0516950ed24)
