### PR TITLE
replay: votes made before restart are eligible for refresh

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -215,8 +215,8 @@ pub(crate) enum BlockhashStatus {
     /// No vote since restart
     #[default]
     Uninitialized,
-    /// Failed generation of last vote tx
-    Failed,
+    /// Non voting validator
+    NonVoting,
     /// Successfully generated vote tx with blockhash
     Blockhash(Hash),
 }
@@ -234,7 +234,7 @@ pub struct Tower {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    // For non voting validators this is Failed
+    // For non voting validators this is NonVoting
     last_vote_tx_blockhash: BlockhashStatus,
     last_timestamp: BlockTimestamp,
     #[serde(skip)]
@@ -544,8 +544,8 @@ impl Tower {
         self.last_vote_tx_blockhash = BlockhashStatus::Blockhash(new_vote_tx_blockhash);
     }
 
-    pub(crate) fn mark_last_vote_tx_blockhash_failed(&mut self) {
-        self.last_vote_tx_blockhash = BlockhashStatus::Failed;
+    pub(crate) fn mark_last_vote_tx_blockhash_non_voting(&mut self) {
+        self.last_vote_tx_blockhash = BlockhashStatus::NonVoting;
     }
 
     pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -544,7 +544,7 @@ impl Tower {
         self.last_vote_tx_blockhash = BlockhashStatus::Blockhash(new_vote_tx_blockhash);
     }
 
-    pub(crate) fn last_vote_tx_blockhash_failed(&mut self) {
+    pub(crate) fn mark_last_vote_tx_blockhash_failed(&mut self) {
         self.last_vote_tx_blockhash = BlockhashStatus::Failed;
     }
 

--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -210,6 +210,17 @@ impl TowerVersions {
     }
 }
 
+#[derive(PartialEq, Eq, Debug, Default, Clone, Copy, AbiExample)]
+pub(crate) enum BlockhashStatus {
+    /// No vote since restart
+    #[default]
+    Uninitialized,
+    /// Failed generation of last vote tx
+    Failed,
+    /// Successfully generated vote tx with blockhash
+    Blockhash(Hash),
+}
+
 #[frozen_abi(digest = "iZi6s9BvytU3HbRsibrAD71jwMLvrqHdCjVk6qKcVvd")]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, AbiExample)]
 pub struct Tower {
@@ -223,8 +234,8 @@ pub struct Tower {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    // For non voting validators this is None
-    last_vote_tx_blockhash: Option<Hash>,
+    // For non voting validators this is Failed
+    last_vote_tx_blockhash: BlockhashStatus,
     last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root
@@ -247,7 +258,7 @@ impl Default for Tower {
             vote_state: VoteState::default(),
             last_vote: VoteTransaction::from(VoteStateUpdate::default()),
             last_timestamp: BlockTimestamp::default(),
-            last_vote_tx_blockhash: None,
+            last_vote_tx_blockhash: BlockhashStatus::default(),
             stray_restored_slot: Option::default(),
             last_switch_threshold_check: Option::default(),
         };
@@ -486,7 +497,7 @@ impl Tower {
         self.vote_state.tower()
     }
 
-    pub fn last_vote_tx_blockhash(&self) -> Option<Hash> {
+    pub(crate) fn last_vote_tx_blockhash(&self) -> BlockhashStatus {
         self.last_vote_tx_blockhash
     }
 
@@ -530,7 +541,11 @@ impl Tower {
     }
 
     pub fn refresh_last_vote_tx_blockhash(&mut self, new_vote_tx_blockhash: Hash) {
-        self.last_vote_tx_blockhash = Some(new_vote_tx_blockhash);
+        self.last_vote_tx_blockhash = BlockhashStatus::Blockhash(new_vote_tx_blockhash);
+    }
+
+    pub(crate) fn last_vote_tx_blockhash_failed(&mut self) {
+        self.last_vote_tx_blockhash = BlockhashStatus::Failed;
     }
 
     pub fn last_voted_slot_in_bank(bank: &Bank, vote_account_pubkey: &Pubkey) -> Option<Slot> {

--- a/core/src/consensus/tower1_14_11.rs
+++ b/core/src/consensus/tower1_14_11.rs
@@ -1,6 +1,6 @@
 use {
-    crate::consensus::SwitchForkDecision,
-    solana_sdk::{clock::Slot, hash::Hash, pubkey::Pubkey},
+    crate::consensus::{BlockhashStatus, SwitchForkDecision},
+    solana_sdk::{clock::Slot, pubkey::Pubkey},
     solana_vote_program::vote_state::{
         vote_state_1_14_11::VoteState1_14_11, BlockTimestamp, VoteTransaction,
     },
@@ -19,7 +19,7 @@ pub struct Tower1_14_11 {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    pub(crate) last_vote_tx_blockhash: Option<Hash>,
+    pub(crate) last_vote_tx_blockhash: BlockhashStatus,
     pub(crate) last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root

--- a/core/src/consensus/tower1_7_14.rs
+++ b/core/src/consensus/tower1_7_14.rs
@@ -1,8 +1,7 @@
 use {
-    crate::consensus::{Result, SwitchForkDecision, TowerError},
+    crate::consensus::{BlockhashStatus, Result, SwitchForkDecision, TowerError},
     solana_sdk::{
         clock::Slot,
-        hash::Hash,
         pubkey::Pubkey,
         signature::{Signature, Signer},
     },
@@ -22,7 +21,7 @@ pub struct Tower1_7_14 {
     // blockhash of the voted block itself, depending if the vote slot was refreshed.
     // For instance, a vote for slot 5, may be refreshed/resubmitted for inclusion in
     //  block 10, in  which case `last_vote_tx_blockhash` equals the blockhash of 10, not 5.
-    pub(crate) last_vote_tx_blockhash: Option<Hash>,
+    pub(crate) last_vote_tx_blockhash: BlockhashStatus,
     pub(crate) last_timestamp: BlockTimestamp,
     #[serde(skip)]
     // Restored last voted slot which cannot be found in SlotHistory at replayed root

--- a/core/src/consensus/tower_storage.rs
+++ b/core/src/consensus/tower_storage.rs
@@ -372,7 +372,7 @@ pub mod test {
         super::*,
         crate::consensus::{
             tower1_7_14::{SavedTower1_7_14, Tower1_7_14},
-            Tower,
+            BlockhashStatus, Tower,
         },
         solana_sdk::{hash::Hash, signature::Keypair},
         solana_vote_program::vote_state::{
@@ -403,7 +403,7 @@ pub mod test {
             vote_state: VoteState1_14_11::from(vote_state),
             last_vote: vote.clone(),
             last_timestamp: BlockTimestamp::default(),
-            last_vote_tx_blockhash: None,
+            last_vote_tx_blockhash: BlockhashStatus::Uninitialized,
             stray_restored_slot: Some(2),
             last_switch_threshold_check: Option::default(),
         };

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2458,7 +2458,9 @@ impl ReplayStage {
         // If we are a non voting validator or have an incorrect setup preventing us from
         // generating vote txs, no need to refresh
         let last_vote_tx_blockhash = match tower.last_vote_tx_blockhash() {
-            BlockhashStatus::Failed => return, // Do not refresh a failed vote
+            // Since the checks in vote generation are deterministic there is no need
+            // to refresh a failed vote
+            BlockhashStatus::Failed => return,
             BlockhashStatus::Uninitialized => None, // Have not voted after restart, eligible for refresh
             BlockhashStatus::Blockhash(blockhash) => Some(blockhash),
         };
@@ -2517,7 +2519,7 @@ impl ReplayStage {
                 .unwrap_or_else(|err| warn!("Error: {:?}", err));
             last_vote_refresh_time.last_refresh_time = Instant::now();
         } else {
-            tower.last_vote_tx_blockhash_failed();
+            tower.mark_last_vote_tx_blockhash_failed();
         }
     }
 
@@ -2566,7 +2568,7 @@ impl ReplayStage {
                 })
                 .unwrap_or_else(|err| warn!("Error: {:?}", err));
         } else {
-            tower.last_vote_tx_blockhash_failed();
+            tower.mark_last_vote_tx_blockhash_failed();
         }
     }
 


### PR DESCRIPTION
#### Problem
Bug in https://github.com/solana-labs/solana/pull/32315 disallows the last vote to be refreshed after a restart.
This was previously allowed before that change.

#### Summary of Changes
Distinguish a failed vote vs an uninitialized tower from restart.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
