### PR TITLE
Unlock only if lock_result was Ok

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -636,18 +636,8 @@ impl Accounts {
     ) {
         let keys: Vec<_> = txs
             .zip(results)
-            .filter_map(|(tx, res)| match res {
-                Err(TransactionError::AccountLoadedTwice)
-                | Err(TransactionError::AccountInUse)
-                | Err(TransactionError::SanitizeFailure)
-                | Err(TransactionError::TooManyAccountLocks)
-                | Err(TransactionError::WouldExceedMaxBlockCostLimit)
-                | Err(TransactionError::WouldExceedMaxVoteCostLimit)
-                | Err(TransactionError::WouldExceedMaxAccountCostLimit)
-                | Err(TransactionError::WouldExceedAccountDataBlockLimit)
-                | Err(TransactionError::WouldExceedAccountDataTotalLimit) => None,
-                _ => Some(tx.get_account_locks_unchecked()),
-            })
+            .filter(|(_, res)| res.is_ok())
+            .map(|(tx, _)| tx.get_account_locks_unchecked())
             .collect();
         let mut account_locks = self.account_locks.lock().unwrap();
         debug!("bank unlock accounts");


### PR DESCRIPTION
#### Problem
- I am adding some earlier filtering of transactions that has different `TransactionError`, which happens before locking
- We are unlocking some error'd lock results if they do not match the specific set of possible errors that is currently in this function
- With newly introduced filtering, this creates a race condition that leads to multiple write locks being taken concurrently if a batch with an error were unlocked during processing
  
#### Summary of Changes
- Only unlock transactions that we actually took locks for

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
