### PR TITLE
Moves Bank tests-only ctors to DCOU

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -8196,21 +8196,6 @@ impl Bank {
         )
     }
 
-    /// Intended for use by tests only.
-    /// create new bank with the given configs.
-    pub fn new_with_runtime_config_for_tests(
-        genesis_config: &GenesisConfig,
-        runtime_config: Arc<RuntimeConfig>,
-    ) -> Self {
-        Self::new_with_paths_for_tests(
-            genesis_config,
-            runtime_config,
-            Vec::new(),
-            AccountSecondaryIndexes::default(),
-            AccountShrinkThreshold::default(),
-        )
-    }
-
     pub fn new_with_paths_for_tests(
         genesis_config: &GenesisConfig,
         runtime_config: Arc<RuntimeConfig>,


### PR DESCRIPTION
#### Problem

Test-only and bench-only functions should ideally be inside a `dev-context-only-utils` block. There are non-DCOU tests-only Bank constructors though.


#### Summary of Changes

- Moves Bank tests-only ctors to DCOU
- Removes new_with_runtime_config_for_tests() because there are no callers (as of #34549)