### PR TITLE
Adds transaction metrics for accounts & data loaded/stored

### DIFF
--- a/program-runtime/src/timings.rs
+++ b/program-runtime/src/timings.rs
@@ -44,8 +44,12 @@ impl ProgramTiming {
 pub enum ExecuteTimingType {
     CheckUs,
     LoadUs,
+    LoadCount,
+    LoadDataBytes,
     ExecuteUs,
     StoreUs,
+    StoreCount,
+    StoreDataBytes,
     UpdateStakesCacheUs,
     NumExecuteBatches,
     CollectLogsUs,
@@ -102,6 +106,20 @@ eager_macro_rules! { $eager_1
                 i64
             ),
             (
+                "load_count",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::LoadCount),
+                i64
+            ),
+            (
+                "load_data_bytes",
+                *$self
+                    .metrics
+                    .index(ExecuteTimingType::LoadDataBytes),
+                i64
+            ),
+            (
                 "execute_us",
                 *$self
                     .metrics
@@ -121,6 +139,22 @@ eager_macro_rules! { $eager_1
 
                     .metrics
                     .index(ExecuteTimingType::StoreUs),
+                i64
+            ),
+            (
+                "store_count",
+                *$self
+
+                    .metrics
+                    .index(ExecuteTimingType::StoreCount),
+                i64
+            ),
+            (
+                "store_data_bytes",
+                *$self
+
+                    .metrics
+                    .index(ExecuteTimingType::StoreDataBytes),
                 i64
             ),
             (

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11006,7 +11006,7 @@ fn test_rent_state_list_len() {
         ))
     });
     let transaction_context = TransactionContext::new(
-        loaded_txs[0].0.as_ref().unwrap().accounts.clone(),
+        loaded_txs.0[0].0.as_ref().unwrap().accounts.clone(),
         Rent::default(),
         compute_budget.max_invoke_stack_height,
         compute_budget.max_instruction_trace_length,


### PR DESCRIPTION
#### Problem

While processing transactions, we track metrics related to how long it takes to load and store accounts, but not the number of accounts[^1] nor the amount of account data.

[^1]: Caveat: We do track the number of accounts that are passed to message processing, "execute_details_total_account_count", which matches the number of accounts loaded. So this PR adds a currently-redundant datapoint for number of loaded accounts. I can remove that if desired. Is there something similar on the store-side? I.e. a number-of-modified-accounts-to-be-stored?

#### Summary of Changes

Add metrics for the number of accounts and amount of account data loaded and stored during transaction processing.

Here's an example of the new metrics:

number of accounts
![number of accounts](https://github.com/solana-labs/solana/assets/840349/bf1e0c4f-1929-4f2d-a639-3be69d8a3663)

account data
![account data](https://github.com/solana-labs/solana/assets/840349/ad129d2a-004b-47af-8921-17e235631a5b)

