### PR TITLE
clippy: runtime lints

### DIFF
--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -480,10 +480,11 @@ fn validate_fee_payer(
         error_counters.account_not_found += 1;
         return Err(TransactionError::AccountNotFound);
     }
-    let min_balance = match get_system_account_kind(payer_account).ok_or_else(|| {
+    let system_account_kind = get_system_account_kind(payer_account).ok_or_else(|| {
         error_counters.invalid_account_for_fee += 1;
         TransactionError::InvalidAccountForFee
-    })? {
+    })?;
+    let min_balance = match system_account_kind {
         SystemAccountKind::System => 0,
         SystemAccountKind::Nonce => {
             // Should we ever allow a fees charge to zero a nonce account's

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3090,15 +3090,11 @@ impl Bank {
                     let (mut stake_account, stake_state) =
                         <(AccountSharedData, StakeStateV2)>::from(stake_account);
                     let vote_pubkey = delegation.voter_pubkey;
-                    let Some(vote_account) = get_vote_account(&vote_pubkey) else {
-                        return None;
-                    };
+                    let vote_account = get_vote_account(&vote_pubkey)?;
                     if vote_account.owner() != &solana_vote_program {
                         return None;
                     }
-                    let Ok(vote_state) = vote_account.vote_state().cloned() else {
-                        return None;
-                    };
+                    let vote_state = vote_account.vote_state().cloned().ok()?;
 
                     let pre_lamport = stake_account.lamports();
 
@@ -4775,9 +4771,7 @@ impl Bank {
         ) -> Option<u128> {
             let mut lamports_sum = 0u128;
             for i in 0..message.account_keys().len() {
-                let Some((_, account)) = accounts.get(i) else {
-                    return None;
-                };
+                let (_, account) = accounts.get(i)?;
                 lamports_sum = lamports_sum.checked_add(u128::from(account.lamports()))?;
             }
             Some(lamports_sum)


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the runtime crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> runtime/src/accounts/mod.rs:483:82
    |
483 |       let min_balance = match get_system_account_kind(payer_account).ok_or_else(|| {
    |  __________________________________________________________________________________^
484 | |         error_counters.invalid_account_for_fee += 1;
485 | |         TransactionError::InvalidAccountForFee
486 | |     })? {
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
    = note: `#[warn(clippy::blocks_in_conditions)]` on by default

warning: this `let...else` may be rewritten with the `?` operator
    --> runtime/src/bank.rs:3093:21
     |
3093 | /                     let Some(vote_account) = get_vote_account(&vote_pubkey) else {
3094 | |                         return None;
3095 | |                     };
     | |______________________^ help: replace it with: `let vote_account = get_vote_account(&vote_pubkey)?;`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark
     = note: `#[warn(clippy::question_mark)]` on by default

warning: this `let...else` may be rewritten with the `?` operator
    --> runtime/src/bank.rs:4778:17
     |
4778 | /                 let Some((_, account)) = accounts.get(i) else {
4779 | |                     return None;
4780 | |                 };
     | |__________________^ help: replace it with: `let (_, account) = accounts.get(i)?;`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#question_mark

    Checking solana-bench-streamer v1.18.0 (/Users/brooks/src/solana/bench-streamer)
warning: `solana-runtime` (lib) generated 3 warnings
```


#### Summary of Changes

Fix 'em.