### PR TITLE
changelog: add getSignaturesForAddress ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Release channels have their own copy of this changelog:
   * Added allow_commission_decrease_at_any_time feature which will allow commission on a vote account to be
     decreased even in the second half of epochs when the commission_updates_only_allowed_in_first_half_of_epoch
     feature would have prevented it
+  * Updated local ledger storage so that the RPC endpoint
+    `getSignaturesForAddress` always returns signatures in block-inclusion order
 * Upgrade Notes
   * `solana-program` and `solana-sdk` default to support for Borsh v1, with
 limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.


### PR DESCRIPTION
#### Problem
As per some conversation on the Telegram RPC channel, we should make the RPC-output changes in https://github.com/solana-labs/solana/pull/33419 more obvious

#### Summary of Changes
Add to changelog

Some additional details for posterity: before #33419 , for multiple addresses within the same block, those pulled from local Blockstore were returned in signature order, whereas those from Bigtable were returned in block-inclusion order. This meant, for nodes backed by Bigtable, there were inconsistencies in return data over time and at the boundary between local Blockstore ledger and Bigtable (`minimumLedgerSlot`).
After the change, ordering will be consistent regardless of which data store a particular slot is queried from.
