### PR TITLE
ledger-tool: Move ledger output methods to output.rs

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -39,8 +39,8 @@ use {
         },
     },
     solana_sdk::{
-        clock::Slot, genesis_config::GenesisConfig, signature::Signer, signer::keypair::Keypair,
-        timing::timestamp,
+        clock::Slot, genesis_config::GenesisConfig, pubkey::Pubkey, signature::Signer,
+        signer::keypair::Keypair, timing::timestamp, transaction::VersionedTransaction,
     },
     solana_streamer::socket::SocketAddrSpace,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
@@ -550,4 +550,14 @@ pub fn open_genesis_config_by(ledger_path: &Path, matches: &ArgMatches<'_>) -> G
     let max_genesis_archive_unpacked_size =
         value_t_or_exit!(matches, "max_genesis_archive_unpacked_size", u64);
     open_genesis_config(ledger_path, max_genesis_archive_unpacked_size)
+}
+
+pub fn get_program_ids(tx: &VersionedTransaction) -> impl Iterator<Item = &Pubkey> + '_ {
+    let message = &tx.message;
+    let account_keys = message.static_account_keys();
+
+    message
+        .instructions()
+        .iter()
+        .map(|ix| ix.program_id(account_keys))
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -1,15 +1,24 @@
 use {
+    crate::ledger_utils::get_program_ids,
     chrono::{Local, TimeZone},
     serde::{Deserialize, Serialize},
-    solana_cli_output::{display::writeln_transaction, QuietDisplay, VerboseDisplay},
+    solana_cli_output::{display::writeln_transaction, OutputFormat, QuietDisplay, VerboseDisplay},
+    solana_entry::entry::Entry,
+    solana_ledger::blockstore::Blockstore,
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
+        hash::Hash,
         native_token::lamports_to_sol,
+        pubkey::Pubkey,
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedTransactionWithStatusMeta, EntrySummary, Rewards,
     },
-    std::fmt::{self, Display, Formatter, Result},
+    std::{
+        collections::HashMap,
+        fmt::{self, Display, Formatter, Result},
+        io::{stdout, Write},
+    },
 };
 
 #[derive(Serialize, Debug, Default)]
@@ -301,5 +310,240 @@ impl EncodedConfirmedBlockWithEntries {
             block_time: block.block_time,
             block_height: block.block_height,
         })
+    }
+}
+
+pub fn output_slot_rewards(blockstore: &Blockstore, slot: Slot, method: &OutputFormat) {
+    // Note: rewards are not output in JSON yet
+    if *method == OutputFormat::Display {
+        if let Ok(Some(rewards)) = blockstore.read_rewards(slot) {
+            if !rewards.is_empty() {
+                println!("  Rewards:");
+                println!(
+                    "    {:<44}  {:^15}  {:<15}  {:<20}  {:>10}",
+                    "Address", "Type", "Amount", "New Balance", "Commission",
+                );
+
+                for reward in rewards {
+                    let sign = if reward.lamports < 0 { "-" } else { "" };
+                    println!(
+                        "    {:<44}  {:^15}  {}◎{:<14.9}  ◎{:<18.9}   {}",
+                        reward.pubkey,
+                        if let Some(reward_type) = reward.reward_type {
+                            format!("{reward_type}")
+                        } else {
+                            "-".to_string()
+                        },
+                        sign,
+                        lamports_to_sol(reward.lamports.unsigned_abs()),
+                        lamports_to_sol(reward.post_balance),
+                        reward
+                            .commission
+                            .map(|commission| format!("{commission:>9}%"))
+                            .unwrap_or_else(|| "    -".to_string())
+                    );
+                }
+            }
+        }
+    }
+}
+
+pub fn output_entry(
+    blockstore: &Blockstore,
+    method: &OutputFormat,
+    slot: Slot,
+    entry_index: usize,
+    entry: Entry,
+) {
+    match method {
+        OutputFormat::Display => {
+            println!(
+                "  Entry {} - num_hashes: {}, hash: {}, transactions: {}",
+                entry_index,
+                entry.num_hashes,
+                entry.hash,
+                entry.transactions.len()
+            );
+            for (transactions_index, transaction) in entry.transactions.into_iter().enumerate() {
+                println!("    Transaction {transactions_index}");
+                let tx_signature = transaction.signatures[0];
+                let tx_status_meta = blockstore
+                    .read_transaction_status((tx_signature, slot))
+                    .unwrap_or_else(|err| {
+                        eprintln!(
+                            "Failed to read transaction status for {} at slot {}: {}",
+                            transaction.signatures[0], slot, err
+                        );
+                        None
+                    })
+                    .map(|meta| meta.into());
+
+                solana_cli_output::display::println_transaction(
+                    &transaction,
+                    tx_status_meta.as_ref(),
+                    "      ",
+                    None,
+                    None,
+                );
+            }
+        }
+        OutputFormat::Json => {
+            // Note: transaction status is not output in JSON yet
+            serde_json::to_writer(stdout(), &entry).expect("serialize entry");
+            stdout().write_all(b",\n").expect("newline");
+        }
+        _ => unreachable!(),
+    }
+}
+
+pub fn output_slot(
+    blockstore: &Blockstore,
+    slot: Slot,
+    allow_dead_slots: bool,
+    method: &OutputFormat,
+    verbose_level: u64,
+    all_program_ids: &mut HashMap<Pubkey, u64>,
+) -> std::result::Result<(), String> {
+    if blockstore.is_dead(slot) {
+        if allow_dead_slots {
+            if *method == OutputFormat::Display {
+                println!(" Slot is dead");
+            }
+        } else {
+            return Err("Dead slot".to_string());
+        }
+    }
+
+    let (entries, num_shreds, is_full) = blockstore
+        .get_slot_entries_with_shred_info(slot, 0, allow_dead_slots)
+        .map_err(|err| format!("Failed to load entries for slot {slot}: {err:?}"))?;
+
+    if *method == OutputFormat::Display {
+        if let Ok(Some(meta)) = blockstore.meta(slot) {
+            if verbose_level >= 1 {
+                println!("  {meta:?} is_full: {is_full}");
+            } else {
+                println!(
+                    "  num_shreds: {}, parent_slot: {:?}, next_slots: {:?}, num_entries: {}, \
+                     is_full: {}",
+                    num_shreds,
+                    meta.parent_slot,
+                    meta.next_slots,
+                    entries.len(),
+                    is_full,
+                );
+            }
+        }
+    }
+
+    if verbose_level >= 2 {
+        for (entry_index, entry) in entries.into_iter().enumerate() {
+            output_entry(blockstore, method, slot, entry_index, entry);
+        }
+
+        output_slot_rewards(blockstore, slot, method);
+    } else if verbose_level >= 1 {
+        let mut transactions = 0;
+        let mut num_hashes = 0;
+        let mut program_ids = HashMap::new();
+        let blockhash = if let Some(entry) = entries.last() {
+            entry.hash
+        } else {
+            Hash::default()
+        };
+
+        for entry in entries {
+            transactions += entry.transactions.len();
+            num_hashes += entry.num_hashes;
+            for transaction in entry.transactions {
+                for program_id in get_program_ids(&transaction) {
+                    *program_ids.entry(*program_id).or_insert(0) += 1;
+                }
+            }
+        }
+
+        println!("  Transactions: {transactions}, hashes: {num_hashes}, block_hash: {blockhash}",);
+        for (pubkey, count) in program_ids.iter() {
+            *all_program_ids.entry(*pubkey).or_insert(0) += count;
+        }
+        println!("  Programs:");
+        output_sorted_program_ids(program_ids);
+    }
+    Ok(())
+}
+
+pub fn output_ledger(
+    blockstore: Blockstore,
+    starting_slot: Slot,
+    ending_slot: Slot,
+    allow_dead_slots: bool,
+    method: OutputFormat,
+    num_slots: Option<Slot>,
+    verbose_level: u64,
+    only_rooted: bool,
+) {
+    let slot_iterator = blockstore
+        .slot_meta_iterator(starting_slot)
+        .unwrap_or_else(|err| {
+            eprintln!("Failed to load entries starting from slot {starting_slot}: {err:?}");
+            std::process::exit(1);
+        });
+
+    if method == OutputFormat::Json {
+        stdout().write_all(b"{\"ledger\":[\n").expect("open array");
+    }
+
+    let num_slots = num_slots.unwrap_or(Slot::MAX);
+    let mut num_printed = 0;
+    let mut all_program_ids = HashMap::new();
+    for (slot, slot_meta) in slot_iterator {
+        if only_rooted && !blockstore.is_root(slot) {
+            continue;
+        }
+        if slot > ending_slot {
+            break;
+        }
+
+        match method {
+            OutputFormat::Display => {
+                println!("Slot {} root?: {}", slot, blockstore.is_root(slot))
+            }
+            OutputFormat::Json => {
+                serde_json::to_writer(stdout(), &slot_meta).expect("serialize slot_meta");
+                stdout().write_all(b",\n").expect("newline");
+            }
+            _ => unreachable!(),
+        }
+
+        if let Err(err) = output_slot(
+            &blockstore,
+            slot,
+            allow_dead_slots,
+            &method,
+            verbose_level,
+            &mut all_program_ids,
+        ) {
+            eprintln!("{err}");
+        }
+        num_printed += 1;
+        if num_printed >= num_slots as usize {
+            break;
+        }
+    }
+
+    if method == OutputFormat::Json {
+        stdout().write_all(b"\n]}\n").expect("close array");
+    } else {
+        println!("Summary of Programs:");
+        output_sorted_program_ids(all_program_ids);
+    }
+}
+
+pub fn output_sorted_program_ids(program_ids: HashMap<Pubkey, u64>) {
+    let mut program_ids_array: Vec<_> = program_ids.into_iter().collect();
+    // Sort descending by count of program id
+    program_ids_array.sort_by(|a, b| b.1.cmp(&a.1));
+    for (program_id, count) in program_ids_array.iter() {
+        println!("{:<44}: {}", program_id.to_string(), count);
     }
 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -16,8 +16,9 @@ use {
     },
     std::{
         collections::HashMap,
-        fmt::{self, Display, Formatter, Result},
+        fmt::{self, Display, Formatter},
         io::{stdout, Write},
+        result::Result,
     },
 };
 
@@ -44,7 +45,7 @@ impl VerboseDisplay for SlotBounds<'_> {}
 impl QuietDisplay for SlotBounds<'_> {}
 
 impl Display for SlotBounds<'_> {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         if self.slots.total > 0 {
             let first = self.slots.first.unwrap();
             let last = self.slots.last.unwrap();
@@ -280,7 +281,7 @@ impl EncodedConfirmedBlockWithEntries {
     pub fn try_from(
         block: EncodedConfirmedBlock,
         entries_iterator: impl Iterator<Item = EntrySummary>,
-    ) -> std::result::Result<Self, String> {
+    ) -> Result<Self, String> {
         let mut entries = vec![];
         for (i, entry) in entries_iterator.enumerate() {
             let ending_transaction_index = entry
@@ -403,7 +404,7 @@ pub fn output_slot(
     method: &OutputFormat,
     verbose_level: u64,
     all_program_ids: &mut HashMap<Pubkey, u64>,
-) -> std::result::Result<(), String> {
+) -> Result<(), String> {
     if blockstore.is_dead(slot) {
         if allow_dead_slots {
             if *method == OutputFormat::Display {


### PR DESCRIPTION
#### Summary of Changes
We have a dedicated file for CLI output, so move the various output functions there.

There is probably work to be done to clean up these `output_*()` functions; however, I think that should be deferred for the sake of this PR as I have another PR that I would like to have consume this one.