### PR TITLE
cargo-install-all: use full path for sourcing

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -17,7 +17,8 @@ if [[ $OSTYPE == darwin* ]]; then
   fi
 fi
 
-cargo="$("${readlink_cmd}" -f "${here}/../cargo")"
+SOLANA_ROOT="$("${readlink_cmd}" -f "${here}/..")"
+cargo="${SOLANA_ROOT}/cargo"
 
 set -e
 
@@ -150,7 +151,7 @@ mkdir -p "$installDir/bin"
   # Exclude `spl-token` binary for net.sh builds
   if [[ -z "$validatorOnly" ]]; then
     # shellcheck source=scripts/spl-token-cli-version.sh
-    source "$here"/spl-token-cli-version.sh
+    source "$SOLANA_ROOT"/scripts/spl-token-cli-version.sh
 
     # the patch-related configs are needed for rust 1.69+ on Windows; see Cargo.toml
     # shellcheck disable=SC2086 # Don't want to double quote $rust_version


### PR DESCRIPTION
#### Problem
`scripts/cargo-install-all.sh` breaks when run outside the `solana` directory: https://discord.com/channels/428295358100013066/670512312339398668/1186583553325142077
This is because source isn't handling the relative path to `spl-token-cli-version.sh` correctly

#### Summary of Changes
Use full path instead
