### PR TITLE
v1.16: pin ahash to 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,14 +67,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.8",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -248,7 +249,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -309,7 +310,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "synstructure",
@@ -321,7 +322,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -396,7 +397,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -407,9 +408,9 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -544,12 +545,12 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease 0.2.4",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -659,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -671,7 +672,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -684,7 +685,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -694,7 +695,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -705,7 +706,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -716,7 +717,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -727,7 +728,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -833,7 +834,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1043,7 +1044,7 @@ checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1133,7 +1134,7 @@ version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f47bf7270cf70d370f8f98c1abb6d2d4cf60a6845d30e05bfb90c6568650"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "unicode-xid 0.2.2",
 ]
@@ -1349,10 +1350,10 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "strsim 0.10.0",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1363,7 +1364,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1429,7 +1430,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1441,7 +1442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustc_version 0.3.3",
  "syn 1.0.109",
@@ -1530,7 +1531,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1612,7 +1613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1653,9 +1654,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1666,7 +1667,7 @@ checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1918,9 +1919,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2150,7 +2151,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
 ]
 
 [[package]]
@@ -2610,7 +2611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3005,7 +3006,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3136,7 +3137,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3147,9 +3148,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3239,7 +3240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3251,9 +3252,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3263,9 +3264,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
 dependencies = [
  "proc-macro-crate 1.1.0",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3331,7 +3332,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3407,7 +3408,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3561,7 +3562,7 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3612,7 +3613,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3718,7 +3719,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -3728,8 +3729,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
- "proc-macro2 1.0.60",
- "syn 2.0.18",
+ "proc-macro2 1.0.76",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3758,7 +3759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "version_check",
@@ -3770,7 +3771,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "version_check",
 ]
@@ -3786,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -3883,7 +3884,7 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3896,7 +3897,7 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -4017,7 +4018,7 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
 ]
 
 [[package]]
@@ -4533,7 +4534,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -4632,9 +4633,9 @@ version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4677,9 +4678,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4728,7 +4729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b6f5d1c3087fb119617cff2966fe3808a80e5eb59a8c1601d5994d66f4346a5"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -5666,7 +5667,7 @@ dependencies = [
 name = "solana-frozen-abi"
 version = "1.16.27"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
  "blake3",
  "block-buffer 0.10.4",
  "bs58",
@@ -5698,10 +5699,10 @@ dependencies = [
 name = "solana-frozen-abi-macro"
 version = "1.16.27"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustc_version 0.4.0",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6149,7 +6150,7 @@ dependencies = [
 name = "solana-perf"
 version = "1.16.27"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
  "bincode",
  "bv",
  "caps",
@@ -6689,10 +6690,10 @@ name = "solana-sdk-macro"
 version = "1.16.27"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustversion",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -7287,7 +7288,7 @@ checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
 dependencies = [
  "quote 1.0.28",
  "spl-discriminator-syn",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -7296,10 +7297,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "sha2 0.10.6",
- "syn 2.0.18",
+ "syn 2.0.43",
  "thiserror",
 ]
 
@@ -7354,10 +7355,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "sha2 0.10.6",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -7499,7 +7500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustversion",
  "syn 1.0.109",
@@ -7534,18 +7535,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "unicode-ident",
 ]
@@ -7562,7 +7563,7 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "unicode-xid 0.2.2",
@@ -7646,7 +7647,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -7696,7 +7697,7 @@ checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -7731,9 +7732,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -7870,7 +7871,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -8061,7 +8062,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "prost-build 0.9.0",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -8074,7 +8075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease 0.1.9",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "prost-build 0.11.4",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -8150,7 +8151,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -8463,9 +8464,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -8497,9 +8498,9 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8848,6 +8849,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.28",
+ "syn 2.0.43",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8862,7 +8883,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "synstructure",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ edition = "2021"
 
 [workspace.dependencies]
 aes-gcm-siv = "0.10.3"
-ahash = "=0.8.3"
+ahash = "=0.8.4"
 anyhow = "1.0.71"
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -67,14 +67,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "72832d73be48bac96a5d7944568f305d829ed55b0ce3b483647089dfaf6cf704"
 dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.8",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -212,7 +213,7 @@ checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -248,7 +249,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -309,7 +310,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "synstructure",
@@ -321,7 +322,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -382,7 +383,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -393,9 +394,9 @@ version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -530,12 +531,12 @@ dependencies = [
  "lazycell",
  "peeking_take_while",
  "prettyplease 0.2.4",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -630,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.11.2",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -642,7 +643,7 @@ dependencies = [
  "borsh-derive-internal 0.9.3",
  "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -655,7 +656,7 @@ dependencies = [
  "borsh-derive-internal 0.10.3",
  "borsh-schema-derive-internal 0.10.3",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -665,7 +666,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -676,7 +677,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb438156919598d2c7bad7e1c0adf3d26ed3840dbc010db1a882a65583ca2fb"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -687,7 +688,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -698,7 +699,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634205cc43f74a1b9046ef87c4540ebda95696ec0f315024860cad7c5b0f5ccd"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -776,7 +777,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aca418a974d83d40a0c1f0c5cba6ff4bc28d8df099109ca459a2118d40b6322"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1165,10 +1166,10 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "strsim 0.10.0",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1179,7 +1180,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1234,7 +1235,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1246,7 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustc_version",
  "syn 1.0.109",
@@ -1329,7 +1330,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1405,7 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
 dependencies = [
  "enum-ordinalize",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1455,9 +1456,9 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1468,7 +1469,7 @@ checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
 dependencies = [
  "num-bigint 0.4.3",
  "num-traits",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -1694,9 +1695,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -1886,7 +1887,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
 ]
 
 [[package]]
@@ -2328,7 +2329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b939a78fa820cdfcb7ee7484466746a7377760970f6f9c6fe19f9edcc8a38d2"
 dependencies = [
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -2756,7 +2757,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -2880,7 +2881,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8b15b261814f992e33760b1fca9fe8b693d8a65299f20c9901688636cfb746"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -2891,9 +2892,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2973,9 +2974,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -2985,9 +2986,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3053,7 +3054,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3132,7 +3133,7 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3286,7 +3287,7 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3327,7 +3328,7 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3403,7 +3404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b83ec2d0af5c5c556257ff52c9f98934e243b9fd39604bfb2a9b75ec2e97f18"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "syn 1.0.109",
 ]
 
@@ -3413,8 +3414,8 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ceca8aaf45b5c46ec7ed39fff75f57290368c1846d33d24a122ca81416ab058"
 dependencies = [
- "proc-macro2 1.0.60",
- "syn 2.0.18",
+ "proc-macro2 1.0.76",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -3443,7 +3444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "version_check",
@@ -3455,7 +3456,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "version_check",
 ]
@@ -3471,9 +3472,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -3548,7 +3549,7 @@ checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3561,7 +3562,7 @@ checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -3668,7 +3669,7 @@ version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
 ]
 
 [[package]]
@@ -4101,7 +4102,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbda6ac5cd1321e724fa9cee216f3a61885889b896f073b8f82322789c5250e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -4179,9 +4180,9 @@ version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4224,9 +4225,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
 dependencies = [
  "darling",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -4827,7 +4828,7 @@ dependencies = [
 name = "solana-frozen-abi"
 version = "1.16.27"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
  "blake3",
  "block-buffer 0.10.4",
  "bs58",
@@ -4858,10 +4859,10 @@ dependencies = [
 name = "solana-frozen-abi-macro"
 version = "1.16.27"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustc_version",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -5088,7 +5089,7 @@ dependencies = [
 name = "solana-perf"
 version = "1.16.27"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.4",
  "bincode",
  "bv",
  "caps",
@@ -5931,10 +5932,10 @@ name = "solana-sdk-macro"
 version = "1.16.27"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustversion",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6367,7 +6368,7 @@ checksum = "fadbefec4f3c678215ca72bd71862697bb06b41fd77c0088902dd3203354387b"
 dependencies = [
  "quote 1.0.28",
  "spl-discriminator-syn",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6376,10 +6377,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e5f2044ca42c8938d54d1255ce599c79a1ffd86b677dfab695caa20f9ffc3f2"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "sha2 0.10.6",
- "syn 2.0.18",
+ "syn 2.0.43",
  "thiserror",
 ]
 
@@ -6424,10 +6425,10 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5269c8e868da17b6552ef35a51355a017bd8e0eae269c201fef830d35fa52c"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "sha2 0.10.6",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6569,7 +6570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.0",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "rustversion",
  "syn 1.0.109",
@@ -6604,18 +6605,18 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "unicode-ident",
 ]
@@ -6632,7 +6633,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "unicode-xid 0.2.3",
@@ -6702,7 +6703,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee42b4e559f17bce0385ebf511a7beb67d5cc33c12c96b7f4e9789919d9c10f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -6759,9 +6760,9 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
 ]
 
 [[package]]
@@ -6892,7 +6893,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -7083,7 +7084,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "prost-build 0.9.0",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -7096,7 +7097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease 0.1.9",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "prost-build 0.11.4",
  "quote 1.0.28",
  "syn 1.0.109",
@@ -7172,7 +7173,7 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
 ]
@@ -7474,9 +7475,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-shared",
 ]
 
@@ -7508,9 +7509,9 @@ version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
- "syn 2.0.18",
+ "syn 2.0.43",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7850,6 +7851,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.76",
+ "quote 1.0.28",
+ "syn 2.0.43",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7864,7 +7885,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
- "proc-macro2 1.0.60",
+ "proc-macro2 1.0.76",
  "quote 1.0.28",
  "syn 1.0.109",
  "synstructure",


### PR DESCRIPTION
Either this one or #34716

Close #34716

---
#### Problem

v1.16.26 publish failed:

![Screenshot 2024-01-10 at 12 13 39](https://github.com/solana-labs/solana/assets/8209234/28845b48-132e-4388-8587-1bead7249ad4)

I think `cargo publish` ignores `Cargo.lock`. (I tried to use a local vendor as well but no luck 😢 )

#### Summary of Changes

pin ahash to 0.8.4
