### PR TITLE
Remove congestion multiplier from calculate_fee function

### DIFF
--- a/banks-client/src/lib.rs
+++ b/banks-client/src/lib.rs
@@ -581,7 +581,9 @@ mod tests {
         // It creates a runtime explicitly (no globals via tokio macros) and calls
         // `runtime.block_on()` just once, to run all the async code.
 
-        let genesis = create_genesis_config(10);
+        // Fund payer account with minimal transaction fee for one signature, plus some extra.
+        let mint_lamports = 10 + solana_sdk::fee::FeeStructure::default().lamports_per_signature;
+        let genesis = create_genesis_config(mint_lamports);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
         let slot = bank.slot();
         let block_commitment_cache = Arc::new(RwLock::new(
@@ -620,7 +622,9 @@ mod tests {
         // is processed (or blockhash expires). In this test, we verify the
         // server-side functionality is available to the client.
 
-        let genesis = create_genesis_config(10);
+        // Fund payer account with minimal transaction fee for one signature, plus some extra.
+        let mint_lamports = 10 + solana_sdk::fee::FeeStructure::default().lamports_per_signature;
+        let genesis = create_genesis_config(mint_lamports);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
         let slot = bank.slot();
         let block_commitment_cache = Arc::new(RwLock::new(

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -419,7 +419,7 @@ impl Banks for BanksServer {
     ) -> Option<u64> {
         let bank = self.bank(commitment);
         let sanitized_message = SanitizedMessage::try_from(message).ok()?;
-        bank.get_fee_for_message(&sanitized_message)
+        Some(bank.get_fee_for_message(&sanitized_message))
     }
 }
 

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -133,7 +133,9 @@ fn test_bench_tps_test_validator(config: Config) {
     let client =
         Arc::new(TpuClient::new(rpc_client, &websocket_url, TpuClientConfig::default()).unwrap());
 
-    let lamports_per_account = 1000;
+    // fund accounts with 2 signatures, and extra
+    let lamports_per_account =
+        1000 + 2 * solana_sdk::fee::FeeStructure::default().lamports_per_signature;
 
     let keypair_count = config.tx_count * config.keypair_multiplier;
     let keypairs = generate_and_fund_keypairs(

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -714,7 +714,6 @@ impl Consumer {
             process_compute_budget_instructions(message.program_instructions_iter())?.into();
         let fee = bank.fee_structure.calculate_fee(
             message,
-            bank.get_lamports_per_signature(),
             &budget_limits,
             bank.feature_set.is_active(
                 &feature_set::include_loaded_accounts_data_size_in_fee_calculation::id(),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -4119,7 +4119,6 @@ fn test_program_fees() {
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
     let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
-        congestion_multiplier,
         &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
             .unwrap_or_default()
             .into(),
@@ -4142,7 +4141,6 @@ fn test_program_fees() {
     let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
     let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
-        congestion_multiplier,
         &process_compute_budget_instructions(sanitized_message.program_instructions_iter())
             .unwrap_or_default()
             .into(),

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -16,7 +16,7 @@ use {
         parse_bpf_upgradeable_loader, BpfUpgradeableLoaderAccountType,
     },
     solana_accounts_db::transaction_results::{
-        DurableNonceFee, InnerInstruction, TransactionExecutionDetails, TransactionExecutionResult,
+        InnerInstruction, TransactionExecutionDetails, TransactionExecutionResult,
         TransactionResults,
     },
     solana_ledger::token_balances::collect_token_balances,
@@ -190,25 +190,13 @@ fn execute_transactions(
                         status,
                         log_messages,
                         inner_instructions,
-                        durable_nonce_fee,
                         return_data,
                         executed_units,
                         ..
                     } = details;
 
-                    let lamports_per_signature = match durable_nonce_fee {
-                        Some(DurableNonceFee::Valid(lamports_per_signature)) => {
-                            Some(lamports_per_signature)
-                        }
-                        Some(DurableNonceFee::Invalid) => None,
-                        None => bank.get_lamports_per_signature_for_blockhash(
-                            &tx.message().recent_blockhash,
-                        ),
-                    }
-                    .expect("lamports_per_signature must be available");
-                    let fee = bank.get_fee_for_message_with_lamports_per_signature(
+                    let fee = bank.get_fee_for_message(
                         &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
-                        lamports_per_signature,
                     );
 
                     let inner_instructions = inner_instructions.map(|inner_instructions| {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4008,7 +4008,7 @@ pub mod rpc_full {
                 .map_err(|err| {
                     Error::invalid_params(format!("invalid transaction message: {err}"))
                 })?;
-            let fee = bank.get_fee_for_message(&sanitized_message);
+            let fee = Some(bank.get_fee_for_message(&sanitized_message));
             Ok(new_response(bank, fee))
         }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5162,7 +5162,6 @@ impl Bank {
             &self.ancestors,
             sanitized_txs,
             check_results,
-            &self.blockhash_queue.read().unwrap(),
             &mut error_counters,
             &self.rent_collector,
             &self.feature_set,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10929,7 +10929,6 @@ fn test_rent_state_list_len() {
         &bank.ancestors,
         &[sanitized_tx.clone()],
         vec![(Ok(()), None)],
-        &bank.blockhash_queue.read().unwrap(),
         &mut error_counters,
         &bank.rent_collector,
         &bank.feature_set,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -9963,10 +9963,7 @@ fn test_call_precomiled_program() {
     bank.process_transaction(&tx).unwrap();
 }
 
-fn calculate_test_fee(
-    message: &SanitizedMessage,
-    fee_structure: &FeeStructure,
-) -> u64 {
+fn calculate_test_fee(message: &SanitizedMessage, fee_structure: &FeeStructure) -> u64 {
     let budget_limits = process_compute_budget_instructions(message.program_instructions_iter())
         .unwrap_or_default()
         .into();
@@ -10110,10 +10107,7 @@ fn test_calculate_prioritization_fee() {
     ))
     .unwrap();
 
-    let fee = calculate_test_fee(
-        &message,
-        &fee_structure,
-    );
+    let fee = calculate_test_fee(&message, &fee_structure);
     assert_eq!(
         fee,
         fee_structure.lamports_per_signature + prioritization_fee

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -288,7 +288,7 @@ impl SyncClient for BankClient {
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
         SanitizedMessage::try_from(message.clone())
             .ok()
-            .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
+            .map(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
             .ok_or_else(|| {
                 TransportError::IoError(io::Error::new(
                     io::ErrorKind::Other,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1808,7 +1808,7 @@ mod tests {
             lamports_to_transfer,
             blockhash,
         ));
-        let fee = bank2.get_fee_for_message(tx.message()).unwrap();
+        let fee = bank2.get_fee_for_message(tx.message());
         let tx = system_transaction::transfer(
             &key1,
             &key2.pubkey(),
@@ -2206,7 +2206,7 @@ mod tests {
                 let transaction = SanitizedTransaction::from_transaction_for_tests(
                     system_transaction::transfer(&key2, &key3.pubkey(), amount, blockhash),
                 );
-                bank.get_fee_for_message(transaction.message()).unwrap()
+                bank.get_fee_for_message(transaction.message())
             };
             bank.transfer(amount + fee, mint, &key1.pubkey()).unwrap();
             bank.transfer(amount + fee, mint, &key2.pubkey()).unwrap();

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -80,17 +80,9 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
-        // Fee based on compute units and signatures
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
-        } else {
-            1.0 // multiplier that has no effect
-        };
-
         let signature_fee = message
             .num_signatures()
             .saturating_mul(self.lamports_per_signature);
@@ -122,12 +114,11 @@ impl FeeStructure {
                     .unwrap_or_default()
             });
 
-        ((budget_limits
+        (budget_limits
             .prioritization_fee
             .saturating_add(signature_fee)
             .saturating_add(write_lock_fee)
             .saturating_add(compute_fee) as f64)
-            * congestion_multiplier)
             .round() as u64
     }
 }


### PR DESCRIPTION
#### Problem

`bank.calculate_fee()` takes a parameter with misleading name (`lamports_per_signature`) for testing congestion multiplier to be zero, which has been removed everywhere. That parameter should also be removed.

Due to legacy or perhaps misleading name of the parameter, call sites are calling extra code to resolve `lamports_per_signature` before calling `calculate_fee()`, in some instances, it locks hash_queue to do so. All of these are not necessary.

#### Summary of Changes
- remove `congestion_multiplier` within `calculate_fee()`
- remove `lamports_per_signature` input parameter of `calculate_fee()`, durable transaction also uses fee rate from time of execution.
- remove code that fetches `lamports_per_signature` from nonce account leading to call of `calculate_fee()`


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
