### PR TITLE
clippy: accounts-db lints

### DIFF
--- a/accounts-db/src/rolling_bit_field/iterators.rs
+++ b/accounts-db/src/rolling_bit_field/iterators.rs
@@ -33,9 +33,7 @@ impl Iterator for RollingBitFieldOnesIter<'_> {
         // Then iterate over the bit vec
         loop {
             // If there are no more bits in the range, then we've iterated over everything and are done
-            let Some(bit) = self.bit_range.next() else {
-                return None;
-            };
+            let bit = self.bit_range.next()?;
 
             if self.rolling_bit_field.contains_assume_in_range(&bit) {
                 break Some(bit);


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the accounts-db crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: this `let...else` may be rewritten with the `?` operator
  --> accounts-db/src/rolling_bit_field/iterators.rs:36:13
   |
36 | /             let Some(bit) = self.bit_range.next() else {
37 | |                 return None;
38 | |             };
   | |______________^ help: replace it with: `let bit = self.bit_range.next()?;`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
   = note: `#[warn(clippy::question_mark)]` on by default

    Checking solana-rpc-client-api v1.18.0 (/Users/brooks/src/solana/rpc-client-api)
warning: `solana-accounts-db` (lib) generated 1 warning
```


#### Summary of Changes

Fix 'em.