### PR TITLE
ledger-tool: Minor cleanup on accountsdb config argument parsing

### DIFF
--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -1,6 +1,6 @@
 use {
     crate::LEDGER_TOOL_DIRECTORY,
-    clap::{value_t, values_t_or_exit, ArgMatches},
+    clap::{value_t, values_t, values_t_or_exit, ArgMatches},
     solana_accounts_db::{
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb},
@@ -38,14 +38,10 @@ pub fn get_accounts_db_config(
             TestPartitionedEpochRewards::None
         };
 
-    let accounts_index_drives: Vec<PathBuf> = if arg_matches.is_present("accounts_index_path") {
-        values_t_or_exit!(arg_matches, "accounts_index_path", String)
-            .into_iter()
-            .map(PathBuf::from)
-            .collect()
-    } else {
-        vec![ledger_tool_ledger_path.join("accounts_index")]
-    };
+    let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
+        .ok()
+        .map(|drives| drives.into_iter().map(PathBuf::from).collect())
+        .unwrap_or_else(|| vec![ledger_tool_ledger_path.join("accounts_index")]);
     let accounts_index_config = AccountsIndexConfig {
         bins: accounts_index_bins,
         index_limit_mb: accounts_index_index_limit_mb,

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -20,6 +20,7 @@ pub fn get_accounts_db_config(
     arg_matches: &ArgMatches<'_>,
 ) -> AccountsDbConfig {
     let ledger_tool_ledger_path = ledger_path.join(LEDGER_TOOL_DIRECTORY);
+
     let accounts_index_bins = value_t!(arg_matches, "accounts_index_bins", usize).ok();
     let accounts_index_index_limit_mb =
         if let Ok(limit) = value_t!(arg_matches, "accounts_index_memory_limit_mb", usize) {
@@ -29,15 +30,6 @@ pub fn get_accounts_db_config(
         } else {
             IndexLimitMb::Unspecified
         };
-    let test_partitioned_epoch_rewards =
-        if arg_matches.is_present("partitioned_epoch_rewards_compare_calculation") {
-            TestPartitionedEpochRewards::CompareResults
-        } else if arg_matches.is_present("partitioned_epoch_rewards_force_enable_single_slot") {
-            TestPartitionedEpochRewards::ForcePartitionedEpochRewardsInOneBlock
-        } else {
-            TestPartitionedEpochRewards::None
-        };
-
     let accounts_index_drives = values_t!(arg_matches, "accounts_index_path", String)
         .ok()
         .map(|drives| drives.into_iter().map(PathBuf::from).collect())
@@ -48,6 +40,15 @@ pub fn get_accounts_db_config(
         drives: Some(accounts_index_drives),
         ..AccountsIndexConfig::default()
     };
+
+    let test_partitioned_epoch_rewards =
+        if arg_matches.is_present("partitioned_epoch_rewards_compare_calculation") {
+            TestPartitionedEpochRewards::CompareResults
+        } else if arg_matches.is_present("partitioned_epoch_rewards_force_enable_single_slot") {
+            TestPartitionedEpochRewards::ForcePartitionedEpochRewardsInOneBlock
+        } else {
+            TestPartitionedEpochRewards::None
+        };
 
     let accounts_hash_cache_path = arg_matches
         .value_of("accounts_hash_cache_path")


### PR DESCRIPTION
#### Summary of Changes
Really minor change here; made the change as part of something else but decided to break it out to avoid cluttering the other PR
- Avoid parsing the `accounts_index_path` twice when it is present
- Reorder the parsing so that the "associated" items appear next to each other. Namely, put all of the parts of `AccountsIndexConfig` next to each other instead of having the `test_partitioned_epoch_rewards` smack in the middle of it

