### PR TITLE
program-test uses Bank::new_with_paths()

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -8,7 +8,10 @@ use {
     base64::{prelude::BASE64_STANDARD, Engine},
     chrono_humanize::{Accuracy, HumanTime, Tense},
     log::*,
-    solana_accounts_db::epoch_accounts_hash::EpochAccountsHash,
+    solana_accounts_db::{
+        accounts_db::AccountShrinkThreshold, accounts_index::AccountSecondaryIndexes,
+        epoch_accounts_hash::EpochAccountsHash,
+    },
     solana_banks_client::start_client,
     solana_banks_server::banks_server::start_local_server,
     solana_bpf_loader_program::serialization::serialize_parameters,
@@ -805,7 +808,7 @@ impl ProgramTest {
         debug!("Payer address: {}", mint_keypair.pubkey());
         debug!("Genesis config: {}", genesis_config);
 
-        let mut bank = Bank::new_with_runtime_config_for_tests(
+        let mut bank = Bank::new_with_paths(
             &genesis_config,
             Arc::new(RuntimeConfig {
                 compute_budget: self.compute_max_units.map(|max_units| ComputeBudget {
@@ -815,6 +818,15 @@ impl ProgramTest {
                 transaction_account_lock_limit: self.transaction_account_lock_limit,
                 ..RuntimeConfig::default()
             }),
+            Vec::default(),
+            None,
+            None,
+            AccountSecondaryIndexes::default(),
+            AccountShrinkThreshold::default(),
+            false,
+            None,
+            None,
+            Arc::default(),
         );
 
         // Add commonly-used SPL programs as a convenience to the user


### PR DESCRIPTION
#### Problem

I'd like to move test-only/bench-only Bank constructors into a DCOU block[^1]. Unfortunately, solana-program-test uses these constructors[^2], but solana-program-test is *not* marked as DCOU-tainted. This prevents moving the constructors[^3].

Ideally we would mark solana-program-test itself as DCOU, but that is non-trivial due to how it is used[^4].

[^1]: https://github.com/solana-labs/solana/pull/34534
[^2]: It uses `Bank::new_with_runtime_config_for_tests()`
[^3]: https://buildkite.com/solana-labs/solana/builds/105883#018c83fe-65a0-4545-9e96-9a43da81387a
[^4]: https://buildkite.com/solana-labs/solana/builds/105885#018c8424-63f5-44c6-a419-bca053007d6c


#### Summary of Changes

Instead, we can replace Bank::new_with_runtime_config_for_tests() with Bank::new_with_paths(). There's nothing special about the AccountsDbConfig that program-test needs, so the defaults are fine.