### PR TITLE
v1.16: unpin ahash for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ edition = "2021"
 
 [workspace.dependencies]
 aes-gcm-siv = "0.10.3"
-ahash = "=0.8.3"
+ahash = "0.8.3"
 anyhow = "1.0.71"
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"


### PR DESCRIPTION
Either this one or #34723

---
#### Problem

v1.16.26 publish failed:

![Screenshot 2024-01-10 at 12 13 39](https://github.com/solana-labs/solana/assets/8209234/37518b46-a294-449d-a558-2cb91c388e8b)

the original error is (https://buildkite.com/solana-labs/solana/builds/106239#018cd29e-8257-4530-9a36-ac08d70f88b3)

I think it means we can't compile a solana program with ahash 0.8.7. if I only build an app, I won't encounter any error.

#### Summary of Changes

unpin ahash for workspace.
