### PR TITLE
blockstore: add last fec set details column

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -239,6 +239,7 @@ pub struct Blockstore {
     optimistic_slots_cf: LedgerColumn<cf::OptimisticSlots>,
     max_root: AtomicU64,
     merkle_root_meta_cf: LedgerColumn<cf::MerkleRootMeta>,
+    last_fec_set_details_cf: LedgerColumn<cf::LastFecSetDetails>,
     insert_shreds_lock: Mutex<()>,
     new_shreds_signals: Mutex<Vec<Sender<bool>>>,
     completed_slots_senders: Mutex<Vec<CompletedSlotsSender>>,
@@ -341,6 +342,7 @@ impl Blockstore {
         let bank_hash_cf = db.column();
         let optimistic_slots_cf = db.column();
         let merkle_root_meta_cf = db.column();
+        let last_fec_set_details_cf = db.column();
 
         let db = Arc::new(db);
 
@@ -379,6 +381,7 @@ impl Blockstore {
             bank_hash_cf,
             optimistic_slots_cf,
             merkle_root_meta_cf,
+            last_fec_set_details_cf,
             new_shreds_signals: Mutex::default(),
             completed_slots_senders: Mutex::default(),
             shred_timing_point_sender: None,
@@ -745,6 +748,7 @@ impl Blockstore {
         self.bank_hash_cf.submit_rocksdb_cf_metrics();
         self.optimistic_slots_cf.submit_rocksdb_cf_metrics();
         self.merkle_root_meta_cf.submit_rocksdb_cf_metrics();
+        self.last_fec_set_details_cf.submit_rocksdb_cf_metrics();
     }
 
     /// Report the accumulated RPC API metrics

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -224,6 +224,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_range_cf::<cf::MerkleRootMeta>(&mut write_batch, from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_range_cf::<cf::LastFecSetDetails>(&mut write_batch, from_slot, to_slot)
                 .is_ok();
         match purge_type {
             PurgeType::Exact => {
@@ -336,6 +340,10 @@ impl Blockstore {
             & self
                 .db
                 .delete_file_in_range_cf::<cf::MerkleRootMeta>(from_slot, to_slot)
+                .is_ok()
+            & self
+                .db
+                .delete_file_in_range_cf::<cf::LastFecSetDetails>(from_slot, to_slot)
                 .is_ok()
     }
 

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -526,6 +526,19 @@ impl OptimisticSlotMetaVersioned {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SizeDetails {
+    pub last_fec_set_index: u32,
+    pub num_coding_received: usize,
+    pub num_data_received: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum LastFecSetDetails {
+    SizeDetails(SizeDetails),
+}
+
 #[cfg(test)]
 mod test {
     use {

--- a/ledger/src/blockstore_meta.rs
+++ b/ledger/src/blockstore_meta.rs
@@ -530,8 +530,12 @@ impl OptimisticSlotMetaVersioned {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SizeDetails {
     pub last_fec_set_index: u32,
-    pub num_coding_received: usize,
-    pub num_data_received: usize,
+    /// These fields keep track of any shreds inserted into blockstore,
+    /// through turbine/repair or erasure recovery.
+    /// Before voting replay will check that the sum of these values are at
+    /// least 2 * `DATA_SHREDS_PER_FEC_BLOCK`.
+    pub num_coding_inserted: usize,
+    pub num_data_inserted: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
#### Problem
There are a number of additional checks we want to perform on the last fec set of each block. This additional column stores the details necessary for these checks allowing easy replay verification with only one blockstore read.

#### Summary of Changes
Add last fec set details column


