### PR TITLE
security-policy: Refer to SPL for on-chain programs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,10 @@ Provide a helpful title, detailed description of the vulnerability and an exploi
 proof-of-concept. Speculative submissions without proof-of-concept will be closed
 with no further consideration.
 
+Please refer to the
+[Solana Program Library (SPL) security policy](https://github.com/solana-labs/solana-program-library/security/policy)
+for vulnerabilities regarding SPL programs such as SPL Token.
+
 If you haven't done so already, please **enable two-factor auth** in your GitHub account.
 
 Expect a response as fast as possible in the advisory, typically within 72 hours.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -98,7 +98,7 @@ mitigation to qualify.
 #### Loss of Funds:
 $2,000,000 USD in locked SOL tokens (locked for 12 months)
 * Theft of funds without users signature from any account
-* Theft of funds without users interaction in system, token, stake, vote programs
+* Theft of funds without users interaction in system, stake, vote programs
 * Theft of funds that requires users signature - creating a vote program that drains the delegated stakes.
 
 #### Consensus/Safety Violations:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -133,10 +133,7 @@ The following components are out of scope for the bounty program
 * Any undeveloped automated tooling (scanners, etc) results. (OK with developed PoC)
 * Any asset whose source code does not exist in this repository (including, but not limited
 to, any and all web properties not explicitly listed on this page)
-
-The Solana Program Library has its own security policy for on-chain programs,
-such as spl-token, which is not covered here. For more information, please refer
-to the
+* Programs in the Solana Program Library, such as SPL Token. Please refer to the
 [SPL security policy](https://github.com/solana-labs/solana-program-library/security/policy).
 
 ### Eligibility:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -134,6 +134,11 @@ The following components are out of scope for the bounty program
 * Any asset whose source code does not exist in this repository (including, but not limited
 to, any and all web properties not explicitly listed on this page)
 
+The Solana Program Library has its own security policy for on-chain programs,
+such as spl-token, which is not covered here. For more information, please refer
+to the
+[SPL security policy](https://github.com/solana-labs/solana-program-library/security/policy).
+
 ### Eligibility:
 * Submissions _MUST_ include an exploit proof-of-concept to be considered eligible
 * The participant submitting the bug report shall follow the process outlined within this document


### PR DESCRIPTION
#### Problem

It's not clear that the SPL has its own security policy for those just looking at the monorepo security policy, and in fact confused a few people.

#### Summary of Changes

In the "Out of Scope" section, add a link to the SPL security policy. 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
