### PR TITLE
Updates bank-new_from_fields datapoints

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1870,15 +1870,15 @@ impl Bank {
         assert_eq!(bank.epoch, bank.epoch_schedule.get_epoch(bank.slot));
 
         datapoint_info!(
-            "bank-new-from-fields",
+            "bank-new_from_fields",
             (
-                "accounts_data_len-from-snapshot",
-                fields.accounts_data_len as i64,
+                "accounts_data_size_from_snapshot",
+                fields.accounts_data_len,
                 i64
             ),
             (
-                "accounts_data_len-from-generate_index",
-                accounts_data_size_initial as i64,
+                "accounts_data_size_from_generate_index",
+                accounts_data_size_initial,
                 i64
             ),
             (


### PR DESCRIPTION
#### Problem

Some minor issues with the `bank-new-from-fields` datapoints:

1. The use of dashes instead of underscores
2. The accounts data size name should be used instead of the old "accounts data len"
3. Unnecessary casts on the datapoints' values


#### Summary of Changes

Use underscores instead of dashes, rename accounts data len to accounts data size, and remove unnecessary casts.

Note: This changes the name of the datapoint, which can be annoying/surprising when unexpected. I'm calling this out to help make the change obvious.