### PR TITLE
ci: split cargo-clippy into stable and nightly

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -26,7 +26,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  clippy:
+  clippy-stable:
     strategy:
       matrix:
         os:
@@ -44,7 +44,28 @@ jobs:
 
       - shell: bash
         run: |
-          source ci/rust-version.sh all
+          source ci/rust-version.sh stable
           rustup component add clippy --toolchain "$rust_stable"
+          scripts/cargo-clippy-stable.sh
+
+  clippy-nightly:
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mozilla-actions/sccache-action@v0.0.3
+        with:
+          version: "v0.5.4"
+
+      - shell: bash
+        run: .github/scripts/cargo-clippy-before-script.sh ${{ runner.os }}
+
+      - shell: bash
+        run: |
+          source ci/rust-version.sh nightly
           rustup component add clippy --toolchain "$rust_nightly"
-          scripts/cargo-clippy.sh
+          scripts/cargo-clippy-nightly.sh

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -60,7 +60,9 @@ pull_request_rules:
           - status-success=build & deploy docs
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|\.github/scripts/cargo-clippy-before-script\.sh|\.github/workflows/cargo\.yml)$
-          - check-success=clippy (macos-latest)
+          - and:
+            - check-success=clippy-stable (macos-latest)
+            - check-success=clippy-nightly (macos-latest)
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-bpf|cargo-test-bpf|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl\.sh|\.github/workflows/downstream-project-spl\.yml)$
           - and:

--- a/scripts/cargo-clippy-nightly.sh
+++ b/scripts/cargo-clippy-nightly.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+here="$(dirname "$0")"
+cargo="$(readlink -f "${here}/../cargo")"
+
+if [[ -z $cargo ]]; then
+  echo >&2 "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
+  to gnu readlink with 'brew install coreutils' and then symlink greadlink as
+  /usr/local/bin/readlink."
+  exit 1
+fi
+
+# shellcheck source=ci/rust-version.sh
+source "$here/../ci/rust-version.sh" nightly
+
+# Use nightly clippy, as frozen-abi proc-macro generates a lot of code across
+# various crates in this whole monorepo (frozen-abi is enabled only under nightly
+# due to the use of unstable rust feature). Likewise, frozen-abi(-macro) crates'
+# unit tests are only compiled under nightly.
+# Similarly, nightly is desired to run clippy over all of bench files because
+# the bench itself isn't stabilized yet...
+#   ref: https://github.com/rust-lang/rust/issues/66287
+"$here/cargo-for-all-lock-files.sh" -- \
+  "+${rust_nightly}" clippy \
+  --workspace --all-targets --features dummy-for-ci-check -- \
+  --deny=warnings \
+  --deny=clippy::default_trait_access \
+  --deny=clippy::arithmetic_side_effects \
+  --deny=clippy::manual_let_else \
+  --deny=clippy::used_underscore_binding \
+  --allow=clippy::redundant_clone

--- a/scripts/cargo-clippy-stable.sh
+++ b/scripts/cargo-clippy-stable.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+here="$(dirname "$0")"
+cargo="$(readlink -f "${here}/../cargo")"
+
+if [[ -z $cargo ]]; then
+  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
+  to gnu readlink with 'brew install coreutils' and then symlink greadlink as
+  /usr/local/bin/readlink."
+  exit 1
+fi
+
+# shellcheck source=ci/rust-version.sh
+source "$here/../ci/rust-version.sh" stable
+
+# temporarily run stable clippy as well to scan the codebase for
+# `redundant_clone`s, which is disabled as nightly clippy is buggy:
+#   https://github.com/solana-labs/solana/issues/31834
+#
+# can't use --all-targets:
+#   error[E0554]: `#![feature]` may not be used on the stable release channel
+"$here/cargo-for-all-lock-files.sh" -- \
+  clippy \
+  --workspace --tests --bins --examples --features dummy-for-ci-check -- \
+  --deny=warnings \
+  --deny=clippy::default_trait_access \
+  --deny=clippy::arithmetic_side_effects \
+  --deny=clippy::manual_let_else \
+  --deny=clippy::used_underscore_binding

--- a/scripts/cargo-clippy.sh
+++ b/scripts/cargo-clippy.sh
@@ -14,48 +14,9 @@
 set -o errexit
 
 here="$(dirname "$0")"
-cargo="$(readlink -f "${here}/../cargo")"
 
-if [[ -z $cargo ]]; then
-  >&2 echo "Failed to find cargo. Mac readlink doesn't support -f. Consider switching
-  to gnu readlink with 'brew install coreutils' and then symlink greadlink as
-  /usr/local/bin/readlink."
-  exit 1
-fi
+# stable
+"$here/cargo-clippy-stable.sh"
 
-# shellcheck source=ci/rust-version.sh
-source "$here/../ci/rust-version.sh"
-
-nightly_clippy_allows=(--allow=clippy::redundant_clone)
-
-# Use nightly clippy, as frozen-abi proc-macro generates a lot of code across
-# various crates in this whole monorepo (frozen-abi is enabled only under nightly
-# due to the use of unstable rust feature). Likewise, frozen-abi(-macro) crates'
-# unit tests are only compiled under nightly.
-# Similarly, nightly is desired to run clippy over all of bench files because
-# the bench itself isn't stabilized yet...
-#   ref: https://github.com/rust-lang/rust/issues/66287
-"$here/cargo-for-all-lock-files.sh" -- \
-  "+${rust_nightly}" clippy \
-  --workspace --all-targets --features dummy-for-ci-check -- \
-  --deny=warnings \
-  --deny=clippy::default_trait_access \
-  --deny=clippy::arithmetic_side_effects \
-  --deny=clippy::manual_let_else \
-  --deny=clippy::used_underscore_binding \
-  "${nightly_clippy_allows[@]}"
-
-# temporarily run stable clippy as well to scan the codebase for
-# `redundant_clone`s, which is disabled as nightly clippy is buggy:
-#   https://github.com/solana-labs/solana/issues/31834
-#
-# can't use --all-targets:
-#   error[E0554]: `#![feature]` may not be used on the stable release channel
-"$here/cargo-for-all-lock-files.sh" -- \
-  clippy \
-  --workspace --tests --bins --examples --features dummy-for-ci-check -- \
-  --deny=warnings \
-  --deny=clippy::default_trait_access \
-  --deny=clippy::arithmetic_side_effects \
-  --deny=clippy::manual_let_else \
-  --deny=clippy::used_underscore_binding
+# nightly
+"$here/cargo-clippy-nightly.sh"


### PR DESCRIPTION
#### Problem

context: https://discord.com/channels/428295358100013066/560503042458517505/1187442157326450780

#### Summary of Changes

- split cargo-clippy into stable and nightly

btw, if we still feel this one too slow, I can split them into smaller pieces (but will be a little bit hardcoded)
or we need a better macos runner 😢 
