### PR TITLE
GitHub workflows: Disable cron schedule for forks

### DIFF
--- a/.github/workflows/autolock_bot_PR.txt
+++ b/.github/workflows/autolock_bot_PR.txt
@@ -14,6 +14,11 @@ concurrency:
 
 jobs:
   action:
+    # Forks do not need to run this, especially on cron schedule.
+    if: >
+      github.event_name != 'schedule'
+      || github.repository == 'solana-labs/solana'
+
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/autolock_bot_closed_issue.txt
+++ b/.github/workflows/autolock_bot_closed_issue.txt
@@ -14,6 +14,11 @@ concurrency:
 
 jobs:
   action:
+    # Forks do not need to run this, especially on cron schedule.
+    if: >
+      github.event_name != 'schedule'
+      || github.repository == 'solana-labs/solana'
+
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3

--- a/.github/workflows/downstream-project-spl-nightly.yml
+++ b/.github/workflows/downstream-project-spl-nightly.yml
@@ -6,6 +6,13 @@ on:
 
 jobs:
   main:
+    # As this is a cron job, it is better to avoid running it for all the forks.
+    # They are unlike to benefit from these executions, and they could easily
+    # eat up all the minutes GitHub allocation to free accounts.
+    if: >
+      github.event_name != 'schedule'
+      || github.repository == 'solana-labs/solana'
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/manage-stale-issues-and-prs.yml
+++ b/.github/workflows/manage-stale-issues-and-prs.yml
@@ -17,6 +17,11 @@ permissions:
 
 jobs:
   stale:
+    # Forks do not need to run this, especially on cron schedule.
+    if: >
+      github.event_name != 'schedule'
+      || github.repository == 'solana-labs/solana'
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v6


### PR DESCRIPTION
## Problem
Forks will run all the cron schedules.  And I do not think they benefit from those.  For the downstream project checks, these runs are actually very expensive - about an hour of run time per execution.  Easily draining free account limits.

## Solution
Disable jobs that run on cron schedules, except for the main repo.

---

I am not 100% sure this is the best solution.
But this is what I was able to figure out base on some online discussions.
I do not think anyone wants to run this in their forks?
But if they do, they would need to carry a local patch.