### PR TITLE
clippy: core lints

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -150,7 +150,7 @@ impl Consumer {
         banking_stage_stats: &BankingStageStats,
         consumed_buffered_packets_count: &mut usize,
         rebuffered_packet_count: &mut usize,
-        packets_to_process: &Vec<Arc<ImmutableDeserializedPacket>>,
+        packets_to_process: &[Arc<ImmutableDeserializedPacket>],
     ) -> Option<Vec<usize>> {
         if payload.reached_end_of_slot {
             return None;

--- a/core/tests/fork-selection.rs
+++ b/core/tests/fork-selection.rs
@@ -11,7 +11,7 @@
 //!     fn test_with_partitions(num_partitions: usize, fail_rate: f64, delay_count: usize, parasite_rate: f64);
 //! ```
 //! Modify the test function
-//! ```
+//! ```no_run
 //! #[test]
 //! #[ignore]
 //! fn test_all_partitions() {


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the core crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
   --> core/src/banking_stage/consumer.rs:153:29
    |
153 |         packets_to_process: &Vec<Arc<ImmutableDeserializedPacket>>,
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[Arc<ImmutableDeserializedPacket>]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default

warning: `solana-core` (lib) generated 1 warning
```

```
warning: unit tests in doctest are not executed
  --> core/tests/fork-selection.rs:15:5
   |
15 |   //! #[test]
   |  _____^
16 | | //! #[ignore]
17 | | //! fn test_all_partitions() {
   | |__________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#test_attr_in_doctest
   = note: `#[warn(clippy::test_attr_in_doctest)]` on by default

warning: `solana-core` (test "fork-selection") generated 1 warning
```

#### Summary of Changes

Fix 'em.