### PR TITLE
Throttle unstaked quic streams for a given connection

### DIFF
--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -248,9 +248,13 @@ where
     fn send<C: BenchTpsClient + ?Sized>(&self, client: &Arc<C>) {
         let mut send_txs = Measure::start("send_and_clone_txs");
         let batch: Vec<_> = self.iter().map(|(_keypair, tx)| tx.clone()).collect();
-        client.send_batch(batch).expect("transfer");
+        let result = client.send_batch(batch);
         send_txs.stop();
-        debug!("send {} {}", self.len(), send_txs);
+        if result.is_err() {
+            debug!("Failed to send batch {result:?}");
+        } else {
+            debug!("send {} {}", self.len(), send_txs);
+        }
     }
 
     fn verify<C: 'static + BenchTpsClient + Send + Sync + ?Sized>(

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2928,24 +2928,26 @@ fn setup_transfer_scan_threads(
                     .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                     .unwrap();
                 for i in 0..starting_keypairs_.len() {
-                    client
-                        .async_transfer(
-                            1,
-                            &starting_keypairs_[i],
-                            &target_keypairs_[i].pubkey(),
-                            blockhash,
-                        )
-                        .unwrap();
+                    let result = client.async_transfer(
+                        1,
+                        &starting_keypairs_[i],
+                        &target_keypairs_[i].pubkey(),
+                        blockhash,
+                    );
+                    if result.is_err() {
+                        debug!("Failed in transfer for starting keypair: {:?}", result);
+                    }
                 }
                 for i in 0..starting_keypairs_.len() {
-                    client
-                        .async_transfer(
-                            1,
-                            &target_keypairs_[i],
-                            &starting_keypairs_[i].pubkey(),
-                            blockhash,
-                        )
-                        .unwrap();
+                    let result = client.async_transfer(
+                        1,
+                        &target_keypairs_[i],
+                        &starting_keypairs_[i].pubkey(),
+                        blockhash,
+                    );
+                    if result.is_err() {
+                        debug!("Failed in transfer for starting keypair: {:?}", result);
+                    }
                 }
             }
         })

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -46,6 +46,7 @@ mod tests {
                 assert_eq!(p.meta().size, num_bytes);
             }
         }
+        assert!(total_packets > 0);
     }
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair, IpAddr) {
@@ -138,6 +139,7 @@ mod tests {
                 assert_eq!(p.meta().size, num_bytes);
             }
         }
+        assert!(total_packets > 0);
     }
 
     #[tokio::test]

--- a/quic-client/tests/quic_client.rs
+++ b/quic-client/tests/quic_client.rs
@@ -46,7 +46,6 @@ mod tests {
                 assert_eq!(p.meta().size, num_bytes);
             }
         }
-        assert_eq!(total_packets, num_expected_packets);
     }
 
     fn server_args() -> (UdpSocket, Arc<AtomicBool>, Keypair, IpAddr) {
@@ -139,7 +138,6 @@ mod tests {
                 assert_eq!(p.meta().size, num_bytes);
             }
         }
-        assert_eq!(total_packets, num_expected_packets);
     }
 
     #[tokio::test]
@@ -182,7 +180,9 @@ mod tests {
         let num_bytes = PACKET_DATA_SIZE;
         let num_expected_packets: usize = 3000;
         let packets = vec![vec![0u8; PACKET_DATA_SIZE]; num_expected_packets];
-        assert!(client.send_data_batch(&packets).await.is_ok());
+        for packet in packets {
+            let _ = client.send_data(&packet).await;
+        }
 
         nonblocking_check_packets(receiver, num_bytes, num_expected_packets).await;
         exit.store(true, Ordering::Relaxed);

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -713,8 +713,8 @@ async fn handle_connection(
                 tokio::time::sleep_until(next_interval).await;
             }
 
-            if tokio::time::Instant::now()
-                .saturating_duration_since(next_interval)
+            if next_interval
+                .saturating_duration_since(tokio::time::Instant::now())
                 .as_millis()
                 == 0
             {

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -59,6 +59,7 @@ const CONNECTION_CLOSE_REASON_EXCEED_MAX_STREAM_COUNT: &[u8] = b"exceed_max_stre
 
 const CONNECTION_CLOSE_CODE_TOO_MANY: u32 = 4;
 const CONNECTION_CLOSE_REASON_TOO_MANY: &[u8] = b"too_many";
+const STREAM_STOP_CODE_THROTTLING: u32 = 15;
 
 // A sequence of bytes that is part of a packet
 // along with where in the packet it is
@@ -741,7 +742,7 @@ async fn handle_connection(
                     if reset_throttling_params_if_needed(&mut last_throttling_instant) {
                         streams_in_current_interval = 0;
                     } else if streams_in_current_interval >= max_streams_per_100ms {
-                        let _ = stream.stop(VarInt::from_u32(0));
+                        let _ = stream.stop(VarInt::from_u32(STREAM_STOP_CODE_THROTTLING));
                         continue;
                     }
                     streams_in_current_interval = streams_in_current_interval.saturating_add(1);


### PR DESCRIPTION
#### Problem
We currently limit of concurrent unstaked QUIC streams. But the client can create unbounded number of streams over time by closing existing streams and creating new ones.

#### Summary of Changes
Track number of streams created in a connection
Once the limit is reached, wait till the next time interval before accepting new streams

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
