### PR TITLE
rekey partitioned epoch rewards

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -370,7 +370,7 @@ pub mod update_rewards_from_cached_accounts {
     solana_sdk::declare_id!("28s7i3htzhahXQKqmS2ExzbEoUypg9krwvtK2M9UWXh9");
 }
 pub mod enable_partitioned_epoch_reward {
-    solana_sdk::declare_id!("HCnE3xQoZtDz9dSVm3jKwJXioTb6zMRbgwCmGg3PHHk8");
+    solana_sdk::declare_id!("41tVp5qR1XwWRt5WifvtSQyuxtqQWJgEK8w91AtBqSwP");
 }
 
 pub mod spl_token_v3_4_0 {


### PR DESCRIPTION
#### Problem

I lost the key for partitioned epoch rewards feature when we migrated from gcp
boxes.


#### Summary of Changes

rekey partitioned epoch rewards feature


Fixes #
Feature Gate Issue: # https://github.com/solana-labs/solana/issues/32166
<!-- Don't forget to add the "feature-gate" label -->
