### PR TITLE
Removes unnecessary new_sized() AccountsDb ctor

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9821,13 +9821,6 @@ pub mod tests {
     }
 
     impl AccountsDb {
-        pub fn new_sized(paths: Vec<PathBuf>, file_size: u64) -> Self {
-            AccountsDb {
-                file_size,
-                ..AccountsDb::new_for_tests(paths, &ClusterType::Development)
-            }
-        }
-
         pub fn get_append_vec_id(&self, pubkey: &Pubkey, slot: Slot) -> Option<AppendVecId> {
             let ancestors = vec![(slot, 1)].into_iter().collect();
             let result = self.accounts_index.get(pubkey, Some(&ancestors), None);
@@ -11544,7 +11537,10 @@ pub mod tests {
     fn test_account_grow_many() {
         let (_accounts_dir, paths) = get_temp_accounts_paths(2).unwrap();
         let size = 4096;
-        let accounts = AccountsDb::new_sized(paths, size);
+        let accounts = AccountsDb {
+            file_size: size,
+            ..AccountsDb::new_for_tests(paths, &ClusterType::Development)
+        };
         let mut keys = vec![];
         for i in 0..9 {
             let key = solana_sdk::pubkey::new_rand();
@@ -12305,7 +12301,10 @@ pub mod tests {
 
         let min_file_bytes = std::mem::size_of::<StoredMeta>() + std::mem::size_of::<AccountMeta>();
 
-        let db = Arc::new(AccountsDb::new_sized(Vec::new(), min_file_bytes as u64));
+        let db = Arc::new(AccountsDb {
+            file_size: min_file_bytes as u64,
+            ..AccountsDb::new_single_for_tests()
+        });
 
         db.add_root(slot);
         let thread_hdls: Vec<_> = (0..num_threads)
@@ -12831,7 +12830,10 @@ pub mod tests {
     #[test]
     fn test_storage_finder() {
         solana_logger::setup();
-        let db = AccountsDb::new_sized(Vec::new(), 16 * 1024);
+        let db = AccountsDb {
+            file_size: 16 * 1024,
+            ..AccountsDb::new_single_for_tests()
+        };
         let key = solana_sdk::pubkey::new_rand();
         let lamports = 100;
         let data_len = 8190;
@@ -12973,7 +12975,10 @@ pub mod tests {
         let zero_lamport_account = AccountSharedData::new(zero_lamport, data_size, &owner);
 
         let mut current_slot = 0;
-        let accounts = AccountsDb::new_sized(Vec::new(), store_size);
+        let accounts = AccountsDb {
+            file_size: store_size,
+            ..AccountsDb::new_single_for_tests()
+        };
 
         // A: Initialize AccountsDb with pubkey1 and pubkey2
         current_slot += 1;
@@ -13617,7 +13622,10 @@ pub mod tests {
     #[test]
     fn test_store_reuse() {
         solana_logger::setup();
-        let accounts = AccountsDb::new_sized(vec![], 4096);
+        let accounts = AccountsDb {
+            file_size: 4096,
+            ..AccountsDb::new_single_for_tests()
+        };
 
         let size = 100;
         let num_accounts: usize = 100;


### PR DESCRIPTION
#### Problem

There are a lot of AccountsDb constructors. This makes it hard for me to remember what each one uniquely does. Also, I'd like to remove all TempDirs from inside AccountsDb, and instead have a common harness that creates them as needed for tests/benches/etc. The abundance of AccountsDb/Accounts/Bank constructors makes this much harder.


#### Summary of Changes

Removes AccountsDb::new_sized() and updates callers.