### PR TITLE
Add entries table to bigtable docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,13 @@ Release channels have their own copy of this changelog:
   * Updated local ledger storage so that the RPC endpoint
     `getSignaturesForAddress` always returns signatures in block-inclusion order
   * RPC's `simulateTransaction` now returns `innerInstructions` as `json`/`jsonParsed` (#34313).
+  * Bigtable upload now includes entry summary data for each slot, stored in a
+    new `entries` table
 * Upgrade Notes
   * `solana-program` and `solana-sdk` default to support for Borsh v1, with
 limited backward compatibility for v0.10 and v0.9. Please upgrade to Borsh v1.
+  * Operators running their own bigtable instances need to create the `entries`
+    table before upgrading their warehouse nodes
 
 ## [1.17.0]
 * Changes

--- a/docs/src/implemented-proposals/rpc-transaction-history.md
+++ b/docs/src/implemented-proposals/rpc-transaction-history.md
@@ -106,3 +106,13 @@ This table maps a transaction signature to its confirmed block, and index within
 
 The row key is the base58-encoded transaction signature.
 The row data is a compressed `TransactionInfo` struct.
+
+### Entries Table: `entries`
+
+This table contains data about the entries in a slot.
+
+The row key is the same as a `block` row key.
+
+The row data is a compressed `Entries` struct, which is a list of entry-summary
+data, including hash, number of hashes since previous entry, number of
+transactions, and starting transaction index.

--- a/docs/src/implemented-proposals/rpc-transaction-history.md
+++ b/docs/src/implemented-proposals/rpc-transaction-history.md
@@ -109,6 +109,8 @@ The row data is a compressed `TransactionInfo` struct.
 
 ### Entries Table: `entries`
 
+> Support for the `entries` table was added in v1.18.0.
+
 This table contains data about the entries in a slot.
 
 The row key is the same as a `block` row key.


### PR DESCRIPTION
#### Problem
The BigTableUploadService now uploads entries, but this behavior isn't documented.

#### Summary of Changes
Add entries schema to "Longterm RPC Transaction History" implemented proposal
Add to changelog

solana-bigtable repo updated here: https://github.com/solana-labs/solana-bigtable/pull/17
