### PR TITLE
cleanup feature code after activated everywhere

### DIFF
--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -3867,7 +3867,6 @@ fn test_program_fees() {
         &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
             .unwrap_or_default()
             .into(),
-        true,
         false,
     );
     bank_client
@@ -3891,7 +3890,6 @@ fn test_program_fees() {
         &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
             .unwrap_or_default()
             .into(),
-        true,
         false,
     );
     assert!(expected_normal_fee < expected_prioritized_fee);

--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -29,7 +29,6 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         feature_set::{
             include_loaded_accounts_data_size_in_fee_calculation,
-            remove_congestion_multiplier_from_fee_calculation,
             simplify_writable_program_account_check, FeatureSet,
         },
         fee::FeeStructure,
@@ -83,8 +82,6 @@ pub(super) fn load_accounts(
                         )
                         .unwrap_or_default()
                         .into(),
-                        feature_set
-                            .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
                         feature_set
                             .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
                     )
@@ -728,7 +725,6 @@ mod tests {
             &process_compute_budget_instructions(message.program_instructions_iter())
                 .unwrap_or_default()
                 .into(),
-            true,
             false,
         );
         assert_eq!(fee, lamports_per_signature);
@@ -1564,7 +1560,6 @@ mod tests {
             &process_compute_budget_instructions(message.program_instructions_iter())
                 .unwrap_or_default()
                 .into(),
-            true,
             false,
         );
         assert_eq!(fee, lamports_per_signature + prioritization_fee);

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -139,10 +139,7 @@ use {
         epoch_info::EpochInfo,
         epoch_schedule::EpochSchedule,
         feature,
-        feature_set::{
-            self, include_loaded_accounts_data_size_in_fee_calculation,
-            remove_congestion_multiplier_from_fee_calculation, FeatureSet,
-        },
+        feature_set::{self, include_loaded_accounts_data_size_in_fee_calculation, FeatureSet},
         fee::FeeStructure,
         fee_calculator::{FeeCalculator, FeeRateGovernor},
         genesis_config::{ClusterType, GenesisConfig},
@@ -4072,8 +4069,6 @@ impl Bank {
             &process_compute_budget_instructions(message.program_instructions_iter())
                 .unwrap_or_default()
                 .into(),
-            self.feature_set
-                .is_active(&remove_congestion_multiplier_from_fee_calculation::id()),
             self.feature_set
                 .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
         )

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -2651,7 +2651,6 @@ fn test_bank_tx_compute_unit_fee() {
             .lamports_per_signature,
         &FeeStructure::default(),
         false,
-        true,
     );
 
     let (expected_fee_collected, expected_fee_burned) =
@@ -2832,7 +2831,6 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
         cheap_lamports_per_signature,
         &FeeStructure::default(),
         false,
-        true,
     );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
@@ -2850,7 +2848,6 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
         expensive_lamports_per_signature,
         &FeeStructure::default(),
         false,
-        true,
     );
     assert_eq!(
         bank.get_balance(&mint_keypair.pubkey()),
@@ -2963,7 +2960,6 @@ fn test_filter_program_errors_and_collect_compute_unit_fee() {
                             .lamports_per_signature,
                         &FeeStructure::default(),
                         false,
-                        true,
                     ) * 2
                 )
                 .0
@@ -10002,7 +9998,6 @@ fn calculate_test_fee(
     lamports_per_signature: u64,
     fee_structure: &FeeStructure,
     support_set_accounts_data_size_limit_ix: bool,
-    remove_congestion_multiplier: bool,
 ) -> u64 {
     let mut feature_set = FeatureSet::all_enabled();
 
@@ -10016,13 +10011,7 @@ fn calculate_test_fee(
         .unwrap_or_default()
         .into();
 
-    fee_structure.calculate_fee(
-        message,
-        lamports_per_signature,
-        &budget_limits,
-        remove_congestion_multiplier,
-        false,
-    )
+    fee_structure.calculate_fee(message, lamports_per_signature, &budget_limits, false)
 }
 
 #[test]
@@ -10040,7 +10029,6 @@ fn test_calculate_fee() {
                     ..FeeStructure::default()
                 },
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             0
         );
@@ -10057,7 +10045,6 @@ fn test_calculate_fee() {
                     ..FeeStructure::default()
                 },
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             1
         );
@@ -10079,7 +10066,6 @@ fn test_calculate_fee() {
                     ..FeeStructure::default()
                 },
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             4
         );
@@ -10106,7 +10092,6 @@ fn test_calculate_fee_compute_units() {
                 1,
                 &fee_structure,
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             max_fee + lamports_per_signature
         );
@@ -10125,7 +10110,6 @@ fn test_calculate_fee_compute_units() {
                 1,
                 &fee_structure,
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             max_fee + 3 * lamports_per_signature
         );
@@ -10166,7 +10150,6 @@ fn test_calculate_fee_compute_units() {
                 1,
                 &fee_structure,
                 support_set_accounts_data_size_limit_ix,
-                true,
             );
             assert_eq!(
                 fee,
@@ -10204,7 +10187,6 @@ fn test_calculate_prioritization_fee() {
         &message,
         fee_structure.lamports_per_signature,
         &fee_structure,
-        true,
         true,
     );
     assert_eq!(
@@ -10250,7 +10232,6 @@ fn test_calculate_fee_secp256k1() {
                 1,
                 &fee_structure,
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             2
         );
@@ -10270,7 +10251,6 @@ fn test_calculate_fee_secp256k1() {
                 1,
                 &fee_structure,
                 support_set_accounts_data_size_limit_ix,
-                true,
             ),
             11
         );
@@ -12015,39 +11995,22 @@ fn test_calculate_fee_with_congestion_multiplier() {
 
     // assert when lamports_per_signature is less than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier has no effect on fee.
-    for remove_congestion_multiplier in [true, false] {
-        assert_eq!(
-            calculate_test_fee(
-                &message,
-                cheap_lamports_per_signature,
-                &fee_structure,
-                true,
-                remove_congestion_multiplier,
-            ),
-            signature_fee * signature_count
-        );
-    }
+    assert_eq!(
+        calculate_test_fee(&message, cheap_lamports_per_signature, &fee_structure, true,),
+        signature_fee * signature_count
+    );
 
     // assert when lamports_per_signature is more than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier will change calculated fee.
-    for remove_congestion_multiplier in [true, false] {
-        let denominator: u64 = if remove_congestion_multiplier {
-            1
-        } else {
-            lamports_scale
-        };
-
-        assert_eq!(
-            calculate_test_fee(
-                &message,
-                expensive_lamports_per_signature,
-                &fee_structure,
-                true,
-                remove_congestion_multiplier,
-            ),
-            signature_fee * signature_count / denominator
-        );
-    }
+    assert_eq!(
+        calculate_test_fee(
+            &message,
+            expensive_lamports_per_signature,
+            &fee_structure,
+            true,
+        ),
+        signature_fee * signature_count
+    );
 }
 
 #[test]
@@ -12076,7 +12039,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
     // assert when request_heap_frame is presented in tx, prioritization fee will be counted
     // into transaction fee
     assert_eq!(
-        calculate_test_fee(&message, lamports_per_signature, &fee_structure, true, true,),
+        calculate_test_fee(&message, lamports_per_signature, &fee_structure, true),
         signature_fee + request_cu * lamports_per_cu
     );
 }

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -82,18 +82,13 @@ impl FeeStructure {
         message: &SanitizedMessage,
         lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
-        remove_congestion_multiplier: bool,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
         // Fee based on compute units and signatures
         let congestion_multiplier = if lamports_per_signature == 0 {
             0.0 // test only
-        } else if remove_congestion_multiplier {
-            1.0 // multiplier that has no effect
         } else {
-            const BASE_CONGESTION: f64 = 5_000.0;
-            let current_congestion = BASE_CONGESTION.max(lamports_per_signature as f64);
-            BASE_CONGESTION / current_congestion
+            1.0 // multiplier that has no effect
         };
 
         let signature_fee = message


### PR DESCRIPTION
#### Problem

Feature `A8xyMHZovGXFkorFqEmVH2PKGLiBip5JD7jt4zsUWo4H` Remove congestion multiplier from transaction fee calculation #29881 has been activated everywhere.

#### Summary of Changes
- clean up feature code

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
