### PR TITLE
send validator-new.version after updating the validator identity

### DIFF
--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -693,6 +693,10 @@ impl AdminRpcImpl {
                 .cluster_info
                 .set_keypair(Arc::new(identity_keypair));
             warn!("Identity set to {}", post_init.cluster_info.id());
+            solana_metrics::datapoint_info!(
+                "validator-new",
+                ("version", solana_version::version!(), String),
+            );
             Ok(())
         })
     }


### PR DESCRIPTION
#### Problem
After updating the validator identity using solana-validator set-identity, the validator-new.version is not sent for the new identity.

#### Summary of Changes
I simply added a datapoint_info! after the identity of the validator has been correctly updated in `admin_rpc_service`

Fixes #34389
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
