### PR TITLE
ci: cancel the previous build when a new commit lands

### DIFF
--- a/.github/workflows/downstream-project-anchor.yml
+++ b/.github/workflows/downstream-project-anchor.yml
@@ -25,6 +25,10 @@ on:
         type: string
         default: "master"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"

--- a/.github/workflows/downstream-project-spl.yml
+++ b/.github/workflows/downstream-project-spl.yml
@@ -26,6 +26,10 @@ on:
         type: string
         default: "master"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   SHELL: /bin/bash
   SCCACHE_GHA_ENABLED: "true"


### PR DESCRIPTION
#### Problem

we don't need to run the previous build if a new commit lands.

#### Summary of Changes

get `downstream-project-spl.yml` and `downstream-project-anchor.yml` cancel the previous build when a new commit lands.