### PR TITLE
clippy: Fixes blocks in conditions

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7973,10 +7973,12 @@ impl Bank {
             }
         }
         for precompile in get_precompiles() {
-            #[allow(clippy::blocks_in_conditions)]
-            if precompile.feature.map_or(false, |ref feature_id| {
-                self.feature_set.is_active(feature_id)
-            }) {
+            let should_add_precompile = precompile
+                .feature
+                .as_ref()
+                .map(|feature_id| self.feature_set.is_active(feature_id))
+                .unwrap_or(false);
+            if should_add_precompile {
                 self.add_precompile(&precompile.program_id);
             }
         }


### PR DESCRIPTION
#### Problem

New clippy lint for the name of `blocks_in_conditions`.


#### Summary of Changes

We could just rename the lint, but it's also trivial to fix properly.