### PR TITLE
ledger-tool: Move blockstore commands to blockstore subcommand

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -168,6 +168,10 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
             .about("Print all the dead slots in the ledger")
             .settings(&hidden)
             .arg(&starting_slot_arg),
+        SubCommand::with_name("duplicate-slots")
+            .about("Print all the duplicate slots in the ledger")
+            .settings(&hidden)
+            .arg(&starting_slot_arg),
     ]
 }
 
@@ -252,6 +256,14 @@ pub fn blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) 
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
             for slot in blockstore.dead_slots_iterator(starting_slot).unwrap() {
+                println!("{slot}");
+            }
+        }
+        ("duplicate-slots", Some(arg_matches)) => {
+            let blockstore =
+                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+            let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
+            for slot in blockstore.duplicate_slots_iterator(starting_slot).unwrap() {
                 println!("{slot}");
             }
         }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -1,0 +1,27 @@
+//! The `blockstore` subcommand
+
+use {
+    clap::{App, AppSettings, ArgMatches, SubCommand},
+    std::path::Path,
+};
+
+pub trait BlockstoreSubCommand {
+    fn blockstore_subcommand(self) -> Self;
+}
+
+impl BlockstoreSubCommand for App<'_, '_> {
+    fn blockstore_subcommand(self) -> Self {
+        self.subcommand(
+            SubCommand::with_name("blockstore")
+                .about("Commands to interact with a local Blockstore")
+                .setting(AppSettings::InferSubcommands)
+                .setting(AppSettings::SubcommandRequiredElseHelp),
+        )
+    }
+}
+
+pub fn blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+    match matches.subcommand() {
+        _ => unreachable!(),
+    }
+}

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -289,32 +289,6 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                     .required(false)
                     .help("Number of roots in the output"),
             ),
-        SubCommand::with_name("set-dead-slot")
-            .about("Mark one or more slots dead")
-            .settings(&hidden)
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .required(true)
-                    .help("Slots to mark dead"),
-            ),
-        SubCommand::with_name("remove-dead-slot")
-            .about("Remove the dead flag for a slot")
-            .settings(&hidden)
-            .arg(
-                Arg::with_name("slots")
-                    .index(1)
-                    .value_name("SLOTS")
-                    .validator(is_slot)
-                    .takes_value(true)
-                    .multiple(true)
-                    .required(true)
-                    .help("Slots to mark as not dead"),
-            ),
         SubCommand::with_name("print-file-metadata")
             .about(
                 "Print the metadata of the specified ledger-store file. If no file name is \
@@ -330,6 +304,32 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
                         "The ledger file name (e.g. 011080.sst.) If no file name is \
                          specified, it will print the metadata of all ledger files.",
                     ),
+            ),
+        SubCommand::with_name("remove-dead-slot")
+            .about("Remove the dead flag for a slot")
+            .settings(&hidden)
+            .arg(
+                Arg::with_name("slots")
+                    .index(1)
+                    .value_name("SLOTS")
+                    .validator(is_slot)
+                    .takes_value(true)
+                    .multiple(true)
+                    .required(true)
+                    .help("Slots to mark as not dead"),
+            ),
+        SubCommand::with_name("set-dead-slot")
+            .about("Mark one or more slots dead")
+            .settings(&hidden)
+            .arg(
+                Arg::with_name("slots")
+                    .index(1)
+                    .value_name("SLOTS")
+                    .validator(is_slot)
+                    .takes_value(true)
+                    .multiple(true)
+                    .required(true)
+                    .help("Slots to mark dead"),
             ),
     ]
 }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -1,9 +1,113 @@
 //! The `blockstore` subcommand
 
 use {
+    crate::ledger_path::canonicalize_ledger_path,
     clap::{App, AppSettings, ArgMatches, SubCommand},
+    serde_json::json,
+    solana_ledger::{
+        blockstore_db::{self, Database},
+        blockstore_options::AccessType,
+    },
     std::path::Path,
 };
+
+fn analyze_column<
+    C: solana_ledger::blockstore_db::Column + solana_ledger::blockstore_db::ColumnName,
+>(
+    db: &Database,
+    name: &str,
+) {
+    let mut key_len: u64 = 0;
+    let mut key_tot: u64 = 0;
+    let mut val_hist = histogram::Histogram::new();
+    let mut val_tot: u64 = 0;
+    let mut row_hist = histogram::Histogram::new();
+    for (key, val) in db.iter::<C>(blockstore_db::IteratorMode::Start).unwrap() {
+        // Key length is fixed, only need to calculate it once
+        if key_len == 0 {
+            key_len = C::key(key).len() as u64;
+        }
+        let val_len = val.len() as u64;
+
+        key_tot += key_len;
+        val_hist.increment(val_len).unwrap();
+        val_tot += val_len;
+
+        row_hist.increment(key_len + val_len).unwrap();
+    }
+
+    let json_result = if val_hist.entries() > 0 {
+        json!({
+            "column":name,
+            "entries":val_hist.entries(),
+            "key_stats":{
+                "max":key_len,
+                "total_bytes":key_tot,
+            },
+            "val_stats":{
+                "p50":val_hist.percentile(50.0).unwrap(),
+                "p90":val_hist.percentile(90.0).unwrap(),
+                "p99":val_hist.percentile(99.0).unwrap(),
+                "p999":val_hist.percentile(99.9).unwrap(),
+                "min":val_hist.minimum().unwrap(),
+                "max":val_hist.maximum().unwrap(),
+                "stddev":val_hist.stddev().unwrap(),
+                "total_bytes":val_tot,
+            },
+            "row_stats":{
+                "p50":row_hist.percentile(50.0).unwrap(),
+                "p90":row_hist.percentile(90.0).unwrap(),
+                "p99":row_hist.percentile(99.0).unwrap(),
+                "p999":row_hist.percentile(99.9).unwrap(),
+                "min":row_hist.minimum().unwrap(),
+                "max":row_hist.maximum().unwrap(),
+                "stddev":row_hist.stddev().unwrap(),
+                "total_bytes":key_tot + val_tot,
+            },
+        })
+    } else {
+        json!({
+        "column":name,
+        "entries":val_hist.entries(),
+        "key_stats":{
+            "max":key_len,
+            "total_bytes":0,
+        },
+        "val_stats":{
+            "total_bytes":0,
+        },
+        "row_stats":{
+            "total_bytes":0,
+        },
+        })
+    };
+
+    println!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+}
+
+fn analyze_storage(database: &Database) {
+    use solana_ledger::blockstore_db::columns::*;
+    analyze_column::<SlotMeta>(database, "SlotMeta");
+    analyze_column::<Orphans>(database, "Orphans");
+    analyze_column::<DeadSlots>(database, "DeadSlots");
+    analyze_column::<DuplicateSlots>(database, "DuplicateSlots");
+    analyze_column::<ErasureMeta>(database, "ErasureMeta");
+    analyze_column::<BankHash>(database, "BankHash");
+    analyze_column::<Root>(database, "Root");
+    analyze_column::<Index>(database, "Index");
+    analyze_column::<ShredData>(database, "ShredData");
+    analyze_column::<ShredCode>(database, "ShredCode");
+    analyze_column::<TransactionStatus>(database, "TransactionStatus");
+    analyze_column::<AddressSignatures>(database, "AddressSignatures");
+    analyze_column::<TransactionMemos>(database, "TransactionMemos");
+    analyze_column::<TransactionStatusIndex>(database, "TransactionStatusIndex");
+    analyze_column::<Rewards>(database, "Rewards");
+    analyze_column::<Blocktime>(database, "Blocktime");
+    analyze_column::<PerfSamples>(database, "PerfSamples");
+    analyze_column::<BlockHeight>(database, "BlockHeight");
+    analyze_column::<ProgramCosts>(database, "ProgramCosts");
+    analyze_column::<OptimisticSlots>(database, "OptimisticSlots");
+}
 
 pub trait BlockstoreSubCommand {
     fn blockstore_subcommand(self) -> Self;
@@ -15,13 +119,33 @@ impl BlockstoreSubCommand for App<'_, '_> {
             SubCommand::with_name("blockstore")
                 .about("Commands to interact with a local Blockstore")
                 .setting(AppSettings::InferSubcommands)
-                .setting(AppSettings::SubcommandRequiredElseHelp),
+                .setting(AppSettings::SubcommandRequiredElseHelp)
+                .subcommands(blockstore_subcommands(false)),
         )
     }
 }
 
+pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
+    let hidden = if hidden {
+        vec![AppSettings::Hidden]
+    } else {
+        vec![]
+    };
+
+    vec![SubCommand::with_name("analyze-storage")
+        .about("Output statistics in JSON format about all column families in the ledger rocksdb")
+        .settings(&hidden)]
+}
+
 pub fn blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+    let ledger_path = canonicalize_ledger_path(ledger_path);
+
     match matches.subcommand() {
+        ("analyze-storage", Some(arg_matches)) => {
+            analyze_storage(
+                &crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary).db(),
+            );
+        }
         _ => unreachable!(),
     }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1122,11 +1122,6 @@ fn main() {
                 .arg(&allow_dead_slots_arg),
         )
         .subcommand(
-            SubCommand::with_name("dead-slots")
-                .arg(&starting_slot_arg)
-                .about("Print all the dead slots in the ledger"),
-        )
-        .subcommand(
             SubCommand::with_name("duplicate-slots")
                 .arg(&starting_slot_arg)
                 .about("Print all the duplicate slots in the ledger"),
@@ -1914,7 +1909,7 @@ fn main() {
         ("program", Some(arg_matches)) => program(&ledger_path, arg_matches),
         // This match case provides legacy support for commands that were previously top level
         // subcommands of the binary, but have been moved under the blockstore subcommand.
-        ("analyze-storage", Some(_)) | ("bounds", Some(_)) => {
+        ("analyze-storage", Some(_)) | ("bounds", Some(_)) | ("dead-slots", Some(_)) => {
             blockstore_process_command(&ledger_path, &matches)
         }
         _ => {
@@ -2157,14 +2152,6 @@ fn main() {
                         std::u64::MAX,
                         true,
                     );
-                }
-                ("dead-slots", Some(arg_matches)) => {
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-                    let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
-                    for slot in blockstore.dead_slots_iterator(starting_slot).unwrap() {
-                        println!("{slot}");
-                    }
                 }
                 ("duplicate-slots", Some(arg_matches)) => {
                     let blockstore =

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    crate::{args::*, bigtable::*, ledger_path::*, ledger_utils::*, output::*, program::*},
+    crate::{
+        args::*, bigtable::*, blockstore::*, ledger_path::*, ledger_utils::*, output::*, program::*,
+    },
     chrono::{DateTime, Utc},
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
@@ -98,6 +100,7 @@ use {
 
 mod args;
 mod bigtable;
+mod blockstore;
 mod ledger_path;
 mod ledger_utils;
 mod output;
@@ -1165,6 +1168,7 @@ fn main() {
                 .help("Show additional information where supported"),
         )
         .bigtable_subcommand()
+        .blockstore_subcommand()
         .subcommand(
             SubCommand::with_name("print")
                 .about("Print the ledger")
@@ -2020,6 +2024,7 @@ fn main() {
 
     match matches.subcommand() {
         ("bigtable", Some(arg_matches)) => bigtable_process_command(&ledger_path, arg_matches),
+        ("blockstore", Some(arg_matches)) => blockstore_process_command(&ledger_path, arg_matches),
         ("program", Some(arg_matches)) => program(&ledger_path, arg_matches),
         _ => {
             let ledger_path = canonicalize_ledger_path(&ledger_path);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
     crate::{args::*, bigtable::*, blockstore::*, ledger_path::*, ledger_utils::*, program::*},
-    chrono::{DateTime, Utc},
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
@@ -56,7 +55,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         account_utils::StateMut,
-        clock::{Epoch, Slot, UnixTimestamp},
+        clock::{Epoch, Slot},
         feature::{self, Feature},
         feature_set::{self, FeatureSet},
         genesis_config::ClusterType,
@@ -88,7 +87,6 @@ use {
             atomic::{AtomicBool, Ordering},
             Arc, RwLock,
         },
-        time::{Duration, UNIX_EPOCH},
     },
 };
 
@@ -540,73 +538,6 @@ fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> 
     Ok(())
 }
 
-/// Returns true if the supplied slot contains any nonvote transactions
-fn slot_contains_nonvote_tx(blockstore: &Blockstore, slot: Slot) -> bool {
-    let (entries, _, _) = blockstore
-        .get_slot_entries_with_shred_info(slot, 0, false)
-        .expect("Failed to get slot entries");
-    let contains_nonvote = entries
-        .iter()
-        .flat_map(|entry| entry.transactions.iter())
-        .flat_map(get_program_ids)
-        .any(|program_id| *program_id != solana_vote_program::id());
-    contains_nonvote
-}
-
-type OptimisticSlotInfo = (Slot, Option<(Hash, UnixTimestamp)>, bool);
-
-/// Return the latest `num_slots` optimistically confirmed slots, including
-/// ancestors of optimistically confirmed slots that may not have been marked
-/// as optimistically confirmed themselves.
-fn get_latest_optimistic_slots(
-    blockstore: &Blockstore,
-    num_slots: usize,
-    exclude_vote_only_slots: bool,
-) -> Vec<OptimisticSlotInfo> {
-    // Consider a chain X -> Y -> Z where X and Z have been optimistically
-    // confirmed. Given that Y is an ancestor of Z, Y can implicitly be
-    // considered as optimistically confirmed. However, there isn't an explicit
-    // guarantee that Y will be marked as optimistically confirmed in the
-    // blockstore.
-    //
-    // Because retrieving optimistically confirmed slots is an important part
-    // of cluster restarts, exercise caution in this function and manually walk
-    // the ancestors of the latest optimistically confirmed slot instead of
-    // solely relying on the contents of the optimistically confirmed column.
-    let Some(latest_slot) = blockstore
-        .get_latest_optimistic_slots(1)
-        .expect("get_latest_optimistic_slots() failed")
-        .pop()
-    else {
-        eprintln!("Blockstore does not contain any optimistically confirmed slots");
-        return vec![];
-    };
-    let latest_slot = latest_slot.0;
-
-    let slot_iter = AncestorIterator::new_inclusive(latest_slot, blockstore).map(|slot| {
-        let contains_nonvote_tx = slot_contains_nonvote_tx(blockstore, slot);
-        let hash_and_timestamp_opt = blockstore
-            .get_optimistic_slot(slot)
-            .expect("get_optimistic_slot() failed");
-        if hash_and_timestamp_opt.is_none() {
-            warn!(
-                "Slot {slot} is an ancestor of latest optimistically confirmed slot \
-                 {latest_slot}, but was not marked as optimistically confirmed in blockstore."
-            );
-        }
-        (slot, hash_and_timestamp_opt, contains_nonvote_tx)
-    });
-
-    if exclude_vote_only_slots {
-        slot_iter
-            .filter(|(_, _, contains_nonvote)| *contains_nonvote)
-            .take(num_slots)
-            .collect()
-    } else {
-        slot_iter.take(num_slots).collect()
-    }
-}
-
 /// Finds the accounts needed to replay slots `snapshot_slot` to `ending_slot`.
 /// Removes all other accounts from accounts_db, and updates the accounts hash
 /// and capitalization. This is used by the --minimize option in create-snapshot
@@ -661,7 +592,6 @@ fn main() {
         unsafe { signal_hook::low_level::register(signal_hook::consts::SIGUSR1, || {}) }.unwrap();
     }
 
-    const DEFAULT_LATEST_OPTIMISTIC_SLOTS_COUNT: &str = "1";
     // Use std::usize::MAX for DEFAULT_MAX_*_SNAPSHOTS_TO_RETAIN such that
     // ledger-tool commands won't accidentally remove any snapshots by default
     const DEFAULT_MAX_FULL_SNAPSHOT_ARCHIVES_TO_RETAIN: usize = std::usize::MAX;
@@ -1580,28 +1510,6 @@ fn main() {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("latest-optimistic-slots")
-                .about(
-                    "Output up to the most recent <num-slots> optimistic slots with their hashes \
-                     and timestamps.",
-                )
-                .arg(
-                    Arg::with_name("num_slots")
-                        .long("num-slots")
-                        .value_name("NUM")
-                        .takes_value(true)
-                        .default_value(DEFAULT_LATEST_OPTIMISTIC_SLOTS_COUNT)
-                        .required(false)
-                        .help("Number of slots in the output"),
-                )
-                .arg(
-                    Arg::with_name("exclude_vote_only_slots")
-                        .long("exclude-vote-only-slots")
-                        .required(false)
-                        .help("Exclude slots that contain only votes from output"),
-                ),
-        )
-        .subcommand(
             SubCommand::with_name("compute-slot-cost")
                 .about(
                     "runs cost_model over the block at the given slots, computes how expensive a \
@@ -1647,6 +1555,7 @@ fn main() {
         | ("copy", Some(_))
         | ("dead-slots", Some(_))
         | ("duplicate-slots", Some(_))
+        | ("latest-optimistic-slots", Some(_))
         | ("list-roots", Some(_))
         | ("print-file-metadata", Some(_))
         | ("purge", Some(_))
@@ -3149,40 +3058,6 @@ fn main() {
                         println!("Capitalization: {}", Sol(bank.capitalization()));
                     }
                 }
-                ("latest-optimistic-slots", Some(arg_matches)) => {
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-                    let num_slots = value_t_or_exit!(arg_matches, "num_slots", usize);
-                    let exclude_vote_only_slots = arg_matches.is_present("exclude_vote_only_slots");
-                    let slots = get_latest_optimistic_slots(
-                        &blockstore,
-                        num_slots,
-                        exclude_vote_only_slots,
-                    );
-
-                    println!(
-                        "{:>20} {:>44} {:>32} {:>13}",
-                        "Slot", "Hash", "Timestamp", "Vote Only?"
-                    );
-                    for (slot, hash_and_timestamp_opt, contains_nonvote) in slots.iter() {
-                        let (time_str, hash_str) =
-                            if let Some((hash, timestamp)) = hash_and_timestamp_opt {
-                                let secs: u64 = (timestamp / 1_000) as u64;
-                                let nanos: u32 = ((timestamp % 1_000) * 1_000_000) as u32;
-                                let t = UNIX_EPOCH + Duration::new(secs, nanos);
-                                let datetime: DateTime<Utc> = t.into();
-
-                                (datetime.to_rfc3339(), format!("{hash}"))
-                            } else {
-                                let unknown = "Unknown";
-                                (String::from(unknown), String::from(unknown))
-                            };
-                        println!(
-                            "{:>20} {:>44} {:>32} {:>13}",
-                            slot, &hash_str, &time_str, !contains_nonvote
-                        );
-                    }
-                }
                 ("compute-slot-cost", Some(arg_matches)) => {
                     let blockstore =
                         open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
@@ -3212,44 +3087,4 @@ fn main() {
     };
     measure_total_execution_time.stop();
     info!("{}", measure_total_execution_time);
-}
-
-#[cfg(test)]
-pub mod tests {
-    use {
-        super::*,
-        solana_ledger::{blockstore::make_many_slot_entries, get_tmp_ledger_path_auto_delete},
-    };
-
-    #[test]
-    fn test_latest_optimistic_ancestors() {
-        let ledger_path = get_tmp_ledger_path_auto_delete!();
-        let blockstore = Blockstore::open(ledger_path.path()).unwrap();
-
-        // Insert 5 slots into blockstore
-        let start_slot = 0;
-        let num_slots = 5;
-        let entries_per_shred = 5;
-        let (shreds, _) = make_many_slot_entries(start_slot, num_slots, entries_per_shred);
-        blockstore.insert_shreds(shreds, None, false).unwrap();
-
-        // Mark even shreds as optimistically confirmed
-        (0..num_slots).step_by(2).for_each(|slot| {
-            blockstore
-                .insert_optimistic_slot(slot, &Hash::default(), UnixTimestamp::default())
-                .unwrap();
-        });
-
-        let exclude_vote_only_slots = false;
-        let optimistic_slots: Vec<_> =
-            get_latest_optimistic_slots(&blockstore, num_slots as usize, exclude_vote_only_slots)
-                .iter()
-                .map(|(slot, _, _)| *slot)
-                .collect();
-
-        // Should see all slots here since they're all chained, despite only evens getting marked
-        // get_latest_optimistic_slots() returns slots in descending order so use .rev()
-        let expected: Vec<_> = (start_slot..num_slots).rev().collect();
-        assert_eq!(optimistic_slots, expected);
-    }
 }

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1122,20 +1122,6 @@ fn main() {
                 .arg(&allow_dead_slots_arg),
         )
         .subcommand(
-            SubCommand::with_name("remove-dead-slot")
-                .about("Remove the dead flag for a slot")
-                .arg(
-                    Arg::with_name("slots")
-                        .index(1)
-                        .value_name("SLOTS")
-                        .validator(is_slot)
-                        .takes_value(true)
-                        .multiple(true)
-                        .required(true)
-                        .help("Slots to mark as not dead"),
-                ),
-        )
-        .subcommand(
             SubCommand::with_name("genesis")
                 .about("Prints the ledger's genesis config")
                 .arg(&max_genesis_archive_unpacked_size_arg)
@@ -1894,6 +1880,7 @@ fn main() {
         | ("bounds", Some(_))
         | ("dead-slots", Some(_))
         | ("duplicate-slots", Some(_))
+        | ("remove-dead-slot", Some(_))
         | ("set-dead-slot", Some(_)) => blockstore_process_command(&ledger_path, &matches),
         _ => {
             let ledger_path = canonicalize_ledger_path(&ledger_path);
@@ -2135,19 +2122,6 @@ fn main() {
                         std::u64::MAX,
                         true,
                     );
-                }
-                ("remove-dead-slot", Some(arg_matches)) => {
-                    let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Primary);
-                    for slot in slots {
-                        match blockstore.remove_dead_slot(slot) {
-                            Ok(_) => println!("Slot {slot} not longer marked dead"),
-                            Err(err) => {
-                                eprintln!("Failed to remove dead flag for slot {slot}, {err:?}")
-                            }
-                        }
-                    }
                 }
                 ("parse_full_frozen", Some(arg_matches)) => {
                     let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -597,12 +597,6 @@ fn main() {
 
     solana_logger::setup_with_default("solana=info");
 
-    let starting_slot_arg = Arg::with_name("starting_slot")
-        .long("starting-slot")
-        .value_name("SLOT")
-        .takes_value(true)
-        .default_value("0")
-        .help("Start at this slot");
     let no_snapshot_arg = Arg::with_name("no_snapshot")
         .long("no-snapshot")
         .takes_value(false)
@@ -989,12 +983,6 @@ fn main() {
                 .arg(&accountsdb_verify_refcounts)
                 .arg(&accounts_db_skip_initial_hash_calc_arg)
                 .arg(&accounts_db_test_skip_rewrites_but_include_in_bank_hash),
-        )
-        .subcommand(
-            SubCommand::with_name("json")
-                .about("Print the ledger in JSON format")
-                .arg(&starting_slot_arg)
-                .arg(&allow_dead_slots_arg),
         )
         .subcommand(
             SubCommand::with_name("verify")
@@ -1496,6 +1484,7 @@ fn main() {
         | ("copy", Some(_))
         | ("dead-slots", Some(_))
         | ("duplicate-slots", Some(_))
+        | ("json", Some(_))
         | ("latest-optimistic-slots", Some(_))
         | ("list-roots", Some(_))
         | ("parse_full_frozen", Some(_))
@@ -1620,20 +1609,6 @@ fn main() {
                         incremental_snapshot_archive_path,
                     );
                     println!("{}", &bank_forks.read().unwrap().working_bank().hash());
-                }
-                ("json", Some(arg_matches)) => {
-                    let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
-                    let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
-                    output_ledger(
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary),
-                        starting_slot,
-                        Slot::MAX,
-                        allow_dead_slots,
-                        OutputFormat::Json,
-                        None,
-                        std::u64::MAX,
-                        true,
-                    );
                 }
                 ("verify", Some(arg_matches)) => {
                     let exit_signal = Arc::new(AtomicBool::new(false));

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -603,11 +603,6 @@ fn main() {
         .takes_value(true)
         .default_value("0")
         .help("Start at this slot");
-    let ending_slot_arg = Arg::with_name("ending_slot")
-        .long("ending-slot")
-        .value_name("SLOT")
-        .takes_value(true)
-        .help("The last slot to iterate to");
     let no_snapshot_arg = Arg::with_name("no_snapshot")
         .long("no-snapshot")
         .takes_value(false)
@@ -927,27 +922,6 @@ fn main() {
         // For the sake of legacy support, also directly add the blockstore commands here so that
         // these subcommands can continue to be called from the top level of the binary.
         .subcommands(blockstore_subcommands(true))
-        .subcommand(
-            SubCommand::with_name("print")
-                .about("Print the ledger")
-                .arg(&starting_slot_arg)
-                .arg(&allow_dead_slots_arg)
-                .arg(&ending_slot_arg)
-                .arg(
-                    Arg::with_name("num_slots")
-                        .long("num-slots")
-                        .value_name("SLOT")
-                        .validator(is_slot)
-                        .takes_value(true)
-                        .help("Number of slots to print"),
-                )
-                .arg(
-                    Arg::with_name("only_rooted")
-                        .long("only-rooted")
-                        .takes_value(false)
-                        .help("Only print root slots"),
-                ),
-        )
         .subcommand(
             SubCommand::with_name("genesis")
                 .about("Prints the ledger's genesis config")
@@ -1525,6 +1499,7 @@ fn main() {
         | ("latest-optimistic-slots", Some(_))
         | ("list-roots", Some(_))
         | ("parse_full_frozen", Some(_))
+        | ("print", Some(_))
         | ("print-file-metadata", Some(_))
         | ("purge", Some(_))
         | ("remove-dead-slot", Some(_))
@@ -1536,24 +1511,6 @@ fn main() {
             let ledger_path = canonicalize_ledger_path(&ledger_path);
 
             match matches.subcommand() {
-                ("print", Some(arg_matches)) => {
-                    let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
-                    let ending_slot =
-                        value_t!(arg_matches, "ending_slot", Slot).unwrap_or(Slot::MAX);
-                    let num_slots = value_t!(arg_matches, "num_slots", Slot).ok();
-                    let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
-                    let only_rooted = arg_matches.is_present("only_rooted");
-                    output_ledger(
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary),
-                        starting_slot,
-                        ending_slot,
-                        allow_dead_slots,
-                        OutputFormat::Display,
-                        num_slots,
-                        verbose_level,
-                        only_rooted,
-                    );
-                }
                 ("genesis", Some(arg_matches)) => {
                     let genesis_config = open_genesis_config_by(&ledger_path, arg_matches);
                     let print_accounts = arg_matches.is_present("accounts");

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1122,20 +1122,6 @@ fn main() {
                 .arg(&allow_dead_slots_arg),
         )
         .subcommand(
-            SubCommand::with_name("set-dead-slot")
-                .about("Mark one or more slots dead")
-                .arg(
-                    Arg::with_name("slots")
-                        .index(1)
-                        .value_name("SLOTS")
-                        .validator(is_slot)
-                        .takes_value(true)
-                        .multiple(true)
-                        .required(true)
-                        .help("Slots to mark dead"),
-                ),
-        )
-        .subcommand(
             SubCommand::with_name("remove-dead-slot")
                 .about("Remove the dead flag for a slot")
                 .arg(
@@ -1907,7 +1893,8 @@ fn main() {
         ("analyze-storage", Some(_))
         | ("bounds", Some(_))
         | ("dead-slots", Some(_))
-        | ("duplicate-slots", Some(_)) => blockstore_process_command(&ledger_path, &matches),
+        | ("duplicate-slots", Some(_))
+        | ("set-dead-slot", Some(_)) => blockstore_process_command(&ledger_path, &matches),
         _ => {
             let ledger_path = canonicalize_ledger_path(&ledger_path);
 
@@ -2148,17 +2135,6 @@ fn main() {
                         std::u64::MAX,
                         true,
                     );
-                }
-                ("set-dead-slot", Some(arg_matches)) => {
-                    let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Primary);
-                    for slot in slots {
-                        match blockstore.set_dead_slot(slot) {
-                            Ok(_) => println!("Slot {slot} dead"),
-                            Err(err) => eprintln!("Failed to set slot {slot} dead slot: {err:?}"),
-                        }
-                    }
                 }
                 ("remove-dead-slot", Some(arg_matches)) => {
                     let slots = values_t_or_exit!(arg_matches, "slots", Slot);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -949,21 +949,6 @@ fn main() {
                 ),
         )
         .subcommand(
-            SubCommand::with_name("slot")
-                .about("Print the contents of one or more slots")
-                .arg(
-                    Arg::with_name("slots")
-                        .index(1)
-                        .value_name("SLOTS")
-                        .validator(is_slot)
-                        .takes_value(true)
-                        .multiple(true)
-                        .required(true)
-                        .help("Slots to print"),
-                )
-                .arg(&allow_dead_slots_arg),
-        )
-        .subcommand(
             SubCommand::with_name("genesis")
                 .about("Prints the ledger's genesis config")
                 .arg(&max_genesis_archive_unpacked_size_arg)
@@ -1545,7 +1530,8 @@ fn main() {
         | ("remove-dead-slot", Some(_))
         | ("repair-roots", Some(_))
         | ("set-dead-slot", Some(_))
-        | ("shred-meta", Some(_)) => blockstore_process_command(&ledger_path, &matches),
+        | ("shred-meta", Some(_))
+        | ("slot", Some(_)) => blockstore_process_command(&ledger_path, &matches),
         _ => {
             let ledger_path = canonicalize_ledger_path(&ledger_path);
 
@@ -1677,25 +1663,6 @@ fn main() {
                         incremental_snapshot_archive_path,
                     );
                     println!("{}", &bank_forks.read().unwrap().working_bank().hash());
-                }
-                ("slot", Some(arg_matches)) => {
-                    let slots = values_t_or_exit!(arg_matches, "slots", Slot);
-                    let allow_dead_slots = arg_matches.is_present("allow_dead_slots");
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-                    for slot in slots {
-                        println!("Slot {slot}");
-                        if let Err(err) = output_slot(
-                            &blockstore,
-                            slot,
-                            allow_dead_slots,
-                            &OutputFormat::Display,
-                            verbose_level,
-                            &mut HashMap::new(),
-                        ) {
-                            eprintln!("{err}");
-                        }
-                    }
                 }
                 ("json", Some(arg_matches)) => {
                     let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -37,7 +37,6 @@ use {
     solana_ledger::{
         ancestor_iterator::AncestorIterator,
         blockstore::{create_new_ledger, Blockstore, PurgeType},
-        blockstore_db::{columns as cf, Column, ColumnName},
         blockstore_options::{AccessType, LedgerColumnOptions, BLOCKSTORE_DIRECTORY_ROCKS_FIFO},
         blockstore_processor::ProcessOptions,
         shred::Shred,
@@ -481,74 +480,6 @@ fn graph_forks(bank_forks: &BankForks, config: &GraphConfig) -> String {
 
     dot.push("}".to_string());
     dot.join("\n")
-}
-
-fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
-    match column_name {
-        cf::SlotMeta::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
-        cf::Orphans::NAME => Some(cf::Orphans::slot(cf::Orphans::index(key))),
-        cf::DeadSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
-        cf::DuplicateSlots::NAME => Some(cf::SlotMeta::slot(cf::SlotMeta::index(key))),
-        cf::ErasureMeta::NAME => Some(cf::ErasureMeta::slot(cf::ErasureMeta::index(key))),
-        cf::BankHash::NAME => Some(cf::BankHash::slot(cf::BankHash::index(key))),
-        cf::Root::NAME => Some(cf::Root::slot(cf::Root::index(key))),
-        cf::Index::NAME => Some(cf::Index::slot(cf::Index::index(key))),
-        cf::ShredData::NAME => Some(cf::ShredData::slot(cf::ShredData::index(key))),
-        cf::ShredCode::NAME => Some(cf::ShredCode::slot(cf::ShredCode::index(key))),
-        cf::TransactionStatus::NAME => Some(cf::TransactionStatus::slot(
-            cf::TransactionStatus::index(key),
-        )),
-        cf::AddressSignatures::NAME => Some(cf::AddressSignatures::slot(
-            cf::AddressSignatures::index(key),
-        )),
-        cf::TransactionMemos::NAME => None, // does not implement slot()
-        cf::TransactionStatusIndex::NAME => None, // does not implement slot()
-        cf::Rewards::NAME => Some(cf::Rewards::slot(cf::Rewards::index(key))),
-        cf::Blocktime::NAME => Some(cf::Blocktime::slot(cf::Blocktime::index(key))),
-        cf::PerfSamples::NAME => Some(cf::PerfSamples::slot(cf::PerfSamples::index(key))),
-        cf::BlockHeight::NAME => Some(cf::BlockHeight::slot(cf::BlockHeight::index(key))),
-        cf::ProgramCosts::NAME => None, // does not implement slot()
-        cf::OptimisticSlots::NAME => {
-            Some(cf::OptimisticSlots::slot(cf::OptimisticSlots::index(key)))
-        }
-        &_ => None,
-    }
-}
-
-fn print_blockstore_file_metadata(
-    blockstore: &Blockstore,
-    file_name: &Option<&str>,
-) -> Result<(), String> {
-    let live_files = blockstore
-        .live_files_metadata()
-        .map_err(|err| format!("{err:?}"))?;
-
-    // All files under live_files_metadata are prefixed with "/".
-    let sst_file_name = file_name.as_ref().map(|name| format!("/{name}"));
-    for file in live_files {
-        if sst_file_name.is_none() || file.name.eq(sst_file_name.as_ref().unwrap()) {
-            println!(
-                "[{}] cf_name: {}, level: {}, start_slot: {:?}, end_slot: {:?}, size: {}, \
-                 num_entries: {}",
-                file.name,
-                file.column_family_name,
-                file.level,
-                raw_key_to_slot(&file.start_key.unwrap(), &file.column_family_name),
-                raw_key_to_slot(&file.end_key.unwrap(), &file.column_family_name),
-                file.size,
-                file.num_entries,
-            );
-            if sst_file_name.is_some() {
-                return Ok(());
-            }
-        }
-    }
-    if sst_file_name.is_some() {
-        return Err(format!(
-            "Failed to find or load the metadata of the specified file {file_name:?}"
-        ));
-    }
-    Ok(())
 }
 
 fn compute_slot_cost(blockstore: &Blockstore, slot: Slot) -> Result<(), String> {
@@ -1837,23 +1768,6 @@ fn main() {
                         ),
                 ),
         )
-        .subcommand(
-            SubCommand::with_name("print-file-metadata")
-                .about(
-                    "Print the metadata of the specified ledger-store file. If no file name is \
-                     specified, it will print the metadata of all ledger files.",
-                )
-                .arg(
-                    Arg::with_name("file_name")
-                        .long("file-name")
-                        .takes_value(true)
-                        .value_name("SST_FILE_NAME")
-                        .help(
-                            "The ledger file name (e.g. 011080.sst.) If no file name is \
-                             specified, it will print the metadata of all ledger files.",
-                        ),
-                ),
-        )
         .program_subcommand()
         .get_matches();
 
@@ -1880,6 +1794,7 @@ fn main() {
         | ("bounds", Some(_))
         | ("dead-slots", Some(_))
         | ("duplicate-slots", Some(_))
+        | ("print-file-metadata", Some(_))
         | ("remove-dead-slot", Some(_))
         | ("set-dead-slot", Some(_)) => blockstore_process_command(&ledger_path, &matches),
         _ => {
@@ -3656,14 +3571,6 @@ fn main() {
                         if let Err(err) = compute_slot_cost(&blockstore, slot) {
                             eprintln!("{err}");
                         }
-                    }
-                }
-                ("print-file-metadata", Some(arg_matches)) => {
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-                    let sst_file_name = arg_matches.value_of("file_name");
-                    if let Err(err) = print_blockstore_file_metadata(&blockstore, &sst_file_name) {
-                        eprintln!("{err}");
                     }
                 }
                 ("", _) => {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -57,7 +57,6 @@ use {
         feature::{self, Feature},
         feature_set::{self, FeatureSet},
         genesis_config::ClusterType,
-        hash::Hash,
         inflation::Inflation,
         native_token::{lamports_to_sol, sol_to_lamports, Sol},
         pubkey::Pubkey,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1122,11 +1122,6 @@ fn main() {
                 .arg(&allow_dead_slots_arg),
         )
         .subcommand(
-            SubCommand::with_name("duplicate-slots")
-                .arg(&starting_slot_arg)
-                .about("Print all the duplicate slots in the ledger"),
-        )
-        .subcommand(
             SubCommand::with_name("set-dead-slot")
                 .about("Mark one or more slots dead")
                 .arg(
@@ -1909,9 +1904,10 @@ fn main() {
         ("program", Some(arg_matches)) => program(&ledger_path, arg_matches),
         // This match case provides legacy support for commands that were previously top level
         // subcommands of the binary, but have been moved under the blockstore subcommand.
-        ("analyze-storage", Some(_)) | ("bounds", Some(_)) | ("dead-slots", Some(_)) => {
-            blockstore_process_command(&ledger_path, &matches)
-        }
+        ("analyze-storage", Some(_))
+        | ("bounds", Some(_))
+        | ("dead-slots", Some(_))
+        | ("duplicate-slots", Some(_)) => blockstore_process_command(&ledger_path, &matches),
         _ => {
             let ledger_path = canonicalize_ledger_path(&ledger_path);
 
@@ -2152,14 +2148,6 @@ fn main() {
                         std::u64::MAX,
                         true,
                     );
-                }
-                ("duplicate-slots", Some(arg_matches)) => {
-                    let blockstore =
-                        open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-                    let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);
-                    for slot in blockstore.duplicate_slots_iterator(starting_slot).unwrap() {
-                        println!("{slot}");
-                    }
                 }
                 ("set-dead-slot", Some(arg_matches)) => {
                     let slots = values_t_or_exit!(arg_matches, "slots", Slot);


### PR DESCRIPTION
#### Problem
`solana-ledger-tool` is a bit of a kitchen sink, and has upwards of 30 commands at the top level (ie 30 commands that can be invoked via `solana-ledger-tool <SOME_COMMAND>`). UI Aside, the contents of `ledger-tool/src/main.rs` are somewhat cluttered.

#### Summary of Changes
To reduce the clutter, this PR:
- Introduces a new blockstore subcommand, and moves all commands that only operate on the blockstore to this new subcommand.
    - As an example, `solana-ledger-tool slot` is now `solana-ledger-tool blockstore slot`
- Supports the old command style (`solana-ledger-tool slot`), but does not display those commands in the top level `--help` command.
    - This steers new users towards using new calling format while avoiding breaking the old calling format for people who have muscle memory with those commands

With this PR, here is the subcommand section of the output for running `solana-ledger-tool help`:
```
USAGE:
    solana-ledger-tool [FLAGS] [OPTIONS] <SUBCOMMAND>
...
SUBCOMMANDS:
    accounts                   Print account stats and contents after processing the ledger
    bank-hash                  Prints the hash of the working bank after reading the ledger
    bigtable                   Ledger data on a BigTable instance
    blockstore                 Commands to interact with a local Blockstore
    capitalization             Print capitalization (aka, total supply) while checksumming it
    compute-slot-cost          runs cost_model over the block at the given slots, computes how expensive a block was
                               based on cost_model
    create-snapshot            Create a new ledger snapshot
    genesis                    Prints the ledger's genesis config
    genesis-hash               Prints the ledger's genesis hash
    graph                      Create a Graphviz rendering of the ledger
    help                       Prints this message or the help of the given subcommand(s)
    latest-optimistic-slots    Output up to the most recent <num-slots> optimistic slots with their hashes and
                               timestamps.
    modify-genesis             Modifies genesis parameters
    program                    Run to test, debug, and analyze on-chain programs.
    shred-version              Prints the ledger's shred hash
    verify                     Verify the ledger
```
And here is `solana-ledger-tool blockstore`:
```
USAGE:
    solana-ledger-tool blockstore [FLAGS] [OPTIONS] <SUBCOMMAND>
...    
SUBCOMMANDS:
    analyze-storage            Output statistics in JSON format about all column families in the ledger rocksdb
    bounds                     Print lowest and highest non-empty slots. Note that there may be empty slots within
                               the bounds
    copy                       Copy the ledger
    dead-slots                 Print all the dead slots in the ledger
    duplicate-slots            Print all the duplicate slots in the ledger
    help                       Prints this message or the help of the given subcommand(s)
    json                       Print the ledger in JSON format
    latest-optimistic-slots    Output up to the most recent <num-slots> optimistic slots with their hashes and
                               timestamps.
    list-roots                 Output up to last <num-roots> root hashes and their heights starting at the given
                               block height
    parse_full_frozen          Parses log for information about critical events about ancestors of the given
                               `ending_slot`
    print                      Print the ledger
    print-file-metadata        Print the metadata of the specified ledger-store file. If no file name is specified,
                               it will print the metadata of all ledger files.
    purge                      Delete a range of slots from the ledger
    remove-dead-slot           Remove the dead flag for a slot
    repair-roots               Traverses the AncestorIterator backward from a last known root to restore missing
                               roots to the Root column
    set-dead-slot              Mark one or more slots dead
    shred-meta                 Prints raw shred metadata
    slot                       Print the contents of one or more slots
```

#### Pre-requisite PRs
In order to reduce the noise in this PR, several items that I changed while working on this have been broken out. All below PR's should be merged and this PR rebased on top before it is ready to merge.
- [x] https://github.com/solana-labs/solana/pull/34595
- [x] https://github.com/solana-labs/solana/pull/34596
- [x] https://github.com/solana-labs/solana/pull/34644