### PR TITLE
count precompiled programs signatures to transaction cost

### DIFF
--- a/cost-model/src/block_cost_limits.rs
+++ b/cost-model/src/block_cost_limits.rs
@@ -4,7 +4,7 @@ use {
     lazy_static::lazy_static,
     solana_sdk::{
         address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
-        compute_budget, ed25519_program, loader_v4, pubkey::Pubkey, secp256k1_program,
+        compute_budget, loader_v4, pubkey::Pubkey,
     },
     std::collections::HashMap,
 };
@@ -42,9 +42,6 @@ lazy_static! {
         (bpf_loader_deprecated::id(), solana_bpf_loader_program::DEPRECATED_LOADER_COMPUTE_UNITS),
         (bpf_loader::id(), solana_bpf_loader_program::DEFAULT_LOADER_COMPUTE_UNITS),
         (loader_v4::id(), solana_loader_v4_program::DEFAULT_COMPUTE_UNITS),
-        // Note: These are precompile, run directly in bank during sanitizing;
-        (secp256k1_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
-        (ed25519_program::id(), COMPUTE_UNIT_TO_US_RATIO * 24),
     ]
     .iter()
     .cloned()

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -18,13 +18,11 @@ use {
     solana_sdk::{
         borsh1::try_from_slice_unchecked,
         compute_budget::{self, ComputeBudgetInstruction},
-        ed25519_program,
         feature_set::{include_loaded_accounts_data_size_in_fee_calculation, FeatureSet},
         fee::FeeStructure,
         instruction::CompiledInstruction,
         program_utils::limited_deserialize,
         pubkey::Pubkey,
-        secp256k1_program,
         system_instruction::SystemInstruction,
         system_program,
         transaction::SanitizedTransaction,
@@ -86,7 +84,7 @@ impl CostModel {
         let mut loaded_accounts_data_size_cost = 0u64;
         let mut data_bytes_len_total = 0u64;
         let mut compute_unit_limit_is_set = false;
-        let mut num_signatures = transaction.signatures().len() as u64;
+        let num_signatures = transaction.message().num_signatures();
 
         for (program_id, instruction) in transaction.message().program_instructions_iter() {
             // to keep the same behavior, look for builtin first
@@ -106,12 +104,6 @@ impl CostModel {
                 {
                     compute_unit_limit_is_set = true;
                 }
-            }
-
-            if (secp256k1_program::check_id(program_id) || ed25519_program::check_id(program_id))
-                && !instruction.data.is_empty()
-            {
-                num_signatures = num_signatures.saturating_add(instruction.data[0] as u64);
             }
         }
 


### PR DESCRIPTION
#### Problem

Cost of signatures can be cleaner
 
#### Summary of Changes
- refactor to simplify it by using SanitizedMessage

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
