### PR TITLE
[program-test] adding method warp_to_epoch

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -30,7 +30,7 @@ use {
     solana_sdk::{
         account::{create_account_shared_data_for_test, Account, AccountSharedData},
         account_info::AccountInfo,
-        clock::Slot,
+        clock::{Epoch, Slot},
         entrypoint::{deserialize, ProgramResult, SUCCESS},
         feature_set::FEATURE_NAMES,
         fee_calculator::{FeeCalculator, FeeRateGovernor, DEFAULT_TARGET_LAMPORTS_PER_SIGNATURE},
@@ -65,7 +65,6 @@ use {
     tokio::task::JoinHandle,
 };
 // Export types so test clients can limit their solana crate dependencies
-use solana_sdk::clock::Epoch;
 pub use {
     solana_banks_client::{BanksClient, BanksClientError},
     solana_banks_interface::BanksTransactionResultWithMetadata,

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -65,6 +65,7 @@ use {
     tokio::task::JoinHandle,
 };
 // Export types so test clients can limit their solana crate dependencies
+use solana_sdk::clock::Epoch;
 pub use {
     solana_banks_client::{BanksClient, BanksClientError},
     solana_banks_interface::BanksTransactionResultWithMetadata,
@@ -1205,6 +1206,14 @@ impl ProgramTestContext {
         let bank = bank_forks.working_bank();
         self.last_blockhash = bank.last_blockhash();
         Ok(())
+    }
+
+    pub fn warp_to_epoch(&mut self, warp_epoch: Epoch) -> Result<(), ProgramTestError> {
+        let warp_slot = self
+            .genesis_config
+            .epoch_schedule
+            .get_first_slot_in_epoch(warp_epoch);
+        self.warp_to_slot(warp_slot)
     }
 
     /// warp forward one more slot and force reward interval end

--- a/program-test/tests/warp.rs
+++ b/program-test/tests/warp.rs
@@ -369,8 +369,15 @@ async fn stake_merge_immediately_after_activation() {
     check_credits_observed(&mut context.banks_client, base_stake_address, 100).await;
     context.increment_vote_account_credits(&vote_address, 100);
 
+    let clock_account = context
+        .banks_client
+        .get_account(clock::id())
+        .await
+        .expect("account exists")
+        .unwrap();
+    let clock: Clock = deserialize(&clock_account.data).unwrap();
+    context.warp_to_epoch(clock.epoch + 1).unwrap();
     current_slot += slots_per_epoch;
-    context.warp_to_slot(current_slot).unwrap();
     context.warp_forward_force_reward_interval_end().unwrap();
 
     // make another stake which will just have its credits observed advanced


### PR DESCRIPTION
#### Problem

The program test contains only method to warping to a particular slot. It would be nice to have a way to easily warp per epoch. The method https://github.com/solana-labs/solana/blob/v1.17.7/ledger-tool/src/main.rs#L3447 provides the calculation of the number of slots per epoch.

It could be then mapped to e.g., `bankrun` to profit from https://github.com/kevinheavey/solana-bankrun/pull/13

#### Summary of Changes

New method `warp_to_epoch` for the tests.
