### PR TITLE
checks: Removes unnecessary braces

### DIFF
--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -59,9 +59,9 @@ macro_rules! declare_process_instruction {
             ) -> std::result::Result<u64, Box<dyn std::error::Error>> {
                 fn process_instruction_inner(
                     $invoke_context: &mut $crate::invoke_context::InvokeContext,
-                ) -> std::result::Result<(), solana_sdk::instruction::InstructionError> {
+                ) -> std::result::Result<(), solana_sdk::instruction::InstructionError>
                     $inner
-                }
+
                 let consumption_result = if $cu_to_consume > 0
                     && invoke_context
                         .feature_set


### PR DESCRIPTION
#### Problem

When upgrading nightly Rust[^1], there was a CI `checks` error[^2]:

```
warning: unnecessary braces around block return value
  --> program-runtime/src/invoke_context.rs:63:21
   |
63 |                     $inner
   |                     ^^^^^^
   |
   = note: `#[warn(unused_braces)]` on by default
warning: `solana-program-runtime` (lib test) generated 1 warning
```

[^1]: https://github.com/solana-labs/solana/pull/34673
[^2]: https://buildkite.com/solana-labs/solana/builds/106341#018ce4f8-f32b-4356-92e3-b6e12960a147


#### Summary of Changes

Remove the braces.