### PR TITLE
Mark solana-program-test as DCOU-tainted

### DIFF
--- a/program-test/Cargo.toml
+++ b/program-test/Cargo.toml
@@ -34,3 +34,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 solana-stake-program = { workspace = true }
+
+[features]
+dev-context-only-utils = []

--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -32,6 +32,7 @@ declare tainted_packages=(
   solana-accounts-bench
   solana-banking-bench
   solana-ledger-tool
+  solana-program-test
 )
 
 # convert to comma separeted (ref: https://stackoverflow.com/a/53839433)


### PR DESCRIPTION
#### Problem

I'd like to move test-only/bench-only Bank constructors into a DCOU block[^1]. Unfortunately, solana-program-test uses these constructors[^2], but solana-program-test is *not* marked as DCOU-tainted. This prevents moving the constructors[^3].

Since solana-program-test is meant for development, I think marking it as "tainted" (i.e. *can* use DCOU functions) is safe and correct.

[^1]: https://github.com/solana-labs/solana/pull/34534
[^2]: It uses `Bank::new_with_runtime_config_for_tests()`
[^3]: https://buildkite.com/solana-labs/solana/builds/105883#018c83fe-65a0-4545-9e96-9a43da81387a


#### Summary of Changes

Mark solana-program-test as DCOU-tainted.