### PR TITLE
Adjust blockstore open logs to say blockstore instead of database

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -316,8 +316,8 @@ impl Blockstore {
         adjust_ulimit_nofile(options.enforce_ulimit_nofile)?;
 
         // Open the database
-        let mut measure = Measure::start("open");
-        info!("Opening database at {:?}", blockstore_path);
+        let mut measure = Measure::start("blockstore open");
+        info!("Opening blockstore at {:?}", blockstore_path);
         let db = Database::open(&blockstore_path, options)?;
 
         let meta_cf = db.column();
@@ -353,7 +353,7 @@ impl Blockstore {
         let max_root = AtomicU64::new(max_root);
 
         measure.stop();
-        info!("{:?} {}", blockstore_path, measure);
+        info!("Opening blockstore done; {measure}");
         let blockstore = Blockstore {
             ledger_path: ledger_path.to_path_buf(),
             db,


### PR DESCRIPTION
#### Problem
Grepping logs, one is probably inclined to search for `blockstore` (the name of the higher level object in the source code) instead of `database`.

#### Summary of Changes
- Use `blockstore` in place of `database`
- Make the log after the open operation more similar to one prior to make it more clear that they are the before/after

Before this PR:
```
[...  solana_ledger::blockstore] Opening database at "/home/sol/ledger/rocksdb
[...  solana_ledger::blockstore] "/home/sol/ledger/rocksdb" open took 895ms
```
And after this PR:
```
[...  solana_ledger::blockstore] Opening blockstore at "/home/sol/ledger/rocksdb
[...  solana_ledger::blockstore] Opening blockstore done; blockstore open took 895ms
```