### PR TITLE
clippy: rpc lints

### DIFF
--- a/rpc/src/optimistically_confirmed_bank_tracker.rs
+++ b/rpc/src/optimistically_confirmed_bank_tracker.rs
@@ -235,7 +235,7 @@ impl OptimisticallyConfirmedBankTracker {
     }
 
     fn notify_new_root_slots(
-        roots: &mut Vec<Slot>,
+        roots: &mut [Slot],
         newest_root_slot: &mut Slot,
         slot_notification_subscribers: &Option<Arc<RwLock<Vec<SlotNotificationSender>>>>,
     ) {


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the rpc crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: writing `&mut Vec` instead of `&mut [_]` involves a new object where a slice will do
   --> rpc/src/optimistically_confirmed_bank_tracker.rs:238:16
    |
238 |         roots: &mut Vec<Slot>,
    |                ^^^^^^^^^^^^^^ help: change this to: `&mut [Slot]`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
    = note: `#[warn(clippy::ptr_arg)]` on by default

warning: `solana-rpc` (lib) generated 1 warning
```


#### Summary of Changes

Fix 'em.