### PR TITLE
clap-utils: Forbid multiple values for `--signer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Release channels have their own copy of this changelog:
   * RPC's `simulateTransaction` now returns `innerInstructions` as `json`/`jsonParsed` (#34313).
   * Bigtable upload now includes entry summary data for each slot, stored in a
     new `entries` table
+  * Forbid multiple values for the `--signer` CLI flag, forcing users to specify multiple occurrences of `--signer`, one for each signature
 * Upgrade Notes
   * `solana-program` and `solana-sdk` default to support for Borsh v1, with
 limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.

--- a/clap-utils/src/offline.rs
+++ b/clap-utils/src/offline.rs
@@ -52,6 +52,7 @@ fn signer_arg<'a, 'b>() -> Arg<'a, 'b> {
         .validator(is_pubkey_sig)
         .requires(BLOCKHASH_ARG.name)
         .multiple(true)
+        .number_of_values(1)
         .help(SIGNER_ARG.help)
 }
 

--- a/clap-v3-utils/src/offline.rs
+++ b/clap-v3-utils/src/offline.rs
@@ -53,7 +53,7 @@ fn signer_arg<'a>() -> Arg<'a> {
         .value_parser(value_parser!(PubkeySignature))
         .requires(BLOCKHASH_ARG.name)
         .multiple_occurrences(true)
-        .multiple_values(true)
+        .multiple_values(false)
         .help(SIGNER_ARG.help)
 }
 


### PR DESCRIPTION
#### Problem

The `--signer` arg doesn't exactly work as expected because it allows for multiple values. This means clap allows for someone to specify: `--signer <PUBKEY>=<SIG> <PUBKEY>=<SIG>`

This can be useful in some situations, but it's inconsistent with the documentation.

For example, https://docs.solana.com/offline-signing#submitting-offline-signed-transactions-to-the-network mentions to specify "--signer BASE58_PUBKEY=BASE58_SIGNATURE, one for each offline signer.", and the examples use multiple occurrences of `--signer`.

Also, the example command of:

```
solana@online$ solana transfer --blockhash 5Tx8F3jgSHx21CbtjwmdaKPLM5tWmreWAnPrbqHomSJF \
    --signer FhtzLVsmcV7S5XqGD79ErgoseCLhZYmEZnz9kQg1Rp7j=4vC38p4bz7XyiXrk6HtaooUqwxTWKocf45cstASGtmrD398biNJnmTcUCVEojE7wVQvgdYbjHJqRFZPpzfCQpmUN
    recipient-keypair.json 1
```

Does not work currently because `--signer` tries to parse multiple values. This means it tries to also parse `recipient-keypair.json` and `1`. Practically, this means that `--signer` must always come last in the command, which contradicts the docs.

Side note: for your reading pleasure here are the docs for `multiple_values` https://docs.rs/clap/3.2.23/clap/builder/struct.Arg.html#method.multiple_values in clap v3 and for `multiple` in clap v2 https://docs.rs/clap/2.34.0/clap/struct.Arg.html#method.multiple

#### Summary of Changes

Cap the number of *values* to 1 (clap v2) and do not allow multiple values per occurrence (clap v3). I'm not sure if this breaks any existing users, so I've put in a changelog entry.

Fixes #34453
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
