### PR TITLE
[TieredStorage] Rename AddressAndBlockOffsetOnly to AddressesThenOffsets

### DIFF
--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -354,7 +354,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -354,7 +354,7 @@ mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 24,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -29,7 +29,7 @@ pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
     account_meta_format: AccountMetaFormat::Hot,
     owners_block_format: OwnersBlockFormat::LocalIndex,
-    index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+    index_block_format: IndexBlockFormat::AddressesThenOffsets,
     account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
@@ -610,7 +610,7 @@ pub mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 16,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -29,7 +29,7 @@ pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     meta_entry_size: std::mem::size_of::<HotAccountMeta>(),
     account_meta_format: AccountMetaFormat::Hot,
     owners_block_format: OwnersBlockFormat::LocalIndex,
-    index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+    index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
     account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
@@ -610,7 +610,7 @@ pub mod tests {
         let expected_footer = TieredStorageFooter {
             account_meta_format: AccountMetaFormat::Hot,
             owners_block_format: OwnersBlockFormat::LocalIndex,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             account_block_format: AccountBlockFormat::AlignedRaw,
             account_entry_count: 300,
             account_meta_entry_size: 16,

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -48,7 +48,7 @@ pub enum IndexBlockFormat {
     /// and block offsets.  It skips storing the size of account data by storing
     /// account block entries and index block entries in the same order.
     #[default]
-    AddressAndBlockOffsetOnly = 0,
+    PlainAddressesAndOffsets = 0,
 }
 
 // Ensure there are no implicit padding bytes
@@ -63,7 +63,7 @@ impl IndexBlockFormat {
         index_entries: &[AccountIndexWriterEntry<impl AccountOffset>],
     ) -> TieredStorageResult<usize> {
         match self {
-            Self::AddressAndBlockOffsetOnly => {
+            Self::PlainAddressesAndOffsets => {
                 let mut bytes_written = 0;
                 for index_entry in index_entries {
                     bytes_written += file.write_pod(index_entry.address)?;
@@ -84,7 +84,7 @@ impl IndexBlockFormat {
         index_offset: IndexOffset,
     ) -> TieredStorageResult<&'a Pubkey> {
         let offset = match self {
-            Self::AddressAndBlockOffsetOnly => {
+            Self::PlainAddressesAndOffsets => {
                 debug_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * (index_offset.0 as usize)
@@ -111,7 +111,7 @@ impl IndexBlockFormat {
         index_offset: IndexOffset,
     ) -> TieredStorageResult<Offset> {
         let offset = match self {
-            Self::AddressAndBlockOffsetOnly => {
+            Self::PlainAddressesAndOffsets => {
                 debug_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
@@ -135,7 +135,7 @@ impl IndexBlockFormat {
     /// Returns the size of one index entry.
     pub fn entry_size<Offset: AccountOffset>(&self) -> usize {
         match self {
-            Self::AddressAndBlockOffsetOnly => {
+            Self::PlainAddressesAndOffsets => {
                 std::mem::size_of::<Pubkey>() + std::mem::size_of::<Offset>()
             }
         }
@@ -182,12 +182,12 @@ mod tests {
 
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
-            let indexer = IndexBlockFormat::AddressAndBlockOffsetOnly;
+            let indexer = IndexBlockFormat::PlainAddressesAndOffsets;
             let cursor = indexer.write_index_block(&file, &index_entries).unwrap();
             footer.owners_block_offset = cursor as u64;
         }
 
-        let indexer = IndexBlockFormat::AddressAndBlockOffsetOnly;
+        let indexer = IndexBlockFormat::PlainAddressesAndOffsets;
         let file = OpenOptions::new()
             .read(true)
             .create(false)
@@ -216,7 +216,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             ..TieredStorageFooter::default()
         };
 
@@ -249,7 +249,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             index_block_offset: 1024,
             // only holds one index entry
             owners_block_offset: 1024 + std::mem::size_of::<HotAccountOffset>() as u64,
@@ -287,7 +287,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             ..TieredStorageFooter::default()
         };
 
@@ -324,7 +324,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::AddressAndBlockOffsetOnly,
+            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
             index_block_offset: 1024,
             // only holds one index entry
             owners_block_offset: 1024 + std::mem::size_of::<HotAccountOffset>() as u64,

--- a/accounts-db/src/tiered_storage/index.rs
+++ b/accounts-db/src/tiered_storage/index.rs
@@ -48,7 +48,7 @@ pub enum IndexBlockFormat {
     /// and block offsets.  It skips storing the size of account data by storing
     /// account block entries and index block entries in the same order.
     #[default]
-    PlainAddressesAndOffsets = 0,
+    AddressesThenOffsets = 0,
 }
 
 // Ensure there are no implicit padding bytes
@@ -63,7 +63,7 @@ impl IndexBlockFormat {
         index_entries: &[AccountIndexWriterEntry<impl AccountOffset>],
     ) -> TieredStorageResult<usize> {
         match self {
-            Self::PlainAddressesAndOffsets => {
+            Self::AddressesThenOffsets => {
                 let mut bytes_written = 0;
                 for index_entry in index_entries {
                     bytes_written += file.write_pod(index_entry.address)?;
@@ -84,7 +84,7 @@ impl IndexBlockFormat {
         index_offset: IndexOffset,
     ) -> TieredStorageResult<&'a Pubkey> {
         let offset = match self {
-            Self::PlainAddressesAndOffsets => {
+            Self::AddressesThenOffsets => {
                 debug_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * (index_offset.0 as usize)
@@ -111,7 +111,7 @@ impl IndexBlockFormat {
         index_offset: IndexOffset,
     ) -> TieredStorageResult<Offset> {
         let offset = match self {
-            Self::PlainAddressesAndOffsets => {
+            Self::AddressesThenOffsets => {
                 debug_assert!(index_offset.0 < footer.account_entry_count);
                 footer.index_block_offset as usize
                     + std::mem::size_of::<Pubkey>() * footer.account_entry_count as usize
@@ -135,7 +135,7 @@ impl IndexBlockFormat {
     /// Returns the size of one index entry.
     pub fn entry_size<Offset: AccountOffset>(&self) -> usize {
         match self {
-            Self::PlainAddressesAndOffsets => {
+            Self::AddressesThenOffsets => {
                 std::mem::size_of::<Pubkey>() + std::mem::size_of::<Offset>()
             }
         }
@@ -182,12 +182,12 @@ mod tests {
 
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
-            let indexer = IndexBlockFormat::PlainAddressesAndOffsets;
+            let indexer = IndexBlockFormat::AddressesThenOffsets;
             let cursor = indexer.write_index_block(&file, &index_entries).unwrap();
             footer.owners_block_offset = cursor as u64;
         }
 
-        let indexer = IndexBlockFormat::PlainAddressesAndOffsets;
+        let indexer = IndexBlockFormat::AddressesThenOffsets;
         let file = OpenOptions::new()
             .read(true)
             .create(false)
@@ -216,7 +216,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             ..TieredStorageFooter::default()
         };
 
@@ -249,7 +249,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             index_block_offset: 1024,
             // only holds one index entry
             owners_block_offset: 1024 + std::mem::size_of::<HotAccountOffset>() as u64,
@@ -287,7 +287,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             ..TieredStorageFooter::default()
         };
 
@@ -324,7 +324,7 @@ mod tests {
 
         let footer = TieredStorageFooter {
             account_entry_count: 100,
-            index_block_format: IndexBlockFormat::PlainAddressesAndOffsets,
+            index_block_format: IndexBlockFormat::AddressesThenOffsets,
             index_block_offset: 1024,
             // only holds one index entry
             owners_block_offset: 1024 + std::mem::size_of::<HotAccountOffset>() as u64,


### PR DESCRIPTION
#### Problem
In the previous refactoring, IndexBlockFormat::AddressAndBlockOffsetOnly
can now work independently with the AccountMetaFormat.  As a result,
the naming of this format should be updated to reflect this.

#### Summary of Changes
As the format first persists the list of addresses followed by the list of offsets,
this PR renames AddressAndBlockOffsetOnly to AddressesThenOffsets.
