### PR TITLE
earlier fee payer validation

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2349,12 +2349,8 @@ mod tests {
             let keypair_c = Keypair::new();
             let keypair_d = Keypair::new();
             for keypair in &[&keypair_a, &keypair_b, &keypair_c, &keypair_d] {
-                bank.transfer(
-                    100_000,
-                    &genesis_config_info.mint_keypair,
-                    &keypair.pubkey(),
-                )
-                .unwrap();
+                bank.transfer(5_000, &genesis_config_info.mint_keypair, &keypair.pubkey())
+                    .unwrap();
             }
 
             let make_prioritized_transfer =

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -403,12 +403,7 @@ impl Consumer {
         let pre_results = vec![Ok(()); txs.len()];
         let check_results =
             bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
-
-        let check_results = check_results
-            .into_iter()
-            .zip(txs)
-            .map(|((result, _nonce), _tx)| result);
-
+        let check_results = check_results.into_iter().map(|(result, _nonce)| result);
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -2349,8 +2349,12 @@ mod tests {
             let keypair_c = Keypair::new();
             let keypair_d = Keypair::new();
             for keypair in &[&keypair_a, &keypair_b, &keypair_c, &keypair_d] {
-                bank.transfer(5_000, &genesis_config_info.mint_keypair, &keypair.pubkey())
-                    .unwrap();
+                bank.transfer(
+                    100_000,
+                    &genesis_config_info.mint_keypair,
+                    &keypair.pubkey(),
+                )
+                .unwrap();
             }
 
             let make_prioritized_transfer =

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -19,8 +19,11 @@ use {
         BankStart, PohRecorderError, RecordTransactionsSummary, RecordTransactionsTimings,
         TransactionRecorder,
     },
-    solana_program_runtime::timings::ExecuteTimings,
+    solana_program_runtime::{
+        compute_budget_processor::process_compute_budget_instructions, timings::ExecuteTimings,
+    },
     solana_runtime::{
+        accounts::validate_fee_payer,
         bank::{Bank, LoadAndExecuteTransactionsOutput},
         transaction_batch::TransactionBatch,
     },
@@ -394,9 +397,52 @@ impl Consumer {
         txs: &[SanitizedTransaction],
         chunk_offset: usize,
     ) -> ProcessTransactionBatchOutput {
-        // No filtering before QoS - transactions should have been sanitized immediately prior to this call
-        let pre_results = std::iter::repeat(Ok(()));
-        self.process_and_record_transactions_with_pre_results(bank, txs, chunk_offset, pre_results)
+        let mut error_counters = TransactionErrorMetrics::default(); // todo how to actually accumulate these?
+        let pre_results = vec![Ok(()); txs.len()];
+        let check_results =
+            bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
+
+        let fee_check_results: Vec<_> = check_results
+            .into_iter()
+            .zip(txs)
+            .map(|((result, _nonce), tx)| {
+                result?; // if there's already error do nothing
+                let fee_payer = tx.message().fee_payer();
+                let budget_limits =
+                    process_compute_budget_instructions(tx.message().program_instructions_iter())?
+                        .into();
+                let fee = bank.fee_structure.calculate_fee(
+                    tx.message(),
+                    bank.get_lamports_per_signature(),
+                    &budget_limits,
+                    bank.feature_set.is_active(
+                        &feature_set::include_loaded_accounts_data_size_in_fee_calculation::id(),
+                    ),
+                );
+                let (mut fee_payer_account, _slot) = bank
+                    .rc
+                    .accounts
+                    .accounts_db
+                    .load_with_fixed_root(&bank.ancestors, fee_payer)
+                    .ok_or(TransactionError::AccountNotFound)?;
+
+                validate_fee_payer(
+                    fee_payer,
+                    &mut fee_payer_account,
+                    0,
+                    &mut error_counters,
+                    bank.rent_collector(),
+                    fee,
+                )
+            })
+            .collect();
+
+        self.process_and_record_transactions_with_pre_results(
+            bank,
+            txs,
+            chunk_offset,
+            fee_check_results.into_iter(),
+        )
     }
 
     pub fn process_and_record_aged_transactions(

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -200,6 +200,7 @@ fn consume_scan_should_process_packet(
         //   be blocked by a transaction that did not take batch locks. This
         //   will lead to some transactions never being processed, and a
         //   mismatch in the priorty-queue and hash map sizes.
+        //
         // Always take locks during batch creation.
         // This prevents lower-priority transactions from taking locks
         // needed by higher-priority txs that were skipped by this check.

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -1,5 +1,6 @@
 use {
     super::{
+        consumer::Consumer,
         forward_packet_batches_by_accounts::ForwardPacketBatchesByAccounts,
         immutable_deserialized_packet::ImmutableDeserializedPacket,
         latest_unprocessed_votes::{
@@ -16,6 +17,7 @@ use {
     },
     itertools::Itertools,
     min_max_heap::MinMaxHeap,
+    solana_accounts_db::transaction_error_metrics::TransactionErrorMetrics,
     solana_measure::{measure, measure_us},
     solana_runtime::bank::Bank,
     solana_sdk::{
@@ -136,6 +138,7 @@ pub struct ConsumeScannerPayload<'a> {
     pub sanitized_transactions: Vec<SanitizedTransaction>,
     pub slot_metrics_tracker: &'a mut LeaderSlotMetricsTracker,
     pub message_hash_to_transaction: &'a mut HashMap<Hash, DeserializedPacket>,
+    pub error_counters: TransactionErrorMetrics,
 }
 
 fn consume_scan_should_process_packet(
@@ -177,12 +180,31 @@ fn consume_scan_should_process_packet(
             return ProcessingDecision::Never;
         }
 
+        if !payload.account_locks.check_locks(message) {
+            return ProcessingDecision::Later;
+        }
+
+        // Run initial transaction checks for fee-payability.
+        if Consumer::check_fee_payer_unlocked(bank, message, &mut payload.error_counters).is_err() {
+            payload
+                .message_hash_to_transaction
+                .remove(packet.message_hash());
+            return ProcessingDecision::Never;
+        }
+
+        // NOTE:
+        //   This must be the last operation before adding the transaction to the
+        //   sanitized_transactions vector. Otherwise, a transaction could
+        //   be blocked by a transaction that did not take batch locks. This
+        //   will lead to some transactions never being processed, and a
+        //   mismatch in the priorty-queue and hash map sizes.
         // Always take locks during batch creation.
         // This prevents lower-priority transactions from taking locks
         // needed by higher-priority txs that were skipped by this check.
-        if !payload.account_locks.take_locks(message) {
-            return ProcessingDecision::Later;
-        }
+        //
+        // SAFETY: We just checked that the locks are available, before
+        //         checking fee-payer balance. They should still be available.
+        assert!(payload.account_locks.take_locks(message));
 
         payload.sanitized_transactions.push(sanitized_transaction);
         ProcessingDecision::Now
@@ -213,6 +235,7 @@ where
         sanitized_transactions: Vec::with_capacity(UNPROCESSED_BUFFER_STEP_SIZE),
         slot_metrics_tracker,
         message_hash_to_transaction,
+        error_counters: TransactionErrorMetrics::default(),
     };
     MultiIteratorScanner::new(
         packets,

--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -479,7 +479,7 @@ fn accumulate_and_check_loaded_account_data_size(
     }
 }
 
-fn validate_fee_payer(
+pub fn validate_fee_payer(
     payer_address: &Pubkey,
     payer_account: &mut AccountSharedData,
     payer_index: IndexOfAccount,


### PR DESCRIPTION
#### Problem
- Expired, already processed, and transactions that cannot pay fees can still take locks.

#### Summary of Changes
- Check these conditions before taking locks
- No significant affect on max or avg TPS in bench-tps
  - The account loading will bring the fee-paying account into cache (if not already there), which will typically make the subsequent load during actual processing faster  

I made a patched bench-tps to spam 60% invalid fee-paying txs. Saw degraded perf on master, much better perf with this change:

```
master: max= 9744, avg=1714
thispr: max=20065, avg=9018
```
bench-tps patch/hack: [invalid-transfer-generation.patch](https://github.com/solana-labs/solana/files/13891624/invalid-transfer-generation.patch)

Blocked by #34652 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
