### PR TITLE
[TieredStorage] Include executable field into AccountMetaFlags

### DIFF
--- a/accounts-db/src/tiered_storage/meta.rs
+++ b/accounts-db/src/tiered_storage/meta.rs
@@ -16,8 +16,10 @@ pub struct AccountMetaFlags {
     pub has_rent_epoch: bool,
     /// whether the account meta has account hash
     pub has_account_hash: bool,
+    /// whether the account is executable
+    pub executable: bool,
     /// the reserved bits.
-    reserved: B30,
+    reserved: B29,
 }
 
 // Ensure there are no implicit padding bytes
@@ -90,6 +92,7 @@ impl AccountMetaFlags {
         let mut flags = AccountMetaFlags::default();
         flags.set_has_rent_epoch(optional_fields.rent_epoch.is_some());
         flags.set_has_account_hash(optional_fields.account_hash.is_some());
+        flags.set_executable(false);
         flags
     }
 }
@@ -177,12 +180,20 @@ pub mod tests {
 
         assert!(flags.has_rent_epoch());
         assert!(!flags.has_account_hash());
+        assert!(!flags.executable());
         verify_flags_serialization(&flags);
 
         flags.set_has_account_hash(true);
 
         assert!(flags.has_rent_epoch());
         assert!(flags.has_account_hash());
+        assert!(!flags.executable());
+        verify_flags_serialization(&flags);
+
+        flags.set_executable(true);
+        assert!(flags.has_rent_epoch());
+        assert!(flags.has_account_hash());
+        assert!(flags.executable());
         verify_flags_serialization(&flags);
 
         // make sure the reserved bits are untouched.


### PR DESCRIPTION
#### Problem
Before we have fully switched to the new way to determine whether
an account is executable, we still need a bit for th executable flag at
this moment in the TieredStorage as well as for backward compatibility
in case we want to revert it back.

#### Summary of Changes
This PR adds the executable flag into AccountMetaFlags.

#### Test Plan
Updated existing tests for AccountMetaFlags to cover executable flag.