### PR TITLE
Add gossip notifications / cluster node notifications to geyser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6011,6 +6011,7 @@ name = "solana-geyser-plugin-interface"
 version = "1.17.5"
 dependencies = [
  "log",
+ "solana-gossip",
  "solana-sdk",
  "solana-transaction-status",
  "thiserror",
@@ -6029,8 +6030,10 @@ dependencies = [
  "log",
  "serde_json",
  "solana-accounts-db",
+ "solana-client",
  "solana-entry",
  "solana-geyser-plugin-interface",
+ "solana-gossip",
  "solana-ledger",
  "solana-measure",
  "solana-metrics",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -644,13 +644,19 @@ impl Validator {
             .as_ref()
             .and_then(|geyser_plugin_service| geyser_plugin_service.get_block_metadata_notifier());
 
+        let cluster_info_notifier = geyser_plugin_service
+            .as_ref()
+            .and_then(|geyser_plugin_service| geyser_plugin_service.get_cluster_info_notifier());
+
         info!(
             "Geyser plugin: accounts_update_notifier: {}, \
             transaction_notifier: {}, \
-            entry_notifier: {}",
+            entry_notifier: {} \
+            cluster_info_notifier: {}",
             accounts_update_notifier.is_some(),
             transaction_notifier.is_some(),
-            entry_notifier.is_some()
+            entry_notifier.is_some(),
+            cluster_info_notifier.is_some(),
         );
 
         let system_monitor_service = Some(SystemMonitorService::new(
@@ -728,6 +734,7 @@ impl Validator {
             identity_keypair.clone(),
             socket_addr_space,
         );
+        cluster_info.set_clusterinfo_notifier(cluster_info_notifier);
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);
         cluster_info.restore_contact_info(ledger_path, config.contact_save_interval);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -734,6 +734,8 @@ impl Validator {
             identity_keypair.clone(),
             socket_addr_space,
         );
+
+        //register Geyzer notifier.
         cluster_info.set_clusterinfo_notifier(cluster_info_notifier);
         cluster_info.set_contact_debug_interval(config.contact_debug_interval);
         cluster_info.set_entrypoints(cluster_entrypoints);

--- a/geyser-plugin-interface/Cargo.toml
+++ b/geyser-plugin-interface/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 log = { workspace = true }
+solana-gossip = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
 thiserror = { workspace = true }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -2,6 +2,8 @@
 /// the GeyserPlugin trait to work with the runtime.
 /// In addition, the dynamic library must export a "C" function _create_plugin which
 /// creates the implementation of the plugin.
+use solana_sdk::pubkey::Pubkey;
+use std::net::SocketAddr;
 use {
     solana_sdk::{
         clock::{Slot, UnixTimestamp},
@@ -12,6 +14,36 @@ use {
     std::{any::Any, error, io},
     thiserror::Error,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// Information about a node  in  the cluster.
+pub struct ReplicaClusterInfoNode {
+    pub id: Pubkey,
+    /// gossip address
+    pub gossip: Option<SocketAddr>,
+    /// address to connect to for replication
+    pub tvu: Option<SocketAddr>,
+    /// TVU over QUIC protocol.
+    pub tvu_quic: Option<SocketAddr>,
+    /// repair service over QUIC protocol.
+    pub serve_repair_quic: Option<SocketAddr>,
+    /// transactions address
+    pub tpu: Option<SocketAddr>,
+    /// address to forward unprocessed transactions to
+    pub tpu_forwards: Option<SocketAddr>,
+    /// address to which to send bank state requests
+    pub tpu_vote: Option<SocketAddr>,
+    /// address to which to send JSON-RPC requests
+    pub rpc: Option<SocketAddr>,
+    /// websocket for JSON-RPC push notifications
+    pub rpc_pubsub: Option<SocketAddr>,
+    /// address to send repair requests to
+    pub serve_repair: Option<SocketAddr>,
+    /// latest wallclock picked
+    pub wallclock: u64,
+    /// node shred version
+    pub shred_version: u16,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Information about an account being updated
@@ -314,6 +346,12 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         slot: Slot,
         is_startup: bool,
     ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Called when a cluster info is updated on gossip network.
+    #[allow(unused_variables)]
+    fn update_cluster_info(&self, cluster_info: &ReplicaClusterInfoNode) -> Result<()> {
         Ok(())
     }
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -413,4 +413,11 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
     fn entry_notifications_enabled(&self) -> bool {
         false
     }
+
+    /// Check if the plugin is interested in cluster info data
+    /// Default is false -- if the plugin is interested in
+    /// cluster info data, return true.
+    fn clusterinfo_notifications_enabled(&self) -> bool {
+        false
+    }
 }

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -355,6 +355,12 @@ pub trait GeyserPlugin: Any + Send + Sync + std::fmt::Debug {
         Ok(())
     }
 
+    /// Called when a cluster info is removed on gossip network.
+    #[allow(unused_variables)]
+    fn notify_clusterinfo_remove(&self, pubkey: &Pubkey) -> Result<()> {
+        Ok(())
+    }
+
     /// Called when all accounts are notified of during startup.
     fn notify_end_of_startup(&self) -> Result<()> {
         Ok(())

--- a/geyser-plugin-manager/Cargo.toml
+++ b/geyser-plugin-manager/Cargo.toml
@@ -20,8 +20,10 @@ libloading = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
 solana-accounts-db = { workspace = true }
+solana-client = { workspace = true }
 solana-entry = { workspace = true }
 solana-geyser-plugin-interface = { workspace = true }
+solana-gossip = { workspace = true }
 solana-ledger = { workspace = true }
 solana-measure = { workspace = true }
 solana-metrics = { workspace = true }

--- a/geyser-plugin-manager/src/cluster_info_notifier.rs
+++ b/geyser-plugin-manager/src/cluster_info_notifier.rs
@@ -1,0 +1,110 @@
+/// Module responsible for notifying plugins of transactions
+use solana_gossip::legacy_contact_info::LegacyContactInfo;
+use solana_sdk::pubkey::Pubkey;
+use {
+    crate::geyser_plugin_manager::GeyserPluginManager,
+    log::*,
+    solana_client::connection_cache::Protocol,
+    solana_geyser_plugin_interface::geyser_plugin_interface::ReplicaClusterInfoNode,
+    solana_gossip::cluster_info_notifier_interface::ClusterInfoNotifierInterface,
+    solana_measure::measure::Measure,
+    solana_metrics::*,
+    solana_rpc::transaction_notifier_interface::TransactionNotifier,
+    solana_sdk::{clock::Slot, signature::Signature, transaction::SanitizedTransaction},
+    solana_transaction_status::TransactionStatusMeta,
+    std::sync::{Arc, RwLock},
+};
+
+/// This implementation of ClusterInfoNotifierImpl is passed to the rpc's TransactionStatusService
+/// at the validator startup. TransactionStatusService invokes the notify_transaction method
+/// for new transactions. The implementation in turn invokes the notify_transaction of each
+/// plugin enabled with transaction notification managed by the GeyserPluginManager.
+#[derive(Debug)]
+pub(crate) struct ClusterInfoNotifierImpl {
+    plugin_manager: Arc<RwLock<GeyserPluginManager>>,
+}
+
+impl ClusterInfoNotifierImpl {
+    fn clusterinfo_from_legacy_contact_info(
+        legacy_info: &LegacyContactInfo,
+    ) -> ReplicaClusterInfoNode {
+        ReplicaClusterInfoNode {
+            id: *legacy_info.pubkey(),
+            /// gossip address
+            gossip: legacy_info.gossip().ok(),
+            /// address to connect to for replication
+            tvu: legacy_info.tvu(Protocol::UDP).ok(),
+            /// TVU over QUIC protocol.
+            tvu_quic: legacy_info.tvu(Protocol::QUIC).ok(),
+            /// repair service over QUIC protocol.
+            serve_repair_quic: legacy_info.serve_repair(Protocol::QUIC).ok(),
+            /// transactions address
+            tpu: legacy_info.tpu(Protocol::UDP).ok(),
+            /// address to forward unprocessed transactions to
+            tpu_forwards: legacy_info.tpu_forwards(Protocol::UDP).ok(),
+            /// address to which to send bank state requests
+            tpu_vote: legacy_info.tpu_vote().ok(),
+            /// address to which to send JSON-RPC requests
+            rpc: legacy_info.rpc().ok(),
+            /// websocket for JSON-RPC push notifications
+            rpc_pubsub: legacy_info.rpc_pubsub().ok(),
+            /// address to send repair requests to
+            serve_repair: legacy_info.serve_repair(Protocol::UDP).ok(),
+            /// latest wallclock picked
+            wallclock: legacy_info.wallclock(),
+            /// node shred version
+            shred_version: legacy_info.shred_version(),
+        }
+    }
+}
+
+impl ClusterInfoNotifierInterface for ClusterInfoNotifierImpl {
+    fn notify_clusterinfo_update(&self, contact_info: &LegacyContactInfo) {
+        let cluster_info =
+            ClusterInfoNotifierImpl::clusterinfo_from_legacy_contact_info(contact_info);
+        let mut measure2 = Measure::start("geyser-plugin-notify_plugins_of_cluster_info_update");
+        let plugin_manager = self.plugin_manager.read().unwrap();
+
+        if plugin_manager.plugins.is_empty() {
+            return;
+        }
+        for plugin in plugin_manager.plugins.iter() {
+            let mut measure = Measure::start("geyser-plugin-update-cluster_info");
+            match plugin.update_cluster_info(&cluster_info) {
+                Err(err) => {
+                    error!(
+                        "Failed to update cluster_info {}, error: {} to plugin {}",
+                        bs58::encode(cluster_info.id).into_string(),
+                        err,
+                        plugin.name()
+                    )
+                }
+                Ok(_) => {
+                    trace!(
+                        "Successfully updated cluster_info {} to plugin {}",
+                        bs58::encode(cluster_info.id).into_string(),
+                        plugin.name()
+                    );
+                }
+            }
+            measure.stop();
+            inc_new_counter_debug!(
+                "geyser-plugin-update-cluster_info-us",
+                measure.as_us() as usize,
+                100000,
+                100000
+            );
+        }
+        measure2.stop();
+        inc_new_counter_debug!(
+            "geyser-plugin-notify_plugins_of_cluster_info_update-us",
+            measure2.as_us() as usize,
+            100000,
+            100000
+        );
+    }
+
+    fn notify_clusterinfo_remove(&self, pubkey: &Pubkey) {
+        todo!()
+    }
+}

--- a/geyser-plugin-manager/src/cluster_info_notifier.rs
+++ b/geyser-plugin-manager/src/cluster_info_notifier.rs
@@ -25,6 +25,10 @@ pub(crate) struct ClusterInfoNotifierImpl {
 }
 
 impl ClusterInfoNotifierImpl {
+    pub fn new(plugin_manager: Arc<RwLock<GeyserPluginManager>>) -> Self {
+        ClusterInfoNotifierImpl { plugin_manager }
+    }
+
     fn clusterinfo_from_legacy_contact_info(
         legacy_info: &LegacyContactInfo,
     ) -> ReplicaClusterInfoNode {

--- a/geyser-plugin-manager/src/geyser_plugin_manager.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_manager.rs
@@ -64,6 +64,15 @@ impl GeyserPluginManager {
         false
     }
 
+    /// Check if the plugin is interested in cluster info data
+    pub fn clusterinfo_notifications_enabled(&self) -> bool {
+        for plugin in &self.plugins {
+            if plugin.entry_notifications_enabled() {
+                return true;
+            }
+        }
+        false
+    }
     /// Admin RPC request handler
     pub(crate) fn list_plugins(&self) -> JsonRpcResult<Vec<String>> {
         Ok(self.plugins.iter().map(|p| p.name().to_owned()).collect())

--- a/geyser-plugin-manager/src/geyser_plugin_service.rs
+++ b/geyser-plugin-manager/src/geyser_plugin_service.rs
@@ -1,3 +1,5 @@
+use crate::cluster_info_notifier::ClusterInfoNotifierImpl;
+use solana_gossip::cluster_info_notifier_interface::ClusterInfoUpdateNotifierLock;
 use {
     crate::{
         accounts_update_notifier::AccountsUpdateNotifierImpl,
@@ -37,6 +39,7 @@ pub struct GeyserPluginService {
     transaction_notifier: Option<TransactionNotifierLock>,
     entry_notifier: Option<EntryNotifierLock>,
     block_metadata_notifier: Option<BlockMetadataNotifierLock>,
+    cluster_info_notifier: Option<ClusterInfoUpdateNotifierLock>,
 }
 
 impl GeyserPluginService {
@@ -81,7 +84,16 @@ impl GeyserPluginService {
             plugin_manager.account_data_notifications_enabled();
         let transaction_notifications_enabled = plugin_manager.transaction_notifications_enabled();
         let entry_notifications_enabled = plugin_manager.entry_notifications_enabled();
+        let cluster_info_notifications_enabled = plugin_manager.clusterinfo_notifications_enabled();
         let plugin_manager = Arc::new(RwLock::new(plugin_manager));
+
+        let cluster_info_notifier: Option<ClusterInfoUpdateNotifierLock> =
+            if cluster_info_notifications_enabled {
+                let cluster_info_notifier = ClusterInfoNotifierImpl::new(plugin_manager.clone());
+                Some(Arc::new(RwLock::new(cluster_info_notifier)))
+            } else {
+                None
+            };
 
         let accounts_update_notifier: Option<AccountsUpdateNotifier> =
             if account_data_notifications_enabled {
@@ -143,6 +155,7 @@ impl GeyserPluginService {
             transaction_notifier,
             entry_notifier,
             block_metadata_notifier,
+            cluster_info_notifier,
         })
     }
 
@@ -170,6 +183,10 @@ impl GeyserPluginService {
 
     pub fn get_block_metadata_notifier(&self) -> Option<BlockMetadataNotifierLock> {
         self.block_metadata_notifier.clone()
+    }
+
+    pub fn get_cluster_info_notifier(&self) -> Option<ClusterInfoUpdateNotifierLock> {
+        self.cluster_info_notifier.clone()
     }
 
     pub fn join(self) -> thread::Result<()> {

--- a/geyser-plugin-manager/src/lib.rs
+++ b/geyser-plugin-manager/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod accounts_update_notifier;
 pub mod block_metadata_notifier;
 pub mod block_metadata_notifier_interface;
+pub mod cluster_info_notifier;
 pub mod entry_notifier;
 pub mod geyser_plugin_manager;
 pub mod geyser_plugin_service;

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -18,6 +18,7 @@
     note = "Please use `solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE}` instead"
 )]
 #[allow(deprecated)]
+use crate::cluster_info_notifier_interface::ClusterInfoUpdateNotifierLock;
 pub use solana_net_utils::{MINIMUM_VALIDATOR_PORT_RANGE_WIDTH, VALIDATOR_PORT_RANGE};
 use {
     crate::{
@@ -437,6 +438,13 @@ impl ClusterInfo {
         me.insert_self();
         me.push_self();
         me
+    }
+
+    pub fn set_clusterinfo_notifier(
+        &self,
+        cluster_info_notifier: Option<ClusterInfoUpdateNotifierLock>,
+    ) {
+        self.gossip.set_clusterinfo_notifier(cluster_info_notifier);
     }
 
     pub fn set_contact_debug_interval(&mut self, new: u64) {

--- a/gossip/src/cluster_info_notifier_interface.rs
+++ b/gossip/src/cluster_info_notifier_interface.rs
@@ -1,0 +1,16 @@
+use crate::legacy_contact_info::LegacyContactInfo;
+use {
+    solana_sdk::pubkey::Pubkey,
+    std::sync::{Arc, RwLock},
+};
+
+pub trait ClusterInfoNotifierInterface: std::fmt::Debug {
+    /// Notified when an cluster node is updated (added or changed).
+    fn notify_clusterinfo_update(&self, cluster_info: &LegacyContactInfo);
+
+    /// Notified when a node is removed from the cluster
+    fn notify_clusterinfo_remove(&self, pubkey: &Pubkey);
+}
+
+pub type ClusterInfoUpdateNotifierLock =
+    Arc<RwLock<dyn ClusterInfoNotifierInterface + Sync + Send>>;

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -550,6 +550,8 @@ impl Crds {
         self.shards.remove(index, &value);
         match value.value.data {
             CrdsData::LegacyContactInfo(_) => {
+                //notify geyzer interface
+                self.notify_clusterinfo_remove(&value.value.pubkey());
                 self.nodes.swap_remove(&index);
             }
             CrdsData::Vote(_, _) => {

--- a/gossip/src/crds.rs
+++ b/gossip/src/crds.rs
@@ -210,6 +210,13 @@ fn overrides(value: &CrdsValue, other: &VersionedCrdsValue) -> bool {
 }
 
 impl Crds {
+    pub fn set_clusterinfo_notifier(
+        &mut self,
+        cluster_info_notifier: Option<ClusterInfoUpdateNotifierLock>,
+    ) {
+        self.clusterinfo_update_notifier = cluster_info_notifier;
+    }
+
     /// Returns true if the given value updates an existing one in the table.
     /// The value is outdated and fails to insert, if it already exists in the
     /// table with a more recent wallclock.

--- a/gossip/src/crds/geyser_plugin_utils.rs
+++ b/gossip/src/crds/geyser_plugin_utils.rs
@@ -1,0 +1,22 @@
+use crate::crds::Crds;
+use crate::crds::Pubkey;
+use crate::crds::VersionedCrdsValue;
+use crate::crds_value::CrdsData;
+
+impl Crds {
+    /// Notified when an account is updated at runtime, due to transaction activities
+    pub fn notify_clusterinfo_update(&self, crd_value: Option<&VersionedCrdsValue>) {
+        if let Some(clusterinfo_update_notifier) = &self.clusterinfo_update_notifier {
+            if let Some(value) = crd_value {
+                if let CrdsData::LegacyContactInfo(ref cluster_info) = value.value.data {
+                    let notifier = &clusterinfo_update_notifier.read().unwrap();
+                    notifier.notify_clusterinfo_update(cluster_info);
+                }
+            }
+        }
+    }
+
+    /// Notified when the AccountsDb is initialized at start when restored
+    /// from a snapshot.
+    pub fn notify_clusterinfo_remove(&self, pubkey: &Pubkey) {}
+}

--- a/gossip/src/crds/geyser_plugin_utils.rs
+++ b/gossip/src/crds/geyser_plugin_utils.rs
@@ -18,5 +18,10 @@ impl Crds {
 
     /// Notified when the AccountsDb is initialized at start when restored
     /// from a snapshot.
-    pub fn notify_clusterinfo_remove(&self, pubkey: &Pubkey) {}
+    pub fn notify_clusterinfo_remove(&self, pubkey: &Pubkey) {
+        if let Some(clusterinfo_update_notifier) = &self.clusterinfo_update_notifier {
+            let notifier = &clusterinfo_update_notifier.read().unwrap();
+            notifier.notify_clusterinfo_remove(pubkey);
+        }
+    }
 }

--- a/gossip/src/crds_gossip.rs
+++ b/gossip/src/crds_gossip.rs
@@ -4,6 +4,7 @@
 //! designed to run with a simulator or over a UDP network connection with messages up to a
 //! packet::PACKET_DATA_SIZE size.
 
+use crate::cluster_info_notifier_interface::ClusterInfoUpdateNotifierLock;
 use {
     crate::{
         cluster_info::Ping,
@@ -45,6 +46,14 @@ pub struct CrdsGossip {
 }
 
 impl CrdsGossip {
+    pub fn set_clusterinfo_notifier(
+        &self,
+        cluster_info_notifier: Option<ClusterInfoUpdateNotifierLock>,
+    ) {
+        let mut crds = self.crds.write().unwrap();
+        crds.set_clusterinfo_notifier(cluster_info_notifier);
+    }
+
     /// Process a push message to the network.
     ///
     /// Returns unique origins' pubkeys of upserted values.

--- a/gossip/src/lib.rs
+++ b/gossip/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod cluster_info;
 pub mod cluster_info_metrics;
+pub mod cluster_info_notifier_interface;
 pub mod contact_info;
 pub mod crds;
 pub mod crds_entry;


### PR DESCRIPTION
#### Problem
See issue #32934

#### Summary of Changes
This PR is a POC to add cluster node's info to the Geyzer plugin notification.

The LegacyContactInfo received on GOSSIP network are forwarded with the Geyzer interface to a client subscriber.

The PR contains:
 * the entry point in crds.rs to notify LegacyContactInfo [updates](https://github.com/solana-labs/solana/blob/f4bc1be708298c0896978c1ce286dcdbf1ecc221/gossip/src/crds.rs#L327) and [removals](https://github.com/solana-labs/solana/blob/f4bc1be708298c0896978c1ce286dcdbf1ecc221/gossip/src/crds.rs#L553),
 * the Geyzer plugin interface update to add [LegacyContactInfo notification](https://github.com/solana-labs/solana/blob/f4bc1be708298c0896978c1ce286dcdbf1ecc221/geyser-plugin-interface/src/geyser_plugin_interface.rs#L20) and [notification entry point](https://github.com/solana-labs/solana/blob/f4bc1be708298c0896978c1ce286dcdbf1ecc221/geyser-plugin-interface/src/geyser_plugin_interface.rs#L354).
 * the processing of the updates by the [geyzer_plugin_manager](https://github.com/solana-labs/solana/blob/f4bc1be708298c0896978c1ce286dcdbf1ecc221/geyser-plugin-manager/src/cluster_info_notifier.rs).

A GRPC [Yellowstone plugin update](https://github.com/rpcpool/yellowstone-grpc/pull/268) has been done to test the process and see the notified data volume. You can see the PR here.

An example of client can be found [here](https://github.com/blockworks-foundation/solana-rpc-v2/blob/main/clusterinfo/src/main.rs). It subscribes to the Cluster info node notification and call from time to time the RPC *get_cluster_nodes* to compare with the notified data.


##### Early results

The test has been done on Testnet cluster with the Solana version 1.17.5 and Yellowstone plugin 1.11.0+solana.1.17.5.

###### Comparison with RPC call
It takes a few second for the plugin to get the majority of the Testnet cluster nodes and after 30s there's less than 10 nodes in error when comparing with the RPC call (around 3000 nodes in the cluster).

After a few minutes, Geyzer and RPC has the same list of cluster's nodes. From time to time they can have some difference (a few nodes) from one part or the other depending on the notification time propagation of update or removal.

###### Data volume

I use Tcpdump to monitor the packet send between the validator grpc server and the client to build the *get_cluster_nodes RPC* call nodes list. 

This graphic is an example of network activity and bandwidth use. The volume of data transmitted is between 0,5 Mbits/s and 3 Mbits/s.

I've done some monitoring of the network connection between the grpc server and the client for the cluster node info notification. 

This is the graphic of the data transferred between the validator grpc server and the client to build the *get_cluster_nodes* RPC call nodes list.

![Network metrics](https://github.com/blockworks-foundation/solana-rpc-v2/blob/main/clusterinfo/grpc_clusterinfo.1.png "gRpc metrics")

