### PR TITLE
Moves where the TransactionExecutionDetails::accounts_data_len_delta is interpreted

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4882,7 +4882,7 @@ impl Bank {
             accounts,
             return_data,
             touched_account_count,
-            accounts_resize_delta,
+            accounts_resize_delta: accounts_data_len_delta,
         } = transaction_context.into();
 
         if status.is_ok()
@@ -4915,7 +4915,7 @@ impl Bank {
                 durable_nonce_fee,
                 return_data,
                 executed_units,
-                accounts_data_len_delta: accounts_resize_delta,
+                accounts_data_len_delta,
             },
             programs_modified_by_tx: Box::new(programs_modified_by_tx),
         }


### PR DESCRIPTION
#### Problem

After executing a transaction, we build and return a `TransactionExecutionResult`. This value is used later when committing transactions.

For recording the accounts data size delta, currently we are modifying the value stored into the execution result during `execute` based on the transaction's status, and then using the delta in `commit`. Since this code is split, it's possible to miss one side vs the other. Also, we're conditionally changing what actually happened during transaction execution. It would be better to not change the delta, but instead move the interpretation to `commit`.


#### Summary of Changes

The commits are:
1. Move where we check the transaction status and get the delta,
2. Refactor using the delta to be a bit simpler (IMO)