### PR TITLE
chore: ignore farf/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-**/farf/
+farf/
 /solana-release/
 /solana-release.tar.bz2
 /solana-metrics/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dos/farf/
 /farf/
+/test-validator/farf/
 /solana-release/
 /solana-release.tar.bz2
 /solana-metrics/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-/dos/farf/
-/farf/
-/test-validator/farf/
+**/farf/
 /solana-release/
 /solana-release.tar.bz2
 /solana-metrics/


### PR DESCRIPTION
#### Problem

we should ignore all *farf* dirs in .gitignore.



#### Summary of Changes

add `farf/` to git ignore

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
