### PR TITLE
v1.16: Hardcode rust version for publish-crate

### DIFF
--- a/ci/publish-crate.sh
+++ b/ci/publish-crate.sh
@@ -2,6 +2,7 @@
 set -e
 cd "$(dirname "$0")/.."
 source ci/semver_bash/semver.sh
+export RUST_STABLE_VERSION=1.70.0
 source ci/rust-version.sh stable
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
#### Problem
Crate publishing failed for v1.16.24, starting with `solana-storage-proto` and all child crates

```
Caused by:
  package `home v0.5.9` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.69.0
```

#### Summary of Changes
Hardcode a slightly higher rust version for crate publishing
(v1.16 is v close to EOL; hopefully after this minor version we can just keep up!)
