### PR TITLE
Allow bank hash file to contain details for multiple slots

### DIFF
--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -23,7 +23,7 @@ use {
 
 /// The components that go into a bank hash calculation
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub(crate) struct BankHashDetails {
+pub(crate) struct BankHashSlotDetails {
     /// The client version
     pub version: String,
     /// The encoding format for account data buffers
@@ -37,7 +37,7 @@ pub(crate) struct BankHashDetails {
     pub accounts: BankHashAccounts,
 }
 
-impl BankHashDetails {
+impl BankHashSlotDetails {
     pub fn new(
         slot: Slot,
         bank_hash: Hash,
@@ -61,7 +61,7 @@ impl BankHashDetails {
     }
 }
 
-impl TryFrom<&Bank> for BankHashDetails {
+impl TryFrom<&Bank> for BankHashSlotDetails {
     type Error = String;
 
     fn try_from(bank: &Bank) -> Result<Self, Self::Error> {
@@ -198,7 +198,7 @@ impl<'de> Deserialize<'de> for BankHashAccounts {
 
 /// Output the components that comprise the overall bank hash for the supplied `Bank`
 pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), String> {
-    let details = BankHashDetails::try_from(bank)?;
+    let details = BankHashSlotDetails::try_from(bank)?;
 
     let slot = details.slot;
     let hash = &details.bank_hash;
@@ -260,7 +260,7 @@ pub mod tests {
         let accounts_delta_hash = hash("accounts_delta".as_bytes());
         let last_blockhash = hash("last_blockhash".as_bytes());
 
-        let bank_hash_details = BankHashDetails::new(
+        let bank_hash_details = BankHashSlotDetails::new(
             slot,
             bank_hash,
             parent_bank_hash,
@@ -271,7 +271,7 @@ pub mod tests {
         );
 
         let serialized_bytes = serde_json::to_vec(&bank_hash_details).unwrap();
-        let deserialized_bank_hash_details: BankHashDetails =
+        let deserialized_bank_hash_details: BankHashSlotDetails =
             serde_json::from_slice(&serialized_bytes).unwrap();
 
         assert_eq!(bank_hash_details, deserialized_bank_hash_details);

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -21,10 +21,12 @@ use {
     std::str::FromStr,
 };
 
+/// The components that go into a bank hash calculation
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct BankHashDetails {
-    /// client version
+    /// The client version
     pub version: String,
+    /// The encoding format for account data buffers
     pub account_data_encoding: String,
     pub slot: Slot,
     pub bank_hash: String,
@@ -99,15 +101,16 @@ impl TryFrom<&Bank> for BankHashDetails {
     }
 }
 
-// Wrap the Vec<...> so we can implement custom Serialize/Deserialize traits on the wrapper type
+/// Wrapper around a Vec<_> to facilitate custom Serialize/Deserialize trait
+/// implementations.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BankHashAccounts {
     pub accounts: Vec<PubkeyHashAccount>,
 }
 
-#[derive(Deserialize, Serialize)]
 /// Used as an intermediate for serializing and deserializing account fields
 /// into a human readable format.
+#[derive(Deserialize, Serialize)]
 struct SerdeAccount {
     pubkey: String,
     hash: String,
@@ -193,7 +196,7 @@ impl<'de> Deserialize<'de> for BankHashAccounts {
     }
 }
 
-/// Output the components that comprise bank hash
+/// Output the components that comprise the overall bank hash for the supplied `Bank`
 pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), String> {
     let details = BankHashDetails::try_from(bank)?;
 

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -267,11 +267,9 @@ pub fn write_bank_hash_details_file(bank: &Bank) -> std::result::Result<(), Stri
 pub mod tests {
     use super::*;
 
-    #[test]
-    fn test_serde_bank_hash_details() {
+    fn build_slot_details(slot: Slot) -> BankHashSlotDetails {
         use solana_sdk::hash::hash;
 
-        let slot = 123_456_789;
         let signature_count = 314;
 
         let account = AccountSharedData::from(Account {
@@ -296,7 +294,7 @@ pub mod tests {
         let accounts_delta_hash = hash("accounts_delta".as_bytes());
         let last_blockhash = hash("last_blockhash".as_bytes());
 
-        let bank_hash_details = BankHashSlotDetails::new(
+        BankHashSlotDetails::new(
             slot,
             bank_hash,
             parent_bank_hash,
@@ -304,7 +302,13 @@ pub mod tests {
             signature_count,
             last_blockhash,
             accounts,
-        );
+        )
+    }
+
+    #[test]
+    fn test_serde_bank_hash_details() {
+        let slot = 123_456_789;
+        let bank_hash_details = build_slot_details(slot);
 
         let serialized_bytes = serde_json::to_vec(&bank_hash_details).unwrap();
         let deserialized_bank_hash_details: BankHashSlotDetails =

--- a/runtime/src/bank/bank_hash_details.rs
+++ b/runtime/src/bank/bank_hash_details.rs
@@ -27,7 +27,7 @@ pub(crate) struct BankHashDetails {
     pub version: String,
     /// The encoding format for account data buffers
     pub account_data_encoding: String,
-    #[serde(rename = "banks")]
+    /// Bank hash details for a collection of banks
     pub bank_hash_details: Vec<BankHashSlotDetails>,
 }
 
@@ -65,7 +65,7 @@ impl BankHashDetails {
     }
 }
 
-/// The components that go into a bank hash calculation
+/// The components that go into a bank hash calculation for a single bank/slot.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct BankHashSlotDetails {
     pub slot: Slot,


### PR DESCRIPTION
#### Problem
The original implementation for bank hash details files (https://github.com/solana-labs/solana/pull/32632) only allows for outputting a single slot at a time. It is advantageous to allow the schema to support multiple slots. One such usescase is a proposed process described in more detail in https://github.com/solana-labs/solana/pull/34246#issuecomment-1833284535. The idea would be:
- Generate the bank hashes for a bunch of slots in a ledger using a "known good" version
- Retain the ledger and bank hash file
- Later, use the ledger + good hashes for testing, whether manual testing of a new feature or in some automated fashion
    - Ie, run the test branch and check computed hashes against good hashes, divergent could be spit out to reduce triage time

#### Summary of Changes
Adjust the `BankHashDetails` struct to allow for details on multiple banks. Note that while the structure can now handle multiple banks, the method exposed to write the file still only allows for passing in a single bank. Allowing for multiple banks (and potentially optional fields) can be added in a follow up PR.

The old `json` object looked like this:
```json
{
  "version": "1.18.0 (src:00000000; feat:142935575, client:SolanaLabs)",
  "account_data_encoding": "base64",
  "slot": 236734421,
  "bank_hash": "D9VzYkV7XxWhWAtATJYWrTayTtAfXbyUKSgSpg5nTRxW",
  "parent_bank_hash": "4YMdLwwqch2PKv9tA3LNyfmPJcFc7S6UXptjGYLoH3MM",
  "accounts_delta_hash": "Et7xGHroFgPiWkWXnL9BGnRNrbDBYmooRvT22fENjdfr",
  "signature_count": 1808,
  "last_blockhash": "9TPtRt3mCgnQJScfnRsAW5G8NAWmHKj48AWHXAg4MpC3",
  "accounts": [
```
With this PR, the structure now has an array for the per-slot details:
```json
{
  "version": "1.18.0 (src:00000000; feat:142935575, client:SolanaLabs)",
  "account_data_encoding": "base64",
  "banks": [
    {
      "slot": 236734421,
      "bank_hash": "D9VzYkV7XxWhWAtATJYWrTayTtAfXbyUKSgSpg5nTRxW",
      "parent_bank_hash": "4YMdLwwqch2PKv9tA3LNyfmPJcFc7S6UXptjGYLoH3MM",
      "accounts_delta_hash": "Et7xGHroFgPiWkWXnL9BGnRNrbDBYmooRvT22fENjdfr",
      "signature_count": 1808,
      "last_blockhash": "9TPtRt3mCgnQJScfnRsAW5G8NAWmHKj48AWHXAg4MpC3",
      "accounts": [ 
```
