### PR TITLE
Adds newline to fastboot's CLI help

### DIFF
--- a/ledger/src/use_snapshot_archives_at_startup.rs
+++ b/ledger/src/use_snapshot_archives_at_startup.rs
@@ -38,7 +38,7 @@ pub mod cli {
         If there is no state already on disk, startup will fail. \
         Note, this will use the latest state available, \
         which may be newer than the latest snapshot archive. \
-        Specifying \"when-newest\" will use snapshot-related state \
+        \nSpecifying \"when-newest\" will use snapshot-related state \
         already on disk unless there are snapshot archives newer than it. \
         This can happen if a new snapshot archive is downloaded \
         while the node is stopped.";


### PR DESCRIPTION
#### Problem

I noticed the help text for fastboot (`--use-snapshot-archives-at-startup`) was missing a newline for "Specifying when-newest". Here's the current help text. I've added a `(X)` for the missing newline.

```
    --use-snapshot-archives-at-startup <use_snapshot_archives_at_startup>
            At startup, when should snapshot archives be extracted versus using what is already on disk? 
            Specifying "always" will always startup by extracting snapshot archives and disregard any snapshot-related
            state already on disk. Note that starting up from snapshot archives will incur the runtime costs associated
            with extracting the archives and rebuilding the local state. 
            Specifying "never" will never startup from snapshot archives and will only use snapshot-related state
            already on disk. If there is no state already on disk, startup will fail. Note, this will use the latest
            state available, which may be newer than the latest snapshot archive. (X) Specifying "when-newest" will use
            snapshot-related state already on disk unless there are snapshot archives newer than it. This can happen if
            a new snapshot archive is downloaded while the node is stopped. [default: always]  [possible values: always,
            never, when-newest]
```

#### Summary of Changes

Add the missing newline.