### PR TITLE
Use EMA to compute QUIC streamer load for staked connections

### DIFF
--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -191,11 +191,9 @@ impl StakedStreamLoadEMA {
         );
 
         // Formula is (max_load ^ 2 / current_load) * (stake / total_stake)
-        // To avoid overflow due to multiplication, we are doing the following
-        // (max_load / current_load) * (max_load / total_stake) * stake
-        let capacity_in_ema_window = ((max_load_in_ema_window as f64 / current_load as f64)
-            * (max_load_in_ema_window as f64 / total_stake as f64)
-            * stake as f64) as u128;
+        let capacity_in_ema_window =
+            (max_load_in_ema_window * max_load_in_ema_window * stake as u128)
+                / (current_load * total_stake as u128);
 
         capacity_in_ema_window * duration_ms / ema_window_ms
     }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -832,6 +832,7 @@ fn max_streams_for_connection_in_duration(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn handle_connection(
     connection: Connection,
     remote_addr: SocketAddr,

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -145,6 +145,9 @@ impl StakedStreamLoadEMA {
                 "Failed to convert EMA {} to a u64. Not updating the load EMA",
                 updated_load_ema
             );
+            self.stats
+                .stream_load_ema_overflow
+                .fetch_add(1, Ordering::Relaxed);
             return;
         };
 
@@ -209,6 +212,9 @@ impl StakedStreamLoadEMA {
                 "Failed to convert stream capacity {} to u64. Using minimum load capacity",
                 calculated_capacity
             );
+            self.stats
+                .stream_load_capacity_overflow
+                .fetch_add(1, Ordering::Relaxed);
             MIN_STREAMS_PER_THROTTLING_INTERVAL_FOR_STAKED_CONNECTION
         });
 

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -176,6 +176,7 @@ pub struct StreamStats {
     pub(crate) connection_removed: AtomicUsize,
     pub(crate) connection_remove_failed: AtomicUsize,
     pub(crate) throttled_streams: AtomicUsize,
+    pub(crate) stream_load_ema: AtomicUsize,
 }
 
 impl StreamStats {
@@ -409,6 +410,11 @@ impl StreamStats {
             (
                 "throttled_streams",
                 self.throttled_streams.swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "stream_load_ema",
+                self.stream_load_ema.load(Ordering::Relaxed),
                 i64
             ),
         );

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -177,6 +177,8 @@ pub struct StreamStats {
     pub(crate) connection_remove_failed: AtomicUsize,
     pub(crate) throttled_streams: AtomicUsize,
     pub(crate) stream_load_ema: AtomicUsize,
+    pub(crate) stream_load_ema_overflow: AtomicUsize,
+    pub(crate) stream_load_capacity_overflow: AtomicUsize,
 }
 
 impl StreamStats {
@@ -415,6 +417,16 @@ impl StreamStats {
             (
                 "stream_load_ema",
                 self.stream_load_ema.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "stream_load_ema_overflow",
+                self.stream_load_ema_overflow.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "stream_load_capacity_overflow",
+                self.stream_load_capacity_overflow.load(Ordering::Relaxed),
                 i64
             ),
         );


### PR DESCRIPTION
#### Problem
The limit for staked connection streams doesn't use current load. If the load is less, more streams can be allowed to the connections.

#### Summary of Changes
- Add support for computing load using EMA
- Update limit calculation logic to use the load
- Add/update unit tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
