### PR TITLE
clippy: Removes ineffective open options

### DIFF
--- a/install/src/command.rs
+++ b/install/src/command.rs
@@ -501,7 +501,6 @@ fn add_to_path(new_path: &str) -> bool {
                     fn append_file(dest: &Path, line: &str) -> io::Result<()> {
                         use std::io::Write;
                         let mut dest_file = fs::OpenOptions::new()
-                            .write(true)
                             .append(true)
                             .create(true)
                             .open(dest)?;

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -58,7 +58,6 @@ pub fn setup() {
 pub fn setup_file_with_default(logfile: &str, filter: &str) {
     use std::fs::OpenOptions;
     let file = OpenOptions::new()
-        .write(true)
         .create(true)
         .append(true)
         .open(logfile)

--- a/validator/src/lib.rs
+++ b/validator/src/lib.rs
@@ -24,12 +24,7 @@ pub mod dashboard;
 #[cfg(unix)]
 fn redirect_stderr(filename: &str) {
     use std::os::unix::io::AsRawFd;
-    match OpenOptions::new()
-        .write(true)
-        .create(true)
-        .append(true)
-        .open(filename)
-    {
+    match OpenOptions::new().create(true).append(true).open(filename) {
         Ok(file) => unsafe {
             libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO);
         },


### PR DESCRIPTION
#### Problem

New clippy lints that need fixing:

```
error: unnecessary use of `.write(true)` because there is `.append(true)`
  --> logger/src/lib.rs:61:9
   |
61 |         .write(true)
   |         ^^^^^^^^^^^^ help: remove `.write(true)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ineffective_open_options
   = note: `-D clippy::ineffective-open-options` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::ineffective_open_options)]`
```


#### Summary of Changes

Remove unnecessary `.write(true)`s.

