### PR TITLE
Fix program buffer account rent-exempt lamport calculation

### DIFF
--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -116,6 +116,7 @@ pub fn load_upgradeable_buffer<T: Client>(
     let program = load_program_from_file(name);
     let buffer_pubkey = buffer_keypair.pubkey();
     let buffer_authority_pubkey = buffer_authority_keypair.pubkey();
+    let program_buffer_bytes = UpgradeableLoaderState::size_of_programdata(program.len());
 
     bank_client
         .send_and_confirm_message(
@@ -127,7 +128,7 @@ pub fn load_upgradeable_buffer<T: Client>(
                     &buffer_authority_pubkey,
                     1.max(
                         bank_client
-                            .get_minimum_balance_for_rent_exemption(program.len())
+                            .get_minimum_balance_for_rent_exemption(program_buffer_bytes)
                             .unwrap(),
                     ),
                     program.len(),


### PR DESCRIPTION
#### Problem

When we use bpf_loader v2 to load a program, we create a buffer account to
upload the program data. However, the required minimum balance of the account
is calculated directly from the program data length, which is not the correct
length for the actual account's data. The actual accounts' data include the additional
45 bytes of metadata. 

Therefore, this can result that buffer account doesn't have enough lamport to be rent
exempted and fails the transaction. 

Example: 

```
[2024-01-09T20:45:22.340224015Z DEBUG solana_metrics::metrics] CounterPoint { name: "rent_paying_err-new_account", count: 0, timestamp: SystemTime { tv_sec: 1704833122, tv_nsec: 340211290 } }
[2024-01-09T20:45:22.340219646Z DEBUG solana_runtime::accounts::account_rent_state] Account 2cdvBZpHx6sxz4gCaYaYdvT4aXduC8cLDQWHsTHcg8WR not rent exempt, state Account { lamports: 714263040, data.len: 102533, owner: BPFLoaderUpgradeab1e11111111111111111111111, executable: false, rent_epoch: 18446744073709551615, data: 010000000115a25dc58afd88ec11d0e139c02e40a359bc71e50dcfc02d370318a7618db852000000000000000000000000000000000000000000000000000000 }
[2024-01-09T20:45:22.340299829Z DEBUG solana_runtime::bank] check: 22us load: 85us execute: 1035us txs_len=1
[2024-01-09T20:45:22.340312332Z DEBUG solana_runtime::bank] tx error: InsufficientFundsForRent { account_index: 1 } SanitizedTransaction { message: Legacy(LegacyMessage { message: Message { header: MessageHeader { num_required_signatures: 2, num_readonly_signed_accounts: 0, num_readonly_unsigned_accounts: 3 }, account_keys: [Crq3FuY6kvwf1g4TGnE1ThH8ECXgAV98wVf2Tka4Q9Pi, 2cdvBZpHx6sxz4gCaYaYdvT4aXduC8cLDQWHsTHcg8WR, 11111111111111111111111111111111, BPFLoaderUpgradeab1e11111111111111111111111, 2TTAEeGBRBt8kDJ3Nk5M9vYTvQ7Y8cwuKmtZy24Pz8gR], recent_blockhash: 94KXuLHsb2jK5pV7hvfSaJbJGXoe2rEC2dSNGJC2GDdG, instructions: [CompiledInstruction { program_id_index: 2, accounts: [0, 1], data: [0, 0, 0, 0, 0, 202, 146, 42, 0, 0, 0, 0, 133, 144, 1, 0, 0, 0, 0, 0, 2, 168, 246, 145, 78, 136, 161, 176, 226, 16, 21, 62, 247, 99, 174, 43, 0, 194, 185, 61, 22, 193, 36, 210, 192, 83, 122, 16, 4, 128, 0, 0] }, CompiledInstruction { program_id_index: 3, accounts: [1, 4], data: [0, 0, 0, 0] }] }, is_writable_account_cache: [true, true, false, false, false] }), message_hash: 9ytdEfJXcMoof3HM58xfu25pKXB2GgB8x4A4jbdmB5Bi, is_simple_vote_tx: false, signatures: [6727fLhm33Dad7QVqtoPxHbAX5AFgXCf6tv2FTEZn1v4sz8FEMSf5CxCstzq2SjgpHK8bD1dNfdXDD8SFJX5HiGc, hpKa8mCzjQGssDcLHN72xxucy44mfkBqHkDYDKbJxjmz4rUxBvfVwB2gz68JuD8pJ8GmKrdZUmwQwty6pnYp1Bb] }
[2024-01-09T20:45:22.340545295Z DEBUG solana_runtime::bank] 1 errors of 1 txs
[2024-01-09T20:45:22.340579881Z DEBUG solana_runtime::bank] store: 19us txs_len=1
[2024-01-09T20:45:22.340677587Z DEBUG solana_accounts_db::accounts] bank unlock accounts
thread 'test_program_sbf_realloc_invoke' panicked at /home/sol/src/solana/runtime/src/loader_utils.rs:145:10:
called `Result::unwrap()` on an `Err` value: TransactionError(InsufficientFundsForRent { account_index: 1 })
```

In this example, the program data is 102496 bytes, while the account's data is
102533 bytes. The lamports (714263040) on the account is calculated based on 102496, which
is not enough for 102533 bytes, and makes this account rent-paying, and failed the transaction.


#### Summary of Changes

Include buffer meta-data when calculating the minimal required lamports for
program buffer account.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
