### PR TITLE
Make check{2,3} faster by enabling parallel rustc for dcou

### DIFF
--- a/scripts/check-dev-context-only-utils.sh
+++ b/scripts/check-dev-context-only-utils.sh
@@ -147,6 +147,7 @@ fi
 # 2. Check implicit usage of `dev-context-only-utils`-gated code in dev (=
 # test/benches) code by building in isolation from other crates, which might
 # happen to enable `dev-context-only-utils`
+export RUSTFLAGS="-Z threads=8 $RUSTFLAGS"
 if [[ $mode = "check-bins" || $mode = "full" ]]; then
   _ cargo "+${rust_nightly}" hack check --bins
 fi


### PR DESCRIPTION
#### Problem

dcou needs some bruteforce compilation for every crates to circumvent cargo's feature unification for its intended functioning. so, it's slow. and people (including me) are starting to be frustrated about it.

#### Summary of Changes

use recent rust's parallelization for front-end. this is especially effective, because the dcou check only doesn't care about generating binaries.

https://blog.rust-lang.org/2023/11/09/parallel-rustc.html

#### results (15%-25% faster):

before (taken from https://github.com/solana-labs/solana/pull/34732):
 buildkite/solana/checks2 Passed (7 minutes) 
 buildkite/solana/checks3 Passed (14 minutes, 50 seconds) 

after:
 buildkite/solana/checks2 Passed (5 minutes, 55 seconds) 
 buildkite/solana/checks3 Passed (10 minutes, 52 seconds) 

related: #32169 
