### PR TITLE
clippy: ledger-tool lints

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2398,7 +2398,7 @@ fn main() {
                 let log_file = PathBuf::from(value_t_or_exit!(arg_matches, "log_path", String));
                 let f = BufReader::new(File::open(log_file).unwrap());
                 println!("Reading log file");
-                for line in f.lines().flatten() {
+                for line in f.lines().map_while(Result::ok) {
                     let parse_results = {
                         if let Some(slot_string) = frozen_regex.captures_iter(&line).next() {
                             Some((slot_string, &mut frozen))


### PR DESCRIPTION
#### Problem
There are new nightly clippy lints in the `ledger-tool` source. See the parent issue https://github.com/solana-labs/solana/issues/34626 for more context

#### Summary of Changes
Apply the change suggested below

```
warning: `flatten()` will run forever if the iterator repeatedly produces an `Err`
    --> ledger-tool/src/main.rs:2649:39
     |
2649 |                 for line in f.lines().flatten() {
     |                                       ^^^^^^^^^ help: replace with: `map_while(Result::ok)`
     |
note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
    --> ledger-tool/src/main.rs:2649:29
     |
2649 |                 for line in f.lines().flatten() {
     |                             ^^^^^^^^^
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok
     = note: `#[warn(clippy::lines_filter_map_ok)]` on by default

warning: `solana-ledger-tool` (bin "solana-ledger-tool" test) generated 1 warning
```