### PR TITLE
[TieredStorage] HotStorageWriter::new()

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -35,6 +35,19 @@ pub const HOT_FORMAT: TieredStorageFormat = TieredStorageFormat {
     account_block_format: AccountBlockFormat::AlignedRaw,
 };
 
+/// An helper function that creates a new default footer for hot
+/// accounts storage.
+fn new_hot_footer() -> TieredStorageFooter {
+    TieredStorageFooter {
+        account_meta_format: HOT_FORMAT.account_meta_format,
+        account_meta_entry_size: HOT_FORMAT.meta_entry_size as u32,
+        account_block_format: HOT_FORMAT.account_block_format,
+        index_block_format: HOT_FORMAT.index_block_format,
+        owners_block_format: HOT_FORMAT.owners_block_format,
+        ..TieredStorageFooter::default()
+    }
+}
+
 /// The maximum number of padding bytes used in a hot account entry.
 const MAX_HOT_PADDING: u8 = 7;
 
@@ -438,27 +451,18 @@ pub struct HotStorageWriter {
     storage: TieredStorageFile,
 }
 
-impl<'format> HotStorageWriter {
+impl HotStorageWriter {
+    /// Create a new HotStorageWriter with the specified path.
     pub fn new(file_path: impl AsRef<Path>) -> TieredStorageResult<Self> {
         Ok(Self {
             storage: TieredStorageFile::new_writable(file_path)?,
         })
     }
 
-    /// An internal helper function that creates a new default footer
-    /// for hot accounts storage.
-    fn new_footer() -> TieredStorageFooter {
-        TieredStorageFooter {
-            account_meta_format: HOT_FORMAT.account_meta_format,
-            account_meta_entry_size: HOT_FORMAT.meta_entry_size as u32,
-            account_block_format: HOT_FORMAT.account_block_format,
-            index_block_format: HOT_FORMAT.index_block_format,
-            owners_block_format: HOT_FORMAT.owners_block_format,
-            ..TieredStorageFooter::default()
-        }
-    }
-
-    pub fn write_accounts<
+    /// An underdevelopment function that will implement append_accounts().
+    ///
+    /// The function is currently private and does not write any accounts.
+    fn write_accounts<
         'a,
         'b,
         T: ReadableAccount + Sync,
@@ -466,10 +470,10 @@ impl<'format> HotStorageWriter {
         V: Borrow<AccountHash>,
     >(
         &self,
-        _accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
+        _storable_accounts: &StorableAccountsWithHashesAndWriteVersions<'a, 'b, T, U, V>,
         _skip: usize,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
-        let footer = HotStorageWriter::new_footer();
+        let footer = new_hot_footer();
 
         footer.write_footer_block(&self.storage)?;
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -16,8 +16,7 @@ use {
             mmap_utils::{get_pod, get_slice},
             owners::{OwnerOffset, OwnersBlock},
             readable::TieredReadableAccount,
-            Borrow, ReadableAccount, StorableAccounts, StorableAccountsWithHashesAndWriteVersions,
-            StoredAccountInfo, TieredStorageError, TieredStorageFormat, TieredStorageResult,
+            TieredStorageError, TieredStorageFormat, TieredStorageResult,
         },
     },
     bytemuck::{Pod, Zeroable},
@@ -478,13 +477,7 @@ pub mod tests {
         assert_matches::assert_matches,
         memoffset::offset_of,
         rand::{seq::SliceRandom, Rng},
-        solana_sdk::{
-            account::{AccountSharedData, ReadableAccount},
-            hash::Hash,
-            pubkey::Pubkey,
-            slot_history::Slot,
-            stake_history::Epoch,
-        },
+        solana_sdk::{account::ReadableAccount, hash::Hash, pubkey::Pubkey, stake_history::Epoch},
         tempfile::TempDir,
     };
 

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1134,7 +1134,9 @@ pub mod tests {
     fn test_hot_storage_writer_twice_on_same_path() {
         // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("test_hot_storage_writer_twice_on_same_path");
+        let path = temp_dir
+            .path()
+            .join("test_hot_storage_writer_twice_on_same_path");
 
         assert_matches!(HotStorageWriter::new(&path), Ok(_));
         assert_matches!(HotStorageWriter::new(&path), Err(_));

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1058,13 +1058,15 @@ pub mod tests {
 
     #[test]
     fn test_hot_storage_writer_twice_on_same_path() {
-        // Generate a new temp path that is guaranteed to NOT already have a file.
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir
             .path()
             .join("test_hot_storage_writer_twice_on_same_path");
 
+        // Expect the first returns Ok
         assert_matches!(HotStorageWriter::new(&path), Ok(_));
+        // Expect the second call on the same path returns Err, as the
+        // HotStorageWriter only writes once.
         assert_matches!(HotStorageWriter::new(&path), Err(_));
     }
 }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -1129,4 +1129,14 @@ pub mod tests {
             HOT_FORMAT.meta_entry_size as u32
         );
     }
+
+    #[test]
+    fn test_hot_storage_writer_twice_on_same_path() {
+        // Generate a new temp path that is guaranteed to NOT already have a file.
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("test_hot_storage_writer_twice_on_same_path");
+
+        assert_matches!(HotStorageWriter::new(&path), Ok(_));
+        assert_matches!(HotStorageWriter::new(&path), Err(_));
+    }
 }


### PR DESCRIPTION
#### Problem
The implementation of HotAccountWriter is missing.

#### Summary of Changes
This PR kicks off the implementation of HotStorageWriter by
adding HotStorageWriter::new().

#### Test Plan
Add a new unit-test that verifies the correctness of HotStorageWriter
writing zero accounts using HotStorageReader.
