### PR TITLE
rekey stake limit feature

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -399,7 +399,7 @@ pub mod stake_raise_minimum_delegation_to_1_sol {
 }
 
 pub mod stake_minimum_delegation_for_rewards {
-    solana_sdk::declare_id!("ELjxSXwNsyXGfAh8TqX8ih22xeT8huF6UngQirbLKYKH");
+    solana_sdk::declare_id!("G6ANXD6ptCSyNd9znZm7j4dEczAJCfx7Cy43oBx3rKHJ");
 }
 
 pub mod add_set_compute_unit_price_ix {


### PR DESCRIPTION
#### Problem

I lost the key for `stake_minimum_delegation_for_rewards` when I migrated from gcp boxes.


#### Summary of Changes

rekey stake_minimum_delegation_for_rewards feature


Fixes #


Feature Gate Issue: https://github.com/solana-labs/solana/issues/29622
<!-- Don't forget to add the "feature-gate" label -->
