### PR TITLE
ledger-tool: Adjust logic to obtain TransactionStatusService Blockstore

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -358,8 +358,9 @@ pub fn load_and_process_ledger(
 
     let (transaction_status_sender, transaction_status_service) =
         if geyser_plugin_active || enable_rpc_transaction_history {
-            // Need Primary (R/W) access to insert transaction data
-            let tss_blockstore = if enable_rpc_transaction_history {
+            // Need Primary (R/W) access to insert transaction data;
+            // obtain Primary access if we do not already have it
+            let tss_blockstore = if enable_rpc_transaction_history && !blockstore.is_primary_access() {
                 Arc::new(open_blockstore(
                     blockstore.ledger_path(),
                     arg_matches,

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -356,39 +356,40 @@ pub fn load_and_process_ledger(
 
     let enable_rpc_transaction_history = arg_matches.is_present("enable_rpc_transaction_history");
 
-    let (transaction_status_sender, transaction_status_service) =
-        if geyser_plugin_active || enable_rpc_transaction_history {
-            // Need Primary (R/W) access to insert transaction data;
-            // obtain Primary access if we do not already have it
-            let tss_blockstore = if enable_rpc_transaction_history && !blockstore.is_primary_access() {
-                Arc::new(open_blockstore(
-                    blockstore.ledger_path(),
-                    arg_matches,
-                    AccessType::PrimaryForMaintenance,
-                ))
-            } else {
-                blockstore.clone()
-            };
-
-            let (transaction_status_sender, transaction_status_receiver) = unbounded();
-            let transaction_status_service = TransactionStatusService::new(
-                transaction_status_receiver,
-                Arc::default(),
-                enable_rpc_transaction_history,
-                transaction_notifier,
-                tss_blockstore,
-                false,
-                exit.clone(),
-            );
-            (
-                Some(TransactionStatusSender {
-                    sender: transaction_status_sender,
-                }),
-                Some(transaction_status_service),
-            )
+    let (transaction_status_sender, transaction_status_service) = if geyser_plugin_active
+        || enable_rpc_transaction_history
+    {
+        // Need Primary (R/W) access to insert transaction data;
+        // obtain Primary access if we do not already have it
+        let tss_blockstore = if enable_rpc_transaction_history && !blockstore.is_primary_access() {
+            Arc::new(open_blockstore(
+                blockstore.ledger_path(),
+                arg_matches,
+                AccessType::PrimaryForMaintenance,
+            ))
         } else {
-            (None, None)
+            blockstore.clone()
         };
+
+        let (transaction_status_sender, transaction_status_receiver) = unbounded();
+        let transaction_status_service = TransactionStatusService::new(
+            transaction_status_receiver,
+            Arc::default(),
+            enable_rpc_transaction_history,
+            transaction_notifier,
+            tss_blockstore,
+            false,
+            exit.clone(),
+        );
+        (
+            Some(TransactionStatusSender {
+                sender: transaction_status_sender,
+            }),
+            Some(transaction_status_service),
+        )
+    } else {
+        (None, None)
+    };
 
     let result = blockstore_processor::process_blockstore_from_root(
         blockstore.as_ref(),


### PR DESCRIPTION
#### Problem
    TransactionStatusService needs Primary access in order to write
    transaction status into the Blockstore if enable_rpc_transaction_history
    is set to True. The current logic attempts to get Primary access for the
    service.
    
#### Summary of Changes
    However, in the event that this function had been called with a
    Blockstore that already had Primary access, this second attempt to get
    Primary access would fail. So, only attempt to open with Primary access
    when necessary AND when the current access level is not sufficient.

Note that this function is currently called with `Secondary` (read only) blockstore access. So, we would not currently run into this error with the default. Someone setting several flags in a particular manner could technically encounter this error. 

Regardless, there is no requirement about the access type of the `Blockstore` passed into `load_and_process_ledger()`. So, this change is more defensive in the event that we start calling this function with `Primary` access, or if someone happens to provide the exact combination of args to hit the error that this change prevents
