### PR TITLE
ledger-tool: add show-entries option to bigtable block

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -113,6 +113,7 @@ async fn first_available_block(
 async fn block(
     slot: Slot,
     output_format: OutputFormat,
+    _show_entries: bool,
     config: solana_storage_bigtable::LedgerStorageConfig,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let bigtable = solana_storage_bigtable::LedgerStorage::new_with_config(config)
@@ -823,6 +824,12 @@ impl BigTableSubCommand for App<'_, '_> {
                                 .takes_value(true)
                                 .index(1)
                                 .required(true),
+                        )
+                        .arg(
+                            Arg::with_name("show_entries")
+                                .long("show-entries")
+                                .required(false)
+                                .help("Display the transactions in their entries"),
                         ),
                 )
                 .subcommand(
@@ -1117,13 +1124,14 @@ pub fn bigtable_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
         }
         ("block", Some(arg_matches)) => {
             let slot = value_t_or_exit!(arg_matches, "slot", Slot);
+            let show_entries = arg_matches.is_present("show_entries");
             let config = solana_storage_bigtable::LedgerStorageConfig {
                 read_only: true,
                 instance_name,
                 app_profile_id,
                 ..solana_storage_bigtable::LedgerStorageConfig::default()
             };
-            runtime.block_on(block(slot, output_format, config))
+            runtime.block_on(block(slot, output_format, show_entries, config))
         }
         ("entries", Some(arg_matches)) => {
             let slot = value_t_or_exit!(arg_matches, "slot", Slot);

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -1,8 +1,8 @@
 use {
     serde::{Deserialize, Serialize},
     solana_cli_output::{QuietDisplay, VerboseDisplay},
-    solana_sdk::clock::Slot,
-    solana_transaction_status::EntrySummary,
+    solana_sdk::clock::{Slot, UnixTimestamp},
+    solana_transaction_status::{EncodedTransactionWithStatusMeta, EntrySummary, Rewards},
     std::fmt::{self, Display, Formatter, Result},
 };
 
@@ -117,4 +117,44 @@ impl From<EntrySummary> for CliEntry {
             starting_transaction_index: entry_summary.starting_transaction_index,
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliPopulatedEntry {
+    num_hashes: u64,
+    hash: String,
+    num_transactions: u64,
+    starting_transaction_index: usize,
+    transactions: Vec<EncodedTransactionWithStatusMeta>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliBlockWithEntries {
+    #[serde(flatten)]
+    pub encoded_confirmed_block: EncodedConfirmedBlockWithEntries,
+    #[serde(skip_serializing)]
+    pub slot: Slot,
+}
+
+impl QuietDisplay for CliBlockWithEntries {}
+impl VerboseDisplay for CliBlockWithEntries {}
+
+impl fmt::Display for CliBlockWithEntries {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EncodedConfirmedBlockWithEntries {
+    pub previous_blockhash: String,
+    pub blockhash: String,
+    pub parent_slot: Slot,
+    pub entries: Vec<CliPopulatedEntry>,
+    pub rewards: Rewards,
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -119,6 +119,17 @@ impl From<EntrySummary> for CliEntry {
     }
 }
 
+impl From<CliPopulatedEntry> for CliEntry {
+    fn from(populated_entry: CliPopulatedEntry) -> Self {
+        Self {
+            num_hashes: populated_entry.num_hashes,
+            hash: populated_entry.hash,
+            num_transactions: populated_entry.num_transactions,
+            starting_transaction_index: populated_entry.starting_transaction_index,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliPopulatedEntry {

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -70,6 +70,14 @@ impl Display for SlotBounds<'_> {
     }
 }
 
+fn writeln_entry(f: &mut dyn fmt::Write, i: usize, entry: &CliEntry, prefix: &str) -> fmt::Result {
+    writeln!(
+        f,
+        "{prefix}Entry {} - num_hashes: {}, hash: {}, transactions: {}, starting_transaction_index: {}",
+        i, entry.num_hashes, entry.hash, entry.num_transactions, entry.starting_transaction_index,
+    )
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CliEntries {
@@ -85,15 +93,7 @@ impl fmt::Display for CliEntries {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "Slot {}", self.slot)?;
         for (i, entry) in self.entries.iter().enumerate() {
-            writeln!(
-                f,
-                "  Entry {} - num_hashes: {}, hash: {}, transactions: {}, starting_transaction_index: {}",
-                i,
-                entry.num_hashes,
-                entry.hash,
-                entry.num_transactions,
-                entry.starting_transaction_index,
-            )?;
+            writeln_entry(f, i, entry, "  ")?;
         }
         Ok(())
     }


### PR DESCRIPTION
#### Problem
Now that entries are uploaded to bigtable, `solana-ledger-tool bigtable block` can reconstruct complete blocks comparable to the data returned by `solana-ledger-tool slot`.
Re: https://github.com/solana-labs/solana/pull/34266#pullrequestreview-1758223135

#### Summary of Changes
Add `--show-entries` flag to build block display struct with entries
Output looks like:

```
$ solana-ledger-tool bigtable block 2 --show-entries

Slot: 2
Parent Slot: 1
Blockhash: D9aBYGVchmxMprqqGDGhCcYkJXS78S4Xnygj2Lnd9pvu
Previous Blockhash: FP1G5WQBMebHhnBkCXLctcU63rkRCzkYACKsPEyZJPvT
Block Time: 2023-12-14T17:28:49-07:00
Block Height: 2
Rewards:
  Address                                            Type        Amount           New Balance           Percent Change  Commission
  9a25m7QZ2VMkiFETP2UzQxnCnUfEE3LUKbXCnWPb1mGz        fee        ◎0.000005000     ◎499.999995000          0.000001000%      -
Total Rewards: ◎0.000005000
Entry 0 - num_hashes: 1, hash: BVCqk2ssPHxpnaWLCKPvAXhHDmvvXHw2hfT8Uv9QvGoG, transactions: 0, starting_transaction_index: 0
Entry 1 - num_hashes: 1, hash: H6nwjKVKPQQDSZyTgYRXPXsY25ZqQW5yDzyQmicUGuAY, transactions: 1, starting_transaction_index: 0
  Transaction 0:
    Version: legacy
    Recent Blockhash: FP1G5WQBMebHhnBkCXLctcU63rkRCzkYACKsPEyZJPvT
    Signature 0: jva724YHSwd8W8vPNJuueeyLDEdrdqHngRyoNrbSJ1pbqb9hEVC9rBYRaLVxkz9ga1Xer5Hht3YSSUGmsXng8pw
    Signature 1: 59m7yLfF89iHvnwEbo3WjeWHF3Mm48NMQ4Ckvn852pUs3wTYtwiNkvxHkUwhfvhhnrkGqzpM5TpLtuC5TPtS6Fs7
...
```
This is similar to what `solana-ledger-tool slot` spits out. The only differences are a lower indent level and metadata (`slot` prints SlotMeta, `bigtable block` prints the block meta, like parent info and rewards).

The output still supports json:
```
$ solana-ledger-tool bigtable block 2 --show-entries --output json

{
  "previousBlockhash": "FP1G5WQBMebHhnBkCXLctcU63rkRCzkYACKsPEyZJPvT",
  "blockhash": "D9aBYGVchmxMprqqGDGhCcYkJXS78S4Xnygj2Lnd9pvu",
  "parentSlot": 1,
  "entries": [
    {
      "numHashes": 1,
      "hash": "BVCqk2ssPHxpnaWLCKPvAXhHDmvvXHw2hfT8Uv9QvGoG",
      "numTransactions": 0,
      "startingTransactionIndex": 0,
      "transactions": []
    },
    {
      "numHashes": 1,
      "hash": "H6nwjKVKPQQDSZyTgYRXPXsY25ZqQW5yDzyQmicUGuAY",
      "numTransactions": 1,
      "startingTransactionIndex": 0,
      "transactions": [
        {
          "transaction": [
            "AiUEBbnLDFFPNO3o2XcNB5YAzF5opjqrrf3g5waeQKmrfJya+7PpBGLETVspvVuan+NBTEA4uegUQU77gtS3JwDPn3U87KByUhG9feL1+aUKT9DG2zg9ZAhmqveFTUZZ/TbyIMlMilNt03ma8a0V+/Jdx9UoE7wxpvJf0oCQf/AKAgABA39S4rf62DlBSnKtIej8CwJ0YYwniIMHlcioNgd6s4pvBVuVE+TlbMBeJem+JRsZfMgybN1tk4+R1QMnYz4R7c4HYUgdNXR0u3xNdiTr072z2DVec9EQQ/wNo1OAAAAAANWmsE8Wa5K57r76aEUBVpRd/fjlFpnCOP04FavM0skcAQICAQE4DAAAAAAAAAAAAAAAAQEBLCW+EHZf1zNDBk/ClQMWqZ+db/ArLKUg+10mBttPS/cBwp17ZQAAAAA=",
            "base64"
          ],
          "meta": {..}
        }
      ]
    }
 ...
}
```
