### PR TITLE
Introduce primitive threading in unified scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7554,6 +7554,7 @@ version = "1.18.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
+ "derivative",
  "log",
  "solana-ledger",
  "solana-logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7544,12 +7544,17 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "1.18.0"
+dependencies = [
+ "solana-sdk",
+]
 
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "1.18.0"
 dependencies = [
  "assert_matches",
+ "crossbeam-channel",
+ "log",
  "solana-ledger",
  "solana-logger",
  "solana-program-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,6 +185,7 @@ ctrlc = "3.4.2"
 curve25519-dalek = "3.2.1"
 dashmap = "5.5.3"
 derivation-path = { version = "0.2.0", default-features = false }
+derivative = "2.2.0"
 dialoguer = "0.10.4"
 digest = "0.10.7"
 dir-diff = "0.3.3"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6544,11 +6544,17 @@ dependencies = [
 [[package]]
 name = "solana-unified-scheduler-logic"
 version = "1.18.0"
+dependencies = [
+ "solana-sdk",
+]
 
 [[package]]
 name = "solana-unified-scheduler-pool"
 version = "1.18.0"
 dependencies = [
+ "assert_matches",
+ "crossbeam-channel",
+ "log",
  "solana-ledger",
  "solana-program-runtime",
  "solana-runtime",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6554,6 +6554,7 @@ version = "1.18.0"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
+ "derivative",
  "log",
  "solana-ledger",
  "solana-program-runtime",

--- a/unified-scheduler-logic/Cargo.toml
+++ b/unified-scheduler-logic/Cargo.toml
@@ -8,3 +8,6 @@ repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+
+[dependencies]
+solana-sdk = { workspace = true }

--- a/unified-scheduler-logic/src/lib.rs
+++ b/unified-scheduler-logic/src/lib.rs
@@ -1,1 +1,20 @@
-// This file will be populated with actual implementation later.
+use solana_sdk::transaction::SanitizedTransaction;
+
+pub struct Task {
+    transaction: SanitizedTransaction,
+    index: usize,
+}
+
+impl Task {
+    pub fn create_task(transaction: SanitizedTransaction, index: usize) -> Self {
+        Task { transaction, index }
+    }
+
+    pub fn task_index(&self) -> usize {
+        self.index
+    }
+
+    pub fn transaction(&self) -> &SanitizedTransaction {
+        &self.transaction
+    }
+}

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -10,6 +10,9 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+assert_matches = { workspace = true }
+crossbeam-channel = { workspace = true }
+log = { workspace = true }
 solana-ledger = { workspace = true }
 solana-program-runtime = { workspace = true }
 solana-runtime = { workspace = true }

--- a/unified-scheduler-pool/Cargo.toml
+++ b/unified-scheduler-pool/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 assert_matches = { workspace = true }
 crossbeam-channel = { workspace = true }
+derivative = { workspace = true }
 log = { workspace = true }
 solana-ledger = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -1033,7 +1033,7 @@ mod tests {
         for AsyncScheduler<TRIGGER_RACE_CONDITION>
     {
         fn id(&self) -> SchedulerId {
-            todo!();
+            unimplemented!();
         }
 
         fn context(&self) -> &SchedulingContext {
@@ -1102,11 +1102,11 @@ mod tests {
         type Inner = Self;
 
         fn into_inner(self) -> (ResultWithTimings, Self::Inner) {
-            todo!();
+            unimplemented!();
         }
 
         fn from_inner(_inner: Self::Inner, _context: SchedulingContext) -> Self {
-            todo!();
+            unimplemented!();
         }
 
         fn spawn(

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -456,9 +456,9 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             // the handler.
             //
             // Thus, it's fatal for unified scheduler's advertised superiority to squeeze every cpu
-            // cycles out of the scheduler thread. Thus, any kinds of overhead sources like
-            // syscalls and VDSO, and even memory (de)allocation should be avoided at all costs by
-            // design or by means of offloading at the last resort.
+            // cycles out of the scheduler thread. Thus, any kinds of unessential overhead sources
+            // like syscalls, VDSO, and even memory (de)allocation should be avoided at all costs
+            // by design or by means of offloading at the last resort.
             move || loop {
                 let mut is_finished = false;
                 while !is_finished {

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -213,7 +213,7 @@ impl ExecutedTask {
     }
 }
 
-// A very tiny generic message type to signal about opening and closing of subchannels, which is
+// A very tiny generic message type to signal about opening and closing of subchannels, which are
 // logically segmented series of Payloads (P1) over a signle continuous time-span, potentially
 // carrying some subchannel metadata (P2) upon opening a new subchannel.
 // Note that the above properties can be upheld only when this is used inside MPSC or SPSC channels
@@ -234,7 +234,7 @@ type ExecutedTaskPayload = SubchanneledPayload<Box<ExecutedTask>, ()>;
 // Usually, there's no way to prevent one of those threads from mixing current and next contexts
 // while processing messages with a multiple-consumer channel. A condvar or other
 // out-of-bound mechanism is needed to notify about switching of contextual data. That's because
-// there's no way to block those threads reliably on such an switching event just with a channel.
+// there's no way to block those threads reliably on such a switching event just with a channel.
 //
 // However, if the number of consumer can be determined, this can be accomplished just over a
 // single channel, which even carries an in-bound control meta-message with the contexts. The trick
@@ -949,9 +949,9 @@ mod tests {
         // That's because we're testing the serialized failing execution case in this test.
         // However, currently threaded impl can't properly abort in this situtation..
         // so, 1 should be observed, intead of 0.
-        // Also note that bank.transaction_count() is generally racy because blockstore_processor
-        // and unified_scheduler both tend to process non-conflicting batches in parallel as normal
-        // operation.
+        // Also note that bank.transaction_count() is generally racy by nature, because
+        // blockstore_processor and unified_scheduler both tend to process non-conflicting batches
+        // in parallel as part of the normal operation.
         assert_eq!(bank.transaction_count(), 1);
 
         let bank = BankWithScheduler::new(bank, Some(scheduler));

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -571,10 +571,9 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
                                 NewTaskPayload::OpenSubchannel(context) => {
                                     // signal about new SchedulingContext to both handler and
                                     // accumulator threads
-                                    runnable_task_sender.send_chained_channel(
-                                        context,
-                                        handler_count
-                                    ).unwrap();
+                                    runnable_task_sender
+                                        .send_chained_channel(context, handler_count)
+                                        .unwrap();
                                     executed_task_sender
                                         .send(ExecutedTaskPayload::OpenSubchannel(()))
                                         .unwrap();

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -509,10 +509,11 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
 
             // Now, this is the main loop for the scheduler thread, which is a special beast.
             //
-            // That's because it's the most notable bottleneck of throughput. Unified scheduler's
-            // overall throughput is largely dependant on its ultra-low latency characteristic,
-            // which is the most important design goal of the scheduler in order to reduce the
-            // transaction confirmation latency for end users.
+            // That's because it could be the most notable bottleneck of throughput in the future
+            // when there are ~100 handler threads. Unified scheduler's overall throughput is
+            // largely dependant on its ultra-low latency characteristic, which is the most
+            // important design goal of the scheduler in order to reduce the transaction
+            // confirmation latency for end users.
             //
             // Firstly, the scheduler thread must handle incoming messages from thread(s) owned by
             // the replay stage or the banking stage. It also must handle incoming messages from
@@ -528,6 +529,11 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             // concurrency density for throughput as the second design goal. This design goal
             // relies on the assumption that there's no considerable penalty arising from the
             // unbatched manner of processing.
+            //
+            // Note that this assumption isn't true as of writing.  The current code path
+            // underneath execute_batch() isn't optimized for unified scheduler's load pattern (ie.
+            // batches just with a single transaction) at all. This will be addressed in the
+            // future.
             //
             // These two key elements of the design philosophy lead to the rather unforgiving
             // implementation burden: Degraded performance would acutely manifest from an even tiny

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -199,7 +199,7 @@ impl TaskHandler for DefaultTaskHandler {
     }
 }
 
-pub struct ExecutedTask {
+struct ExecutedTask {
     task: Task,
     result_with_timings: ResultWithTimings,
 }

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -530,7 +530,7 @@ impl<S: SpawnableScheduler<TH>, TH: TaskHandler> ThreadManager<S, TH> {
             // relies on the assumption that there's no considerable penalty arising from the
             // unbatched manner of processing.
             //
-            // Note that this assumption isn't true as of writing.  The current code path
+            // Note that this assumption isn't true as of writing. The current code path
             // underneath execute_batch() isn't optimized for unified scheduler's load pattern (ie.
             // batches just with a single transaction) at all. This will be addressed in the
             // future.

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -215,7 +215,7 @@ impl ExecutedTask {
 }
 
 // A very tiny generic message type to signal about opening and closing of subchannels, which are
-// logically segmented series of Payloads (P1) over a signle continuous time-span, potentially
+// logically segmented series of Payloads (P1) over a single continuous time-span, potentially
 // carrying some subchannel metadata (P2) upon opening a new subchannel.
 // Note that the above properties can be upheld only when this is used inside MPSC or SPSC channels
 // (i.e. the consumer side needs to be single threaded). For the multiple consumer cases,

--- a/unified-scheduler-pool/src/lib.rs
+++ b/unified-scheduler-pool/src/lib.rs
@@ -11,6 +11,7 @@
 use {
     assert_matches::assert_matches,
     crossbeam_channel::{select, unbounded, Receiver, SendError, Sender},
+    derivative::Derivative,
     log::*,
     solana_ledger::blockstore_processor::{
         execute_batch, TransactionBatchWithIndexes, TransactionStatusSender,
@@ -326,18 +327,13 @@ mod chained_channel {
         }
     }
 
+    // P doesn't need to be `: Clone`, yet rustc derive can't handle it.
+    // see https://github.com/rust-lang/rust/issues/26925
+    #[derive(Derivative)]
+    #[derivative(Clone(bound = "C: Clone"))]
     pub(super) struct ChainedChannelReceiver<P, C: Clone> {
         receiver: Receiver<ChainedChannel<P, C>>,
         context: C,
-    }
-
-    impl<P, C: Clone> Clone for ChainedChannelReceiver<P, C> {
-        fn clone(&self) -> Self {
-            Self {
-                receiver: self.receiver.clone(),
-                context: self.context.clone(),
-            }
-        }
     }
 
     impl<P, C: Clone> ChainedChannelReceiver<P, C> {


### PR DESCRIPTION
(no need to start to review this at weekend).

#### Problem

There's no threading support in the unified scheduler, which will exhibit an extremely minimized overhead for unbatched processing.

#### Summary of Changes

Add minimum threading model and wire it, which still lacks suspending (and resuming) threads and aborting them on transaction error in dead blocks. Also, current impl is still full of `.unwrap()`s.

also, note that the actual scheduling code will come in later prs. after that, the code in this pr is ready for multi threaded with proper scheduling code. yet, it's still single threaded at the time of this pr. all this breakdowns are done for bite-sized pr reviewing.

Also, patching crossbeam is planned but yet not included in this pr as well.

#### Context

extracted from: https://github.com/solana-labs/solana/pull/33070

