### PR TITLE
[clap-v3-utils] Add functions to parse directly from `SignerSource`

### DIFF
--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -2,8 +2,8 @@ use {
     crate::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, pubkeys_of},
         keypair::{
-            parse_signer_source, pubkey_from_path, resolve_signer_from_path, signer_from_path,
-            SignerSource, SignerSourceError, SignerSourceKind,
+            pubkey_from_path, resolve_signer_from_path, signer_from_path, SignerSource,
+            SignerSourceError, SignerSourceKind,
         },
     },
     clap::{builder::ValueParser, ArgMatches},
@@ -72,7 +72,7 @@ impl SignerSourceParserBuilder {
     pub fn build(self) -> ValueParser {
         ValueParser::from(
             move |arg: &str| -> Result<SignerSource, SignerSourceError> {
-                let signer_source = parse_signer_source(arg)?;
+                let signer_source = SignerSource::parse(arg)?;
                 if !self.allow_legacy && signer_source.legacy {
                     return Err(SignerSourceError::UnsupportedSource);
                 }

--- a/clap-v3-utils/src/input_parsers/signer.rs
+++ b/clap-v3-utils/src/input_parsers/signer.rs
@@ -1,19 +1,161 @@
 use {
     crate::{
         input_parsers::{keypair_of, keypairs_of, pubkey_of, pubkeys_of},
-        keypair::{
-            pubkey_from_path, resolve_signer_from_path, signer_from_path, SignerSource,
-            SignerSourceError, SignerSourceKind,
-        },
+        keypair::{pubkey_from_path, resolve_signer_from_path, signer_from_path, ASK_KEYWORD},
     },
     clap::{builder::ValueParser, ArgMatches},
-    solana_remote_wallet::remote_wallet::RemoteWalletManager,
+    solana_remote_wallet::{
+        locator::{Locator as RemoteWalletLocator, LocatorError as RemoteWalletLocatorError},
+        remote_wallet::RemoteWalletManager,
+    },
     solana_sdk::{
+        derivation_path::{DerivationPath, DerivationPathError},
         pubkey::Pubkey,
         signature::{Keypair, Signature, Signer},
     },
     std::{error, rc::Rc, str::FromStr},
+    thiserror::Error,
 };
+
+const SIGNER_SOURCE_PROMPT: &str = "prompt";
+const SIGNER_SOURCE_FILEPATH: &str = "file";
+const SIGNER_SOURCE_USB: &str = "usb";
+const SIGNER_SOURCE_STDIN: &str = "stdin";
+const SIGNER_SOURCE_PUBKEY: &str = "pubkey";
+
+#[derive(Debug, Error)]
+pub enum SignerSourceError {
+    #[error("unrecognized signer source")]
+    UnrecognizedSource,
+    #[error(transparent)]
+    RemoteWalletLocatorError(#[from] RemoteWalletLocatorError),
+    #[error(transparent)]
+    DerivationPathError(#[from] DerivationPathError),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+    #[error("unsupported source")]
+    UnsupportedSource,
+}
+
+#[derive(Clone)]
+pub enum SignerSourceKind {
+    Prompt,
+    Filepath(String),
+    Usb(RemoteWalletLocator),
+    Stdin,
+    Pubkey(Pubkey),
+}
+
+impl AsRef<str> for SignerSourceKind {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Prompt => SIGNER_SOURCE_PROMPT,
+            Self::Filepath(_) => SIGNER_SOURCE_FILEPATH,
+            Self::Usb(_) => SIGNER_SOURCE_USB,
+            Self::Stdin => SIGNER_SOURCE_STDIN,
+            Self::Pubkey(_) => SIGNER_SOURCE_PUBKEY,
+        }
+    }
+}
+
+impl std::fmt::Debug for SignerSourceKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let s: &str = self.as_ref();
+        write!(f, "{s}")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SignerSource {
+    pub kind: SignerSourceKind,
+    pub derivation_path: Option<DerivationPath>,
+    pub legacy: bool,
+}
+
+impl SignerSource {
+    fn new(kind: SignerSourceKind) -> Self {
+        Self {
+            kind,
+            derivation_path: None,
+            legacy: false,
+        }
+    }
+
+    fn new_legacy(kind: SignerSourceKind) -> Self {
+        Self {
+            kind,
+            derivation_path: None,
+            legacy: true,
+        }
+    }
+
+    pub(crate) fn parse<S: AsRef<str>>(source: S) -> Result<Self, SignerSourceError> {
+        let source = source.as_ref();
+        let source = {
+            #[cfg(target_family = "windows")]
+            {
+                // trim matched single-quotes since cmd.exe won't
+                let mut source = source;
+                while let Some(trimmed) = source.strip_prefix('\'') {
+                    source = if let Some(trimmed) = trimmed.strip_suffix('\'') {
+                        trimmed
+                    } else {
+                        break;
+                    }
+                }
+                source.replace('\\', "/")
+            }
+            #[cfg(not(target_family = "windows"))]
+            {
+                source.to_string()
+            }
+        };
+        match uriparse::URIReference::try_from(source.as_str()) {
+            Err(_) => Err(SignerSourceError::UnrecognizedSource),
+            Ok(uri) => {
+                if let Some(scheme) = uri.scheme() {
+                    let scheme = scheme.as_str().to_ascii_lowercase();
+                    match scheme.as_str() {
+                        SIGNER_SOURCE_PROMPT => Ok(SignerSource {
+                            kind: SignerSourceKind::Prompt,
+                            derivation_path: DerivationPath::from_uri_any_query(&uri)?,
+                            legacy: false,
+                        }),
+                        SIGNER_SOURCE_FILEPATH => Ok(SignerSource::new(
+                            SignerSourceKind::Filepath(uri.path().to_string()),
+                        )),
+                        SIGNER_SOURCE_USB => Ok(SignerSource {
+                            kind: SignerSourceKind::Usb(RemoteWalletLocator::new_from_uri(&uri)?),
+                            derivation_path: DerivationPath::from_uri_key_query(&uri)?,
+                            legacy: false,
+                        }),
+                        SIGNER_SOURCE_STDIN => Ok(SignerSource::new(SignerSourceKind::Stdin)),
+                        _ => {
+                            #[cfg(target_family = "windows")]
+                            // On Windows, an absolute path's drive letter will be parsed as the URI
+                            // scheme. Assume a filepath source in case of a single character shceme.
+                            if scheme.len() == 1 {
+                                return Ok(SignerSource::new(SignerSourceKind::Filepath(source)));
+                            }
+                            Err(SignerSourceError::UnrecognizedSource)
+                        }
+                    }
+                } else {
+                    match source.as_str() {
+                        STDOUT_OUTFILE_TOKEN => Ok(SignerSource::new(SignerSourceKind::Stdin)),
+                        ASK_KEYWORD => Ok(SignerSource::new_legacy(SignerSourceKind::Prompt)),
+                        _ => match Pubkey::from_str(source.as_str()) {
+                            Ok(pubkey) => Ok(SignerSource::new(SignerSourceKind::Pubkey(pubkey))),
+                            Err(_) => std::fs::metadata(source.as_str())
+                                .map(|_| SignerSource::new(SignerSourceKind::Filepath(source)))
+                                .map_err(|err| err.into()),
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
 
 // Sentinel value used to indicate to write to screen instead of file
 pub const STDOUT_OUTFILE_TOKEN: &str = "-";
@@ -240,10 +382,129 @@ mod tests {
         super::*,
         assert_matches::assert_matches,
         clap::{Arg, Command},
+        solana_remote_wallet::locator::Manufacturer,
         solana_sdk::signature::write_keypair_file,
         std::fs,
         tempfile::NamedTempFile,
     };
+
+    #[test]
+    fn test_parse_signer_source() {
+        assert_matches!(
+            SignerSource::parse(STDOUT_OUTFILE_TOKEN).unwrap(),
+            SignerSource {
+                kind: SignerSourceKind::Stdin,
+                derivation_path: None,
+                legacy: false,
+            }
+        );
+        let stdin = "stdin:".to_string();
+        assert_matches!(
+            SignerSource::parse(stdin).unwrap(),
+            SignerSource {
+                kind: SignerSourceKind::Stdin,
+                derivation_path: None,
+                legacy: false,
+            }
+        );
+        assert_matches!(
+            SignerSource::parse(ASK_KEYWORD).unwrap(),
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: true,
+            }
+        );
+        let pubkey = Pubkey::new_unique();
+        assert!(
+            matches!(SignerSource::parse(pubkey.to_string()).unwrap(), SignerSource {
+                kind: SignerSourceKind::Pubkey(p),
+                derivation_path: None,
+                legacy: false,
+            }
+            if p == pubkey)
+        );
+
+        // Set up absolute and relative path strs
+        let file0 = NamedTempFile::new().unwrap();
+        let path = file0.path();
+        assert!(path.is_absolute());
+        let absolute_path_str = path.to_str().unwrap();
+
+        let file1 = NamedTempFile::new_in(std::env::current_dir().unwrap()).unwrap();
+        let path = file1.path().file_name().unwrap().to_str().unwrap();
+        let path = std::path::Path::new(path);
+        assert!(path.is_relative());
+        let relative_path_str = path.to_str().unwrap();
+
+        assert!(
+            matches!(SignerSource::parse(absolute_path_str).unwrap(), SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            } if p == absolute_path_str)
+        );
+        assert!(
+            matches!(SignerSource::parse(relative_path_str).unwrap(), SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            } if p == relative_path_str)
+        );
+
+        let usb = "usb://ledger".to_string();
+        let expected_locator = RemoteWalletLocator {
+            manufacturer: Manufacturer::Ledger,
+            pubkey: None,
+        };
+        assert_matches!(SignerSource::parse(usb).unwrap(), SignerSource {
+                kind: SignerSourceKind::Usb(u),
+                derivation_path: None,
+                legacy: false,
+            } if u == expected_locator);
+        let usb = "usb://ledger?key=0/0".to_string();
+        let expected_locator = RemoteWalletLocator {
+            manufacturer: Manufacturer::Ledger,
+            pubkey: None,
+        };
+        let expected_derivation_path = Some(DerivationPath::new_bip44(Some(0), Some(0)));
+        assert_matches!(SignerSource::parse(usb).unwrap(), SignerSource {
+                kind: SignerSourceKind::Usb(u),
+                derivation_path: d,
+                legacy: false,
+            } if u == expected_locator && d == expected_derivation_path);
+        // Catchall into SignerSource::Filepath fails
+        let junk = "sometextthatisnotapubkeyorfile".to_string();
+        assert!(Pubkey::from_str(&junk).is_err());
+        assert_matches!(
+            SignerSource::parse(&junk),
+            Err(SignerSourceError::IoError(_))
+        );
+
+        let prompt = "prompt:".to_string();
+        assert_matches!(
+            SignerSource::parse(prompt).unwrap(),
+            SignerSource {
+                kind: SignerSourceKind::Prompt,
+                derivation_path: None,
+                legacy: false,
+            }
+        );
+        assert!(
+            matches!(SignerSource::parse(format!("file:{absolute_path_str}")).unwrap(), SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            } if p == absolute_path_str)
+        );
+        assert!(
+            matches!(SignerSource::parse(format!("file:{relative_path_str}")).unwrap(), SignerSource {
+                kind: SignerSourceKind::Filepath(p),
+                derivation_path: None,
+                legacy: false,
+            } if p == relative_path_str)
+        );
+    }
 
     fn app<'ab>() -> Command<'ab> {
         Command::new("test")

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -1,5 +1,5 @@
 use {
-    crate::keypair::{parse_signer_source, SignerSourceKind, ASK_KEYWORD},
+    crate::keypair::{SignerSource, SignerSourceKind, ASK_KEYWORD},
     chrono::DateTime,
     solana_sdk::{
         clock::{Epoch, Slot},
@@ -119,7 +119,7 @@ pub fn is_prompt_signer_source(string: &str) -> Result<(), String> {
     if string == ASK_KEYWORD {
         return Ok(());
     }
-    match parse_signer_source(string)
+    match SignerSource::parse(string)
         .map_err(|err| format!("{err}"))?
         .kind
     {
@@ -154,7 +154,7 @@ pub fn is_valid_pubkey<T>(string: T) -> Result<(), String>
 where
     T: AsRef<str> + Display,
 {
-    match parse_signer_source(string.as_ref())
+    match SignerSource::parse(string.as_ref())
         .map_err(|err| format!("{err}"))?
         .kind
     {

--- a/clap-v3-utils/src/input_validators.rs
+++ b/clap-v3-utils/src/input_validators.rs
@@ -1,5 +1,8 @@
 use {
-    crate::keypair::{SignerSource, SignerSourceKind, ASK_KEYWORD},
+    crate::{
+        input_parsers::signer::{SignerSource, SignerSourceKind},
+        keypair::ASK_KEYWORD,
+    },
     chrono::DateTime,
     solana_sdk::{
         clock::{Epoch, Slot},

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -11,10 +11,7 @@
 
 use {
     crate::{
-        input_parsers::{
-            pubkeys_sigs_of,
-            signer::{try_pubkeys_sigs_of, SignerSource, SignerSourceKind},
-        },
+        input_parsers::signer::{try_pubkeys_sigs_of, SignerSource, SignerSourceKind},
         offline::{SIGNER_ARG, SIGN_ONLY_ARG},
         ArgConstant,
     },

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -554,7 +554,7 @@ pub fn signer_from_path(
     signer_from_path_with_config(matches, path, keypair_name, wallet_manager, &config)
 }
 
-fn signer_from_source(
+pub fn signer_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     keypair_name: &str,
@@ -632,7 +632,7 @@ pub fn signer_from_path_with_config(
     signer_from_source_with_config(matches, &source, keypair_name, wallet_manager, config)
 }
 
-fn signer_from_source_with_config(
+pub fn signer_from_source_with_config(
     matches: &ArgMatches,
     source: &SignerSource,
     keypair_name: &str,
@@ -750,7 +750,7 @@ pub fn pubkey_from_path(
     pubkey_from_source(matches, &source, keypair_name, wallet_manager)
 }
 
-fn pubkey_from_source(
+pub fn pubkey_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     keypair_name: &str,
@@ -772,7 +772,7 @@ pub fn resolve_signer_from_path(
     resolve_signer_from_source(matches, &source, keypair_name, wallet_manager)
 }
 
-fn resolve_signer_from_source(
+pub fn resolve_signer_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     keypair_name: &str,
@@ -912,7 +912,7 @@ pub fn keypair_from_path(
     Ok(keypair)
 }
 
-fn keypair_from_source(
+pub fn keypair_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     keypair_name: &str,
@@ -974,7 +974,7 @@ pub fn elgamal_keypair_from_path(
     Ok(elgamal_keypair)
 }
 
-fn elgamal_keypair_from_source(
+pub fn elgamal_keypair_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     elgamal_keypair_name: &str,
@@ -1039,7 +1039,7 @@ pub fn ae_key_from_path(
     encodable_key_from_path(path, key_name, skip_validation)
 }
 
-fn ae_key_from_source(
+pub fn ae_key_from_source(
     matches: &ArgMatches,
     source: &SignerSource,
     key_name: &str,


### PR DESCRIPTION
#### Problem
As described in https://github.com/solana-labs/solana/pull/33478, the `Arg::validator` is deprecated in clap-v3. The approach specified in https://github.com/solana-labs/solana/pull/33478 is to naturally use `SignerSource` as an intermediate type so that applications can call `matches.get_one::<SignerSource>(...)` to idiomatically validate and parse signer source.

A previous PR https://github.com/solana-labs/solana/pull/33802 added a way to flexibly parse `SignerSource`. What we need now is to parse `Signer`, `Keypair`, or `Pubkey` from a source.

#### Summary of Changes
- [87f0cb1](https://github.com/solana-labs/solana/pull/34678/commits/87f0cb14119779cd5237892d9abebf369ce0d08e): Added `_from_source` variants of the functions that parse `Signer`, `Keypair`, or `Pubkey` from "path".
- [a00e8fc](https://github.com/solana-labs/solana/pull/34678/commits/a00e8fcfb6d4a1eb57b36c2718ba435eeb6e016d): Moved the private function `parse_signer_source` to be an associated function of `SignerSource` to make the code cleaner.
- [31f1183](https://github.com/solana-labs/solana/pull/34678/commits/31f11834af2f01e2e631a49becf098171620a11f): Made `SignerSource` a public type and moved it into `input_parsers::signer`.
- [a300fdb](https://github.com/solana-labs/solana/pull/34678/commits/a300fdb82bcdf1fa022f3e4b63e5c79069ff6b11): Made the `_from_source` functions public so that downstream cli projects can use it to parse `Signer`, `Keypair`, or `Pubkey`. 

Combined with https://github.com/solana-labs/solana/pull/33802, this PR replaces the original PR https://github.com/solana-labs/solana/pull/33478.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
