### PR TITLE
Metrics prioritization fees

### DIFF
--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -659,7 +659,7 @@ impl BankingStage {
         }
         let (decision, make_decision_time) =
             measure!(decision_maker.make_consume_or_forward_decision());
-        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank_start());
+        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank_start(), Some(unprocessed_transaction_storage));
         slot_metrics_tracker.increment_make_decision_us(make_decision_time.as_us());
 
         match decision {

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -659,7 +659,10 @@ impl BankingStage {
         }
         let (decision, make_decision_time) =
             measure!(decision_maker.make_consume_or_forward_decision());
-        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(decision.bank_start(), Some(unprocessed_transaction_storage));
+        let metrics_action = slot_metrics_tracker.check_leader_slot_boundary(
+            decision.bank_start(),
+            Some(unprocessed_transaction_storage),
+        );
         slot_metrics_tracker.increment_make_decision_us(make_decision_time.as_us());
 
         match decision {

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -19,7 +19,9 @@ use {
         BankStart, PohRecorderError, RecordTransactionsSummary, RecordTransactionsTimings,
         TransactionRecorder,
     },
-    solana_program_runtime::timings::ExecuteTimings,
+    solana_program_runtime::{
+        compute_budget_processor::process_compute_budget_instructions, timings::ExecuteTimings,
+    },
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},
         transaction_batch::TransactionBatch,
@@ -64,6 +66,8 @@ pub struct ExecuteAndCommitTransactionsOutput {
     pub commit_transactions_result: Result<Vec<CommitTransactionDetails>, PohRecorderError>,
     pub(crate) execute_and_commit_timings: LeaderExecuteAndCommitTimings,
     pub(crate) error_counters: TransactionErrorMetrics,
+    pub(crate) scheduled_min_prioritization_fees: usize,
+    pub(crate) scheduled_max_prioritization_fees: usize,
 }
 
 pub struct Consumer {
@@ -286,6 +290,8 @@ impl Consumer {
         let mut total_execute_and_commit_timings = LeaderExecuteAndCommitTimings::default();
         let mut total_error_counters = TransactionErrorMetrics::default();
         let mut reached_max_poh_height = false;
+        let mut total_scheduled_min_prioritization_fees: usize = usize::MAX;
+        let mut total_scheduled_max_prioritization_fees: usize = 0;
         while chunk_start != transactions.len() {
             let chunk_end = std::cmp::min(
                 transactions.len(),
@@ -316,6 +322,8 @@ impl Consumer {
                 commit_transactions_result: new_commit_transactions_result,
                 execute_and_commit_timings: new_execute_and_commit_timings,
                 error_counters: new_error_counters,
+                scheduled_min_prioritization_fees,
+                scheduled_max_prioritization_fees,
                 ..
             } = execute_and_commit_transactions_output;
 
@@ -324,6 +332,14 @@ impl Consumer {
             saturating_add_assign!(
                 total_transactions_attempted_execution_count,
                 new_transactions_attempted_execution_count
+            );
+            total_scheduled_min_prioritization_fees = std::cmp::min(
+                total_scheduled_min_prioritization_fees,
+                scheduled_min_prioritization_fees,
+            );
+            total_scheduled_max_prioritization_fees = std::cmp::min(
+                total_scheduled_max_prioritization_fees,
+                scheduled_max_prioritization_fees,
             );
 
             trace!(
@@ -385,6 +401,8 @@ impl Consumer {
             cost_model_us: total_cost_model_us,
             execute_and_commit_timings: total_execute_and_commit_timings,
             error_counters: total_error_counters,
+            scheduled_min_prioritization_fees: total_scheduled_min_prioritization_fees,
+            scheduled_max_prioritization_fees: total_scheduled_max_prioritization_fees,
         }
     }
 
@@ -545,6 +563,18 @@ impl Consumer {
         });
         execute_and_commit_timings.collect_balances_us = collect_balances_us;
 
+        let min_max = batch
+            .sanitized_transactions()
+            .iter()
+            .filter_map(|transaction| {
+                let message = transaction.message();
+                process_compute_budget_instructions(message.program_instructions_iter()).ok()
+            })
+            .map(|cu_limits| cu_limits.compute_unit_price)
+            .minmax();
+        let (scheduled_min_prioritization_fees, scheduled_max_prioritization_fees) =
+            min_max.into_option().unwrap_or_default();
+
         let (load_and_execute_transactions_output, load_execute_us) = measure_us!(bank
             .load_and_execute_transactions(
                 batch,
@@ -619,6 +649,8 @@ impl Consumer {
                 commit_transactions_result: Err(recorder_err),
                 execute_and_commit_timings,
                 error_counters,
+                scheduled_min_prioritization_fees: scheduled_min_prioritization_fees as usize,
+                scheduled_max_prioritization_fees: scheduled_max_prioritization_fees as usize,
             };
         }
 
@@ -674,6 +706,8 @@ impl Consumer {
             commit_transactions_result: Ok(commit_transaction_statuses),
             execute_and_commit_timings,
             error_counters,
+            scheduled_min_prioritization_fees: scheduled_min_prioritization_fees as usize,
+            scheduled_max_prioritization_fees: scheduled_max_prioritization_fees as usize,
         }
     }
 

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -193,6 +193,14 @@ impl UnprocessedPacketBatches {
         self.packet_priority_queue.is_empty()
     }
 
+    pub fn get_min_priority(&self) -> Option<u64> {
+        self.packet_priority_queue.peek_min().map(|x| x.priority())
+    }
+
+    pub fn get_max_priority(&self) -> Option<u64> {
+        self.packet_priority_queue.peek_max().map(|x| x.priority())
+    }
+
     fn push_internal(&mut self, deserialized_packet: DeserializedPacket) {
         // Push into the priority queue
         self.packet_priority_queue

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -260,14 +260,18 @@ impl UnprocessedTransactionStorage {
     pub fn get_min_priority(&self) -> Option<u64> {
         match self {
             Self::VoteStorage(_) => None,
-            Self::LocalTransactionStorage(transaction_storage) => transaction_storage.get_min_priority(),
+            Self::LocalTransactionStorage(transaction_storage) => {
+                transaction_storage.get_min_priority()
+            }
         }
     }
 
-    pub fn get_max_priority(&self) -> Option<u64>  {
+    pub fn get_max_priority(&self) -> Option<u64> {
         match self {
             Self::VoteStorage(_) => None,
-            Self::LocalTransactionStorage(transaction_storage) => transaction_storage.get_max_priority(),
+            Self::LocalTransactionStorage(transaction_storage) => {
+                transaction_storage.get_max_priority()
+            }
         }
     }
 
@@ -522,7 +526,7 @@ impl ThreadLocalUnprocessedPackets {
         self.unprocessed_packet_batches.get_min_priority()
     }
 
-    pub fn get_max_priority(&self) -> Option<u64>  {
+    pub fn get_max_priority(&self) -> Option<u64> {
         self.unprocessed_packet_batches.get_max_priority()
     }
 

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -257,6 +257,20 @@ impl UnprocessedTransactionStorage {
         }
     }
 
+    pub fn get_min_priority(&self) -> Option<u64> {
+        match self {
+            Self::VoteStorage(_) => None,
+            Self::LocalTransactionStorage(transaction_storage) => transaction_storage.get_min_priority(),
+        }
+    }
+
+    pub fn get_max_priority(&self) -> Option<u64>  {
+        match self {
+            Self::VoteStorage(_) => None,
+            Self::LocalTransactionStorage(transaction_storage) => transaction_storage.get_max_priority(),
+        }
+    }
+
     /// Returns the maximum number of packets a receive should accept
     pub fn max_receive_size(&self) -> usize {
         match self {
@@ -502,6 +516,14 @@ impl ThreadLocalUnprocessedPackets {
 
     fn len(&self) -> usize {
         self.unprocessed_packet_batches.len()
+    }
+
+    pub fn get_min_priority(&self) -> Option<u64> {
+        self.unprocessed_packet_batches.get_min_priority()
+    }
+
+    pub fn get_max_priority(&self) -> Option<u64>  {
+        self.unprocessed_packet_batches.get_max_priority()
     }
 
     fn max_receive_size(&self) -> usize {


### PR DESCRIPTION
#### Problem
Currently there are not enough metrics about prioritization fees for each thread processing transactions. We need few more metrics to track how prioritization fees are respected by the validator. As we are on the verge of changing the scheduler metrics like these could be very important.

#### Summary of Changes

Adding a metrics which tracks min and max prioritization fees in the heap before starting to build the block.
Adding a metrics which tracks min and max prioritization fees for transactions that are scheduled for execution.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
