### PR TITLE
Bump prio-graph version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4022,9 +4022,9 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952091df80157ff6f267c9bcb6ad68e42405e217bd83268f2aedee0aa4f03b5c"
+checksum = "6492a75ca57066a4479af45efa302bed448680182b0563f96300645d5f896097"
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ pickledb = { version = "0.5.1", default-features = false }
 pkcs8 = "0.8.0"
 predicates = "2.1"
 pretty-hex = "0.3.0"
-prio-graph = "0.2.0"
+prio-graph = "0.2.1"
 proc-macro2 = "1.0.74"
 proptest = "1.4"
 prost = "0.11.9"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3612,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "prio-graph"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952091df80157ff6f267c9bcb6ad68e42405e217bd83268f2aedee0aa4f03b5c"
+checksum = "6492a75ca57066a4479af45efa302bed448680182b0563f96300645d5f896097"
 
 [[package]]
 name = "proc-macro-crate"


### PR DESCRIPTION
#### Problem
- prio-graph 0.2.0 had a bug which did not correctly track write-read conflicts if there were multiple reads after a write. This is fixed in 0.2.1 - see https://github.com/apfitzge/prio-graph/pull/57
- If the write had higher-priority, the scheduler will still have scheduled the write first. However, if they had the same priority, it could have led to an inconsistent scheduling order.

#### Summary of Changes
- Bump prio-graph version

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->

--- 
Close #34606 
