### PR TITLE
V1.16: Cargo needs version arg after subcommand

### DIFF
--- a/scripts/cargo-install-all.sh
+++ b/scripts/cargo-install-all.sh
@@ -158,8 +158,7 @@ mkdir -p "$installDir/bin"
     "$cargo" $maybeRustVersion \
       --config 'patch.crates-io.ntapi.git="https://github.com/solana-labs/ntapi"' \
       --config 'patch.crates-io.ntapi.rev="97ede981a1777883ff86d142b75024b023f04fad"' \
-      $maybeSplTokenCliVersionArg \
-      install --locked spl-token-cli --root "$installDir"
+      install --locked spl-token-cli --root "$installDir" $maybeSplTokenCliVersionArg
   fi
 )
 

--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=v3.2.0
+splTokenCliVersion=3.2.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Summary of Changes
https://github.com/solana-labs/solana/pull/34547 for v1.16
Move arg to after install subcommand
Also fix semver, now that version is actually being respected
