### PR TITLE
clippy: zk-token-sdk lints

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
@@ -59,10 +59,10 @@ impl BatchedRangeProofContext {
     }
 
     fn new(
-        commitments: &Vec<&PedersenCommitment>,
-        amounts: &Vec<u64>,
-        bit_lengths: &Vec<usize>,
-        openings: &Vec<&PedersenOpening>,
+        commitments: &[&PedersenCommitment],
+        amounts: &[u64],
+        bit_lengths: &[usize],
+        openings: &[&PedersenOpening],
     ) -> Result<Self, ProofGenerationError> {
         // the number of commitments is capped at 8
         let num_commitments = commitments.len();


### PR DESCRIPTION
#### Problem

There are new nightly clippy lints in the zk-token-sdk crate. Refer to https://github.com/solana-labs/solana/issues/34626 for more information.

```
warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
  --> zk-token-sdk/src/instruction/batched_range_proof/mod.rs:62:22
   |
62 |         commitments: &Vec<&PedersenCommitment>,
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[&PedersenCommitment]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
   = note: `#[warn(clippy::ptr_arg)]` on by default

warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
  --> zk-token-sdk/src/instruction/batched_range_proof/mod.rs:63:18
   |
63 |         amounts: &Vec<u64>,
   |                  ^^^^^^^^^ help: change this to: `&[u64]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
  --> zk-token-sdk/src/instruction/batched_range_proof/mod.rs:64:22
   |
64 |         bit_lengths: &Vec<usize>,
   |                      ^^^^^^^^^^^ help: change this to: `&[usize]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

warning: writing `&Vec` instead of `&[_]` involves a new object where a slice will do
  --> zk-token-sdk/src/instruction/batched_range_proof/mod.rs:65:19
   |
65 |         openings: &Vec<&PedersenOpening>,
   |                   ^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `&[&PedersenOpening]`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg

    Checking solana-clap-utils v1.18.0 (/Users/brooks/src/solana/clap-utils)
warning: `solana-zk-token-sdk` (lib) generated 4 warnings
```


#### Summary of Changes

Fix 'em.