### PR TITLE
refactor: optional `stake_history` arg is never `None`

### DIFF
--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2320,7 +2320,7 @@ pub fn build_stake_state(
                 deactivating,
             } = stake.delegation.stake_activating_and_deactivating(
                 current_epoch,
-                Some(stake_history),
+                stake_history,
                 new_rate_activation_epoch,
             );
             let lockup = if lockup.is_in_force(clock, None) {

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -205,7 +205,7 @@ async fn stake_rewards_from_warp() {
     assert_eq!(
         stake
             .delegation
-            .stake_activating_and_deactivating(clock.epoch, Some(&stake_history), None),
+            .stake_activating_and_deactivating(clock.epoch, &stake_history, None),
         StakeActivationStatus::with_effective(stake.delegation.stake),
     );
 }
@@ -321,7 +321,7 @@ async fn stake_rewards_filter_bench_core(num_stake_accounts: u64) {
     assert_eq!(
         stake
             .delegation
-            .stake_activating_and_deactivating(clock.epoch, Some(&stake_history), None),
+            .stake_activating_and_deactivating(clock.epoch, &stake_history, None),
         StakeActivationStatus::with_effective(stake.delegation.stake),
     );
 }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -566,7 +566,7 @@ mod tests {
             if let StakeStateV2::Stake(_meta, stake, _stake_flags) = account.state().unwrap() {
                 let stake_status = stake.delegation.stake_activating_and_deactivating(
                     clock.epoch,
-                    Some(stake_history),
+                    stake_history,
                     None,
                 );
                 active_stake += stake_status.effective;
@@ -6817,15 +6817,11 @@ mod tests {
                 create_account_shared_data_for_test(&stake_history),
             );
             if stake_amount
-                == stake.stake(
-                    clock.epoch,
-                    Some(&stake_history),
-                    new_warmup_cooldown_rate_epoch,
-                )
+                == stake.stake(clock.epoch, &stake_history, new_warmup_cooldown_rate_epoch)
                 && merge_from_amount
                     == merge_from_stake.stake(
                         clock.epoch,
-                        Some(&stake_history),
+                        &stake_history,
                         new_warmup_cooldown_rate_epoch,
                     )
             {
@@ -6906,14 +6902,10 @@ mod tests {
                 stake_history::id(),
                 create_account_shared_data_for_test(&stake_history),
             );
-            if 0 == stake.stake(
-                clock.epoch,
-                Some(&stake_history),
-                new_warmup_cooldown_rate_epoch,
-            ) && 0
-                == merge_from_stake.stake(
+            if 0 == stake.stake(clock.epoch, &stake_history, new_warmup_cooldown_rate_epoch)
+                && 0 == merge_from_stake.stake(
                     clock.epoch,
-                    Some(&stake_history),
+                    &stake_history,
                     new_warmup_cooldown_rate_epoch,
                 )
             {
@@ -7359,11 +7351,7 @@ mod tests {
                     initial_stake_state
                         .delegation()
                         .unwrap()
-                        .stake_activating_and_deactivating(
-                            current_epoch,
-                            Some(&stake_history),
-                            None
-                        )
+                        .stake_activating_and_deactivating(current_epoch, &stake_history, None)
                 );
             }
 
@@ -7859,7 +7847,7 @@ mod tests {
                 },
                 stake.delegation.stake_activating_and_deactivating(
                     current_epoch,
-                    Some(&stake_history),
+                    &stake_history,
                     None
                 )
             );

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -1770,7 +1770,7 @@ impl JsonRpcRequestProcessor {
             deactivating,
         } = delegation.stake_activating_and_deactivating(
             epoch,
-            Some(&stake_history),
+            &stake_history,
             new_rate_activation_epoch,
         );
         let stake_activation_state = if deactivating > 0 {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3020,7 +3020,7 @@ impl Bank {
                     stake_state::calculate_points(
                         stake_account.stake_state(),
                         vote_state,
-                        Some(stake_history),
+                        stake_history,
                         new_warmup_cooldown_rate_epoch,
                     )
                     .unwrap_or(0)
@@ -3057,7 +3057,7 @@ impl Bank {
                             stake_state::calculate_points(
                                 stake_account.stake_state(),
                                 vote_state,
-                                Some(stake_history),
+                                stake_history,
                                 new_warmup_cooldown_rate_epoch,
                             )
                             .unwrap_or(0)
@@ -3144,7 +3144,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(stake_history),
+                        stake_history,
                         reward_calc_tracer.as_ref(),
                         new_warmup_cooldown_rate_epoch,
                     );
@@ -3263,7 +3263,7 @@ impl Bank {
                         &mut stake_account,
                         &vote_state,
                         &point_value,
-                        Some(stake_history),
+                        stake_history,
                         reward_calc_tracer.as_ref(),
                         new_warmup_cooldown_rate_epoch,
                     );

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3970,7 +3970,7 @@ fn test_bank_epoch_vote_accounts() {
         // epoch_stakes are a snapshot at the leader_schedule_slot_offset boundary
         //   in the prior epoch (0 in this case)
         assert_eq!(
-            leader_stake.stake(0, None, None),
+            leader_stake.stake(0, &StakeHistory::default(), None),
             vote_accounts.unwrap().get(&leader_vote_account).unwrap().0
         );
 
@@ -3986,7 +3986,7 @@ fn test_bank_epoch_vote_accounts() {
 
     assert!(child.epoch_vote_accounts(epoch).is_some());
     assert_eq!(
-        leader_stake.stake(child.epoch(), None, None),
+        leader_stake.stake(child.epoch(), &StakeHistory::default(), None),
         child
             .epoch_vote_accounts(epoch)
             .unwrap()
@@ -4004,7 +4004,7 @@ fn test_bank_epoch_vote_accounts() {
     );
     assert!(child.epoch_vote_accounts(epoch).is_some());
     assert_eq!(
-        leader_stake.stake(child.epoch(), None, None),
+        leader_stake.stake(child.epoch(), &StakeHistory::default(), None),
         child
             .epoch_vote_accounts(epoch)
             .unwrap()

--- a/runtime/tests/stake.rs
+++ b/runtime/tests/stake.rs
@@ -105,12 +105,10 @@ fn warmed_up(bank: &Bank, stake_pubkey: &Pubkey) -> bool {
     stake.delegation.stake
         == stake.stake(
             bank.epoch(),
-            Some(
-                &from_account::<StakeHistory, _>(
-                    &bank.get_account(&sysvar::stake_history::id()).unwrap(),
-                )
-                .unwrap(),
-            ),
+            &from_account::<StakeHistory, _>(
+                &bank.get_account(&sysvar::stake_history::id()).unwrap(),
+            )
+            .unwrap(),
             bank.new_warmup_cooldown_rate_epoch(),
         )
 }
@@ -120,12 +118,10 @@ fn get_staked(bank: &Bank, stake_pubkey: &Pubkey) -> u64 {
         .unwrap()
         .stake(
             bank.epoch(),
-            Some(
-                &from_account::<StakeHistory, _>(
-                    &bank.get_account(&sysvar::stake_history::id()).unwrap(),
-                )
-                .unwrap(),
-            ),
+            &from_account::<StakeHistory, _>(
+                &bank.get_account(&sysvar::stake_history::id()).unwrap(),
+            )
+            .unwrap(),
             bank.new_warmup_cooldown_rate_epoch(),
         )
 }

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -641,7 +641,7 @@ impl Delegation {
     pub fn stake(
         &self,
         epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.stake_activating_and_deactivating(epoch, history, new_rate_activation_epoch)
@@ -652,7 +652,7 @@ impl Delegation {
     pub fn stake_activating_and_deactivating(
         &self,
         target_epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> StakeActivationStatus {
         // first, calculate an effective and activating stake
@@ -673,17 +673,14 @@ impl Delegation {
         } else if target_epoch == self.deactivation_epoch {
             // can only deactivate what's activated
             StakeActivationStatus::with_deactivating(effective_stake)
-        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
-            history.and_then(|history| {
-                history
-                    .get(self.deactivation_epoch)
-                    .map(|cluster_stake_at_deactivation_epoch| {
-                        (
-                            history,
-                            self.deactivation_epoch,
-                            cluster_stake_at_deactivation_epoch,
-                        )
-                    })
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
+            .get(self.deactivation_epoch)
+            .map(|cluster_stake_at_deactivation_epoch| {
+                (
+                    history,
+                    self.deactivation_epoch,
+                    cluster_stake_at_deactivation_epoch,
+                )
             })
         {
             // target_epoch > self.deactivation_epoch
@@ -742,7 +739,7 @@ impl Delegation {
     fn stake_and_activating(
         &self,
         target_epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> (u64, u64) {
         let delegated_stake = self.stake;
@@ -760,17 +757,14 @@ impl Delegation {
         } else if target_epoch < self.activation_epoch {
             // not yet enabled
             (0, 0)
-        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) =
-            history.and_then(|history| {
-                history
-                    .get(self.activation_epoch)
-                    .map(|cluster_stake_at_activation_epoch| {
-                        (
-                            history,
-                            self.activation_epoch,
-                            cluster_stake_at_activation_epoch,
-                        )
-                    })
+        } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
+            .get(self.activation_epoch)
+            .map(|cluster_stake_at_activation_epoch| {
+                (
+                    history,
+                    self.activation_epoch,
+                    cluster_stake_at_activation_epoch,
+                )
             })
         {
             // target_epoch > self.activation_epoch
@@ -926,7 +920,7 @@ impl Stake {
     pub fn stake(
         &self,
         epoch: Epoch,
-        history: Option<&StakeHistory>,
+        history: &StakeHistory,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.delegation


### PR DESCRIPTION
#### Problem
The optional `stake_history` arg is never `None` except for in tests which can use `StakeHistory::default()`

#### Summary of Changes
- Remove option wrapping for `stake_history` arg

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
