### PR TITLE
git: ignore all `target/` directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 farf/
+target/
 /solana-release/
 /solana-release.tar.bz2
 /solana-metrics/
 /solana-metrics.tar.bz2
-/target/
 /test-ledger/
 
 **/*.rs.bk


### PR DESCRIPTION
We have at least target/ and programs/sbf/target/