### PR TITLE
ci: use larger runner for macos nightly clippy 

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -62,7 +62,9 @@ pull_request_rules:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|\.github/scripts/cargo-clippy-before-script\.sh|\.github/workflows/cargo\.yml)$
           - and:
             - check-success=clippy-stable (macos-latest)
-            - check-success=clippy-nightly (macos-latest)
+            - or:
+              - check-success=clippy-nightly (macos-latest)
+              - check-success=clippy-nightly (macos-latest-large)
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|cargo-build-bpf|cargo-test-bpf|cargo-build-sbf|cargo-test-sbf|ci/downstream-projects/run-spl\.sh|\.github/workflows/downstream-project-spl\.yml)$
           - and:


### PR DESCRIPTION
#### Problem

after we bumped rust nightly version, the macos nightly clippy becomes very flaky. listed some of them here:

- https://github.com/solana-labs/solana/actions/runs/7471834475
- https://github.com/solana-labs/solana/actions/runs/7470806359
- https://github.com/solana-labs/solana/actions/runs/7468751360
- https://github.com/solana-labs/solana/actions/runs/7468441247

all of them are terminated by signal 6

#### Summary of Changes

use `macos-latest-large` for macos nightly clippy test

---

the only concern is that it will charge us more.

![Screenshot 2024-01-10 at 17 23 50](https://github.com/solana-labs/solana/assets/8209234/09fbc676-8430-4917-9861-7e7bfff744d1)

https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates
