### PR TITLE
program-test consumes some units as native

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -112,6 +112,9 @@ pub fn invoke_builtin_function(
     let instruction_data = instruction_context.get_instruction_data();
     let instruction_account_indices = 0..instruction_context.get_number_of_instruction_accounts();
 
+    // mock builtin program must consume units
+    invoke_context.consume_checked(1)?;
+
     let log_collector = invoke_context.get_log_collector();
     let program_id = instruction_context.get_last_program_key(transaction_context)?;
     stable_log::program_invoke(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -14010,7 +14010,16 @@ fn test_failed_simulation_compute_units() {
         Bank::new_with_mockup_builtin_for_tests(&genesis_config, program_id, MockBuiltin::vm).0;
 
     const TEST_UNITS: u64 = 10_000;
-    declare_process_instruction!(MockBuiltin, 1, |invoke_context| {
+    const MOCK_BUILTIN_UNITS: u64 = 1;
+    let expected_consumed_units = if bank
+        .feature_set
+        .is_active(&solana_sdk::feature_set::native_programs_consume_cu::id())
+    {
+        TEST_UNITS + MOCK_BUILTIN_UNITS
+    } else {
+        TEST_UNITS
+    };
+    declare_process_instruction!(MockBuiltin, MOCK_BUILTIN_UNITS, |invoke_context| {
         invoke_context.consume_checked(TEST_UNITS).unwrap();
         Err(InstructionError::InvalidInstructionData)
     });
@@ -14024,5 +14033,5 @@ fn test_failed_simulation_compute_units() {
     bank.freeze();
     let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
     let simulation = bank.simulate_transaction(&sanitized, false);
-    assert_eq!(TEST_UNITS, simulation.units_consumed);
+    assert_eq!(expected_consumed_units, simulation.units_consumed);
 }


### PR DESCRIPTION
#### Problem

All builtin programs must consume some units. Program-test should too when it is in "native" mode.

#### Summary of Changes
- Program-test consume 1 unit when in native mode
- harden a unit test wrt if builtin consumes units.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
