### PR TITLE
rpc: improve latency by not blocking worker threads polling IO notifications

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -111,6 +111,7 @@ use {
         },
         time::Duration,
     },
+    tokio::task,
 };
 
 type RpcCustomResult<T> = std::result::Result<T, RpcCustomError>;
@@ -434,7 +435,7 @@ impl JsonRpcRequestProcessor {
         Ok(new_response(&bank, response))
     }
 
-    pub fn get_multiple_accounts(
+    pub async fn get_multiple_accounts(
         &self,
         pubkeys: Vec<Pubkey>,
         config: Option<RpcAccountInfoConfig>,
@@ -451,10 +452,17 @@ impl JsonRpcRequestProcessor {
         })?;
         let encoding = encoding.unwrap_or(UiAccountEncoding::Base64);
 
-        let accounts = pubkeys
-            .into_iter()
-            .map(|pubkey| get_encoded_account(&bank, &pubkey, encoding, data_slice))
-            .collect::<Result<Vec<_>>>()?;
+        let mut accounts = Vec::with_capacity(pubkeys.len());
+        for pubkey in pubkeys {
+            let bank = Arc::clone(&bank);
+            accounts.push(
+                task::spawn_blocking(move || {
+                    get_encoded_account(&bank, &pubkey, encoding, data_slice)
+                })
+                .await
+                .expect("rpc: get_encoded_account panicked")?,
+            );
+        }
         Ok(new_response(&bank, accounts))
     }
 
@@ -2968,7 +2976,7 @@ pub mod rpc_accounts {
             meta: Self::Metadata,
             pubkey_strs: Vec<String>,
             config: Option<RpcAccountInfoConfig>,
-        ) -> Result<RpcResponse<Vec<Option<UiAccount>>>>;
+        ) -> BoxFuture<Result<RpcResponse<Vec<Option<UiAccount>>>>>;
 
         #[rpc(meta, name = "getBlockCommitment")]
         fn get_block_commitment(
@@ -3026,7 +3034,7 @@ pub mod rpc_accounts {
             meta: Self::Metadata,
             pubkey_strs: Vec<String>,
             config: Option<RpcAccountInfoConfig>,
-        ) -> Result<RpcResponse<Vec<Option<UiAccount>>>> {
+        ) -> BoxFuture<Result<RpcResponse<Vec<Option<UiAccount>>>>> {
             debug!(
                 "get_multiple_accounts rpc request received: {:?}",
                 pubkey_strs.len()
@@ -3037,15 +3045,19 @@ pub mod rpc_accounts {
                 .max_multiple_accounts
                 .unwrap_or(MAX_MULTIPLE_ACCOUNTS);
             if pubkey_strs.len() > max_multiple_accounts {
-                return Err(Error::invalid_params(format!(
+                return Box::pin(future::err(Error::invalid_params(format!(
                     "Too many inputs provided; max {max_multiple_accounts}"
-                )));
+                ))));
             }
             let pubkeys = pubkey_strs
                 .into_iter()
                 .map(|pubkey_str| verify_pubkey(&pubkey_str))
-                .collect::<Result<Vec<_>>>()?;
-            meta.get_multiple_accounts(pubkeys, config)
+                .collect::<Result<Vec<_>>>();
+            let pubkeys = match pubkeys {
+                Ok(pubkeys) => pubkeys,
+                Err(err) => return Box::pin(future::err(err)),
+            };
+            Box::pin(async move { meta.get_multiple_accounts(pubkeys, config).await })
         }
 
         fn get_block_commitment(

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -145,6 +145,7 @@ pub struct JsonRpcConfig {
     pub max_multiple_accounts: Option<usize>,
     pub account_indexes: AccountSecondaryIndexes,
     pub rpc_threads: usize,
+    pub rpc_blocking_threads: usize,
     pub rpc_niceness_adj: i8,
     pub full_api: bool,
     pub obsolete_v1_7_api: bool,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -844,6 +844,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("Number of threads to use for servicing RPC requests"),
         )
         .arg(
+            Arg::with_name("rpc_blocking_threads")
+                .long("rpc-blocking-threads")
+                .value_name("NUMBER")
+                .validator(is_parsable::<usize>)
+                .takes_value(true)
+                .default_value(&default_args.rpc_blocking_threads)
+                .help("Number of blocking threads to use for servicing CPU bound RPC requests (eg getMultipleAccounts)"),
+        )
+        .arg(
             Arg::with_name("rpc_niceness_adj")
                 .long("rpc-niceness-adjustment")
                 .value_name("ADJUSTMENT")
@@ -1921,6 +1930,7 @@ pub struct DefaultArgs {
     pub rpc_send_transaction_service_max_retries: String,
     pub rpc_send_transaction_batch_size: String,
     pub rpc_threads: String,
+    pub rpc_blocking_threads: String,
     pub rpc_niceness_adjustment: String,
     pub rpc_bigtable_timeout: String,
     pub rpc_bigtable_instance_name: String,
@@ -2005,6 +2015,7 @@ impl DefaultArgs {
                 .batch_size
                 .to_string(),
             rpc_threads: num_cpus::get().to_string(),
+            rpc_blocking_threads: (num_cpus::get() / 2).to_string(),
             rpc_niceness_adjustment: "0".to_string(),
             rpc_bigtable_timeout: "30".to_string(),
             rpc_bigtable_instance_name: solana_storage_bigtable::DEFAULT_INSTANCE_NAME.to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1294,6 +1294,7 @@ pub fn main() {
             ),
             disable_health_check: false,
             rpc_threads: value_t_or_exit!(matches, "rpc_threads", usize),
+            rpc_blocking_threads: value_t_or_exit!(matches, "rpc_blocking_threads", usize),
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),


### PR DESCRIPTION
#### Problem

Some RPC operations are CPU bound and run for a significant amount of time. Those operations end up blocking worker threads that are also used to handle IO notifications, leading to notifications not being polled often enough and so for the whole RPC server to potentially become slow and exhibit high latency. When latency gets high enough it can exceed request timeouts, leading to failed requests.

#### Summary of Changes

This PR makes some of the most CPU expensive RPC methods use `tokio::task::spawn_blocking` to run cpu hungry code. This way the worker threads doing IO don't get blocked and latency is improved.

The methods changed so far include:
- `getMultipleAccounts`
- `getProgramAccounts`
- `getAccount`
- `getTokenAccountsByDelegate`
- `getTokenAccountsByOwner`

I'm not super familiar with RPC so I've changed what looking at the code seems to be loading/copying a lot of data around. Please feel free to suggest more!