### PR TITLE
ledger-tool: support v0 transactions in blocks from bigtable

### DIFF
--- a/ledger-tool/src/bigtable.rs
+++ b/ledger-tool/src/bigtable.rs
@@ -130,7 +130,7 @@ async fn block(
             BlockEncodingOptions {
                 transaction_details: TransactionDetails::Full,
                 show_rewards: true,
-                max_supported_transaction_version: None,
+                max_supported_transaction_version: Some(0),
             },
         )
         .map_err(|err| match err {


### PR DESCRIPTION
#### Problem
Querying bigtable for a block with a v0 transaction in it errors:
```
$ GOOGLE_APPLICATION_CREDENTIALS=<mnb_credential> solana-ledger-tool bigtable block 236304134
..
"Failed to process unsupported transaction version (0) in block"
```

#### Summary of Changes
Update encoding options to support blocks with v0 transactions
