### PR TITLE
clippy: validator lints

### DIFF
--- a/validator/src/dashboard.rs
+++ b/validator/src/dashboard.rs
@@ -220,13 +220,13 @@ async fn wait_for_validator_startup(
                 if start_progress == ValidatorStartProgress::Running {
                     let admin_client = admin_client.take().unwrap();
 
-                    match async move {
+                    let validator_info = async move {
                         let rpc_addr = admin_client.rpc_addr().await?;
                         let start_time = admin_client.start_time().await?;
                         Ok::<_, jsonrpc_core_client::RpcError>((rpc_addr, start_time))
                     }
-                    .await
-                    {
+                    .await;
+                    match validator_info {
                         Ok((None, _)) => progress_bar.set_message("RPC service not available"),
                         Ok((Some(rpc_addr), start_time)) => return Some((rpc_addr, start_time)),
                         Err(err) => {


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the validator crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: in a `match` scrutinee, avoid complex blocks or closures with blocks; instead, move the block or closure higher and bind it with a `let`
   --> validator/src/dashboard.rs:223:38
    |
223 |                       match async move {
    |  ______________________________________^
224 | |                         let rpc_addr = admin_client.rpc_addr().await?;
225 | |                         let start_time = admin_client.start_time().await?;
226 | |                         Ok::<_, jsonrpc_core_client::RpcError>((rpc_addr, start_time))
227 | |                     }
    | |_____________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#blocks_in_conditions
    = note: `#[warn(clippy::blocks_in_conditions)]` on by default

warning: `solana-validator` (lib) generated 1 warning
```


#### Summary of Changes

Fix 'em.