### PR TITLE
Cargo needs version arg after subcommand

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -158,8 +158,7 @@ mkdir -p "$installDir/bin"
     "$cargo" $maybeRustVersion \
       --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
       --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
-      $maybeSplTokenCliVersionArg \
-      install --locked spl-token-cli --root "$installDir"
+      install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi
 )
 


### PR DESCRIPTION
#### Summary of Changes
Move arg to after `install` subcommand
