### PR TITLE
Removes unnecessary AccountsDb::new_with_config_for_benches()

### DIFF
--- a/accounts-bench/src/main.rs
+++ b/accounts-bench/src/main.rs
@@ -10,6 +10,7 @@ use {
         accounts_db::{
             test_utils::{create_test_accounts, update_accounts_bench},
             AccountShrinkThreshold, AccountsDb, CalcAccountsHashDataSource,
+            ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS,
         },
         accounts_index::AccountSecondaryIndexes,
         ancestors::Ancestors,
@@ -69,11 +70,14 @@ fn main() {
     if fs::remove_dir_all(path.clone()).is_err() {
         println!("Warning: Couldn't remove {path:?}");
     }
-    let accounts_db = AccountsDb::new_with_config_for_benches(
+    let accounts_db = AccountsDb::new_with_config(
         vec![path],
         &ClusterType::Testnet,
         AccountSecondaryIndexes::default(),
         AccountShrinkThreshold::default(),
+        Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
+        None,
+        Arc::default(),
     );
     let accounts = Accounts::new(Arc::new(accounts_db));
     println!("Creating {num_accounts} accounts");

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9522,23 +9522,6 @@ pub(crate) enum UpdateIndexThreadSelection {
 // These functions/fields are only usable from a dev context (i.e. tests and benches)
 #[cfg(feature = "dev-context-only-utils")]
 impl AccountsDb {
-    pub fn new_with_config_for_benches(
-        paths: Vec<PathBuf>,
-        cluster_type: &ClusterType,
-        account_indexes: AccountSecondaryIndexes,
-        shrink_ratio: AccountShrinkThreshold,
-    ) -> Self {
-        Self::new_with_config(
-            paths,
-            cluster_type,
-            account_indexes,
-            shrink_ratio,
-            Some(ACCOUNTS_DB_CONFIG_FOR_BENCHMARKS),
-            None,
-            Arc::default(),
-        )
-    }
-
     pub fn load_without_fixed_root(
         &self,
         ancestors: &Ancestors,


### PR DESCRIPTION
#### Problem

There are too many AccountsDb constructors. AccountsDb::new_with_config_for_benches() is unnecessary. The current callers can new `AccountsDb::new_with_config()` instead.

#### Summary of Changes

Remove AccountsDb::new_with_config_for_benches() and update callers.