### PR TITLE
Version bump v1.16.28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "gen-headers"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "regex",
@@ -1989,7 +1989,7 @@ dependencies = [
 
 [[package]]
 name = "gen-syscall-list"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "regex",
 ]
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "protobuf-src",
  "tonic-build 0.8.4",
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "rbpf-cli"
-version = "1.16.27"
+version = "1.16.28"
 
 [[package]]
 name = "rcgen"
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -4957,7 +4957,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-bench"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "solana-accounts-cluster-bench"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -5019,7 +5019,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program-tests"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banking-bench"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -5054,7 +5054,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "borsh 0.10.3",
  "futures 0.3.28",
@@ -5071,7 +5071,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-streamer"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 3.2.23",
  "crossbeam-channel",
@@ -5108,7 +5108,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bench-tps"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "crossbeam-channel",
@@ -5149,7 +5149,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bv",
  "fnv",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5184,7 +5184,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program-tests"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bv",
  "fs_extra",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-bpf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-build-sbf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_cmd",
  "bzip2",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-bpf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cargo-test-sbf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "cargo_metadata",
  "clap 3.2.23",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-v3-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "chrono",
  "clap 3.2.23",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bs58",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "anyhow",
  "dirs-next",
@@ -5364,7 +5364,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -5390,7 +5390,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5423,7 +5423,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client-test"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "futures-util",
  "serde_json",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -5459,7 +5459,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "chrono",
@@ -5472,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "solana-dos"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -5597,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "console",
  "indicatif",
@@ -5609,7 +5609,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ed25519-program-tests"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "ed25519-dalek",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "byteorder",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "ahash 0.8.4",
  "blake3",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.28",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-download-utils",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bv",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "solana-install"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "atty",
  "bincode",
@@ -5860,7 +5860,7 @@ dependencies = [
 
 [[package]]
 name = "solana-keygen"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger-tool"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_cmd",
  "bs58",
@@ -5988,7 +5988,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -6001,7 +6001,7 @@ dependencies = [
 
 [[package]]
 name = "solana-local-cluster"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "crossbeam-channel",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "solana-log-analyzer"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "byte-unit",
  "clap 3.2.23",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-sdk",
@@ -6065,11 +6065,11 @@ dependencies = [
 
 [[package]]
 name = "solana-memory-management"
-version = "1.16.27"
+version = "1.16.28"
 
 [[package]]
 name = "solana-merkle-root-bench"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6082,7 +6082,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "fast-math",
  "hex",
@@ -6092,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "crossbeam-channel",
  "env_logger",
@@ -6107,7 +6107,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-shaper"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 3.2.23",
  "rand 0.7.3",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "clap 3.2.23",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "solana-notifier"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "reqwest",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "ahash 0.8.4",
  "bincode",
@@ -6177,7 +6177,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "core_affinity",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh-bench"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 3.2.23",
  "log",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -6271,7 +6271,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -6298,7 +6298,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6324,7 +6324,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "anyhow",
  "crossbeam-channel",
@@ -6348,7 +6348,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -6377,7 +6377,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -6385,7 +6385,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "console",
  "dialoguer",
@@ -6403,7 +6403,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -6461,7 +6461,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -6490,7 +6490,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -6510,7 +6510,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "anyhow",
  "clap 2.33.3",
@@ -6527,7 +6527,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-test"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bs58",
@@ -6554,7 +6554,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "arrayref",
  "assert_matches",
@@ -6631,7 +6631,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -6687,7 +6687,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.76",
@@ -6698,7 +6698,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -6713,7 +6713,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-accounts"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6746,7 +6746,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "backoff",
  "bincode",
@@ -6778,7 +6778,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bs58",
@@ -6794,7 +6794,7 @@ dependencies = [
 
 [[package]]
 name = "solana-store-tool"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "log",
@@ -6806,7 +6806,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-channel",
  "bytes",
@@ -6838,7 +6838,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -6852,7 +6852,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -6881,7 +6881,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -6895,7 +6895,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tokens"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "chrono",
@@ -6927,7 +6927,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6951,7 +6951,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-dos"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "clap 2.33.3",
@@ -6978,7 +6978,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -7002,7 +7002,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -7015,7 +7015,7 @@ dependencies = [
 
 [[package]]
 name = "solana-upload-perf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "serde_json",
  "solana-metrics",
@@ -7023,7 +7023,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -7086,7 +7086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "rustc_version 0.4.0",
@@ -7100,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-watchtower"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "humantime",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-keygen"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "clap 3.2.23",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.16",
@@ -7173,7 +7173,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program-tests"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bytemuck",
  "curve25519-dalek",
@@ -7185,7 +7185,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "1.16.27"
+version = "1.16.28"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
 homepage = "https://solanalabs.com/"
@@ -289,76 +289,76 @@ smpl_jwt = "0.7.1"
 socket2 = "0.4.9"
 soketto = "0.7"
 solana_rbpf = "=0.6.1"
-solana-account-decoder = { path = "account-decoder", version = "=1.16.27" }
-solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.16.27" }
-solana-banks-client = { path = "banks-client", version = "=1.16.27" }
-solana-banks-interface = { path = "banks-interface", version = "=1.16.27" }
-solana-banks-server = { path = "banks-server", version = "=1.16.27" }
-solana-bench-tps = { path = "bench-tps", version = "=1.16.27" }
-solana-bloom = { path = "bloom", version = "=1.16.27" }
-solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=1.16.27" }
-solana-bucket-map = { path = "bucket_map", version = "=1.16.27" }
-solana-connection-cache = { path = "connection-cache", version = "=1.16.27", default-features = false }
-solana-clap-utils = { path = "clap-utils", version = "=1.16.27" }
-solana-clap-v3-utils = { path = "clap-v3-utils", version = "=1.16.27" }
-solana-cli = { path = "cli", version = "=1.16.27" }
-solana-cli-config = { path = "cli-config", version = "=1.16.27" }
-solana-cli-output = { path = "cli-output", version = "=1.16.27" }
-solana-client = { path = "client", version = "=1.16.27" }
-solana-compute-budget-program = { path = "programs/compute-budget", version = "=1.16.27" }
-solana-config-program = { path = "programs/config", version = "=1.16.27" }
-solana-core = { path = "core", version = "=1.16.27" }
-solana-download-utils = { path = "download-utils", version = "=1.16.27" }
-solana-entry = { path = "entry", version = "=1.16.27" }
-solana-faucet = { path = "faucet", version = "=1.16.27" }
-solana-frozen-abi = { path = "frozen-abi", version = "=1.16.27" }
-solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=1.16.27" }
-solana-genesis = { path = "genesis", version = "=1.16.27" }
-solana-genesis-utils = { path = "genesis-utils", version = "=1.16.27" }
-solana-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=1.16.27" }
-solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=1.16.27" }
-solana-gossip = { path = "gossip", version = "=1.16.27" }
-solana-loader-v4-program = { path = "programs/loader-v4", version = "=1.16.27" }
-solana-ledger = { path = "ledger", version = "=1.16.27" }
-solana-local-cluster = { path = "local-cluster", version = "=1.16.27" }
-solana-logger = { path = "logger", version = "=1.16.27" }
-solana-measure = { path = "measure", version = "=1.16.27" }
-solana-merkle-tree = { path = "merkle-tree", version = "=1.16.27" }
-solana-metrics = { path = "metrics", version = "=1.16.27" }
-solana-net-utils = { path = "net-utils", version = "=1.16.27" }
-solana-notifier = { path = "notifier", version = "=1.16.27" }
-solana-perf = { path = "perf", version = "=1.16.27" }
-solana-poh = { path = "poh", version = "=1.16.27" }
-solana-program = { path = "sdk/program", version = "=1.16.27" }
-solana-program-runtime = { path = "program-runtime", version = "=1.16.27" }
-solana-program-test = { path = "program-test", version = "=1.16.27" }
-solana-pubsub-client = { path = "pubsub-client", version = "=1.16.27" }
-solana-quic-client = { path = "quic-client", version = "=1.16.27" }
-solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.16.27" }
-solana-remote-wallet = { path = "remote-wallet", version = "=1.16.27", default-features = false }
-solana-rpc = { path = "rpc", version = "=1.16.27" }
-solana-rpc-client = { path = "rpc-client", version = "=1.16.27", default-features = false }
-solana-rpc-client-api = { path = "rpc-client-api", version = "=1.16.27" }
-solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=1.16.27" }
-solana-runtime = { path = "runtime", version = "=1.16.27" }
-solana-sdk = { path = "sdk", version = "=1.16.27" }
-solana-sdk-macro = { path = "sdk/macro", version = "=1.16.27" }
-solana-send-transaction-service = { path = "send-transaction-service", version = "=1.16.27" }
-solana-stake-program = { path = "programs/stake", version = "=1.16.27" }
-solana-storage-bigtable = { path = "storage-bigtable", version = "=1.16.27" }
-solana-storage-proto = { path = "storage-proto", version = "=1.16.27" }
-solana-streamer = { path = "streamer", version = "=1.16.27" }
-solana-system-program = { path = "programs/system", version = "=1.16.27" }
-solana-test-validator = { path = "test-validator", version = "=1.16.27" }
-solana-thin-client = { path = "thin-client", version = "=1.16.27" }
-solana-tpu-client = { path = "tpu-client", version = "=1.16.27", default-features = false }
-solana-transaction-status = { path = "transaction-status", version = "=1.16.27" }
-solana-udp-client = { path = "udp-client", version = "=1.16.27" }
-solana-version = { path = "version", version = "=1.16.27" }
-solana-vote-program = { path = "programs/vote", version = "=1.16.27" }
-solana-zk-keygen = { path = "zk-keygen", version = "=1.16.27" }
-solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=1.16.27" }
-solana-zk-token-sdk = { path = "zk-token-sdk", version = "=1.16.27" }
+solana-account-decoder = { path = "account-decoder", version = "=1.16.28" }
+solana-address-lookup-table-program = { path = "programs/address-lookup-table", version = "=1.16.28" }
+solana-banks-client = { path = "banks-client", version = "=1.16.28" }
+solana-banks-interface = { path = "banks-interface", version = "=1.16.28" }
+solana-banks-server = { path = "banks-server", version = "=1.16.28" }
+solana-bench-tps = { path = "bench-tps", version = "=1.16.28" }
+solana-bloom = { path = "bloom", version = "=1.16.28" }
+solana-bpf-loader-program = { path = "programs/bpf_loader", version = "=1.16.28" }
+solana-bucket-map = { path = "bucket_map", version = "=1.16.28" }
+solana-connection-cache = { path = "connection-cache", version = "=1.16.28", default-features = false }
+solana-clap-utils = { path = "clap-utils", version = "=1.16.28" }
+solana-clap-v3-utils = { path = "clap-v3-utils", version = "=1.16.28" }
+solana-cli = { path = "cli", version = "=1.16.28" }
+solana-cli-config = { path = "cli-config", version = "=1.16.28" }
+solana-cli-output = { path = "cli-output", version = "=1.16.28" }
+solana-client = { path = "client", version = "=1.16.28" }
+solana-compute-budget-program = { path = "programs/compute-budget", version = "=1.16.28" }
+solana-config-program = { path = "programs/config", version = "=1.16.28" }
+solana-core = { path = "core", version = "=1.16.28" }
+solana-download-utils = { path = "download-utils", version = "=1.16.28" }
+solana-entry = { path = "entry", version = "=1.16.28" }
+solana-faucet = { path = "faucet", version = "=1.16.28" }
+solana-frozen-abi = { path = "frozen-abi", version = "=1.16.28" }
+solana-frozen-abi-macro = { path = "frozen-abi/macro", version = "=1.16.28" }
+solana-genesis = { path = "genesis", version = "=1.16.28" }
+solana-genesis-utils = { path = "genesis-utils", version = "=1.16.28" }
+solana-geyser-plugin-interface = { path = "geyser-plugin-interface", version = "=1.16.28" }
+solana-geyser-plugin-manager = { path = "geyser-plugin-manager", version = "=1.16.28" }
+solana-gossip = { path = "gossip", version = "=1.16.28" }
+solana-loader-v4-program = { path = "programs/loader-v4", version = "=1.16.28" }
+solana-ledger = { path = "ledger", version = "=1.16.28" }
+solana-local-cluster = { path = "local-cluster", version = "=1.16.28" }
+solana-logger = { path = "logger", version = "=1.16.28" }
+solana-measure = { path = "measure", version = "=1.16.28" }
+solana-merkle-tree = { path = "merkle-tree", version = "=1.16.28" }
+solana-metrics = { path = "metrics", version = "=1.16.28" }
+solana-net-utils = { path = "net-utils", version = "=1.16.28" }
+solana-notifier = { path = "notifier", version = "=1.16.28" }
+solana-perf = { path = "perf", version = "=1.16.28" }
+solana-poh = { path = "poh", version = "=1.16.28" }
+solana-program = { path = "sdk/program", version = "=1.16.28" }
+solana-program-runtime = { path = "program-runtime", version = "=1.16.28" }
+solana-program-test = { path = "program-test", version = "=1.16.28" }
+solana-pubsub-client = { path = "pubsub-client", version = "=1.16.28" }
+solana-quic-client = { path = "quic-client", version = "=1.16.28" }
+solana-rayon-threadlimit = { path = "rayon-threadlimit", version = "=1.16.28" }
+solana-remote-wallet = { path = "remote-wallet", version = "=1.16.28", default-features = false }
+solana-rpc = { path = "rpc", version = "=1.16.28" }
+solana-rpc-client = { path = "rpc-client", version = "=1.16.28", default-features = false }
+solana-rpc-client-api = { path = "rpc-client-api", version = "=1.16.28" }
+solana-rpc-client-nonce-utils = { path = "rpc-client-nonce-utils", version = "=1.16.28" }
+solana-runtime = { path = "runtime", version = "=1.16.28" }
+solana-sdk = { path = "sdk", version = "=1.16.28" }
+solana-sdk-macro = { path = "sdk/macro", version = "=1.16.28" }
+solana-send-transaction-service = { path = "send-transaction-service", version = "=1.16.28" }
+solana-stake-program = { path = "programs/stake", version = "=1.16.28" }
+solana-storage-bigtable = { path = "storage-bigtable", version = "=1.16.28" }
+solana-storage-proto = { path = "storage-proto", version = "=1.16.28" }
+solana-streamer = { path = "streamer", version = "=1.16.28" }
+solana-system-program = { path = "programs/system", version = "=1.16.28" }
+solana-test-validator = { path = "test-validator", version = "=1.16.28" }
+solana-thin-client = { path = "thin-client", version = "=1.16.28" }
+solana-tpu-client = { path = "tpu-client", version = "=1.16.28", default-features = false }
+solana-transaction-status = { path = "transaction-status", version = "=1.16.28" }
+solana-udp-client = { path = "udp-client", version = "=1.16.28" }
+solana-version = { path = "version", version = "=1.16.28" }
+solana-vote-program = { path = "programs/vote", version = "=1.16.28" }
+solana-zk-keygen = { path = "zk-keygen", version = "=1.16.28" }
+solana-zk-token-proof-program = { path = "programs/zk-token-proof", version = "=1.16.28" }
+solana-zk-token-sdk = { path = "zk-token-sdk", version = "=1.16.28" }
 spl-associated-token-account = "=2.2.0"
 spl-instruction-padding = "0.1"
 spl-memo = "=4.0.0"

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -631,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.12.3",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -631,7 +631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive 0.10.3",
- "hashbrown 0.13.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -4465,7 +4465,7 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "borsh 0.10.3",
  "futures 0.3.28",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-interface"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "serde",
  "solana-sdk",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "solana-banks-server"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bv",
  "fnv",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-loader-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4559,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bpf-rust-big-mod-exp"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "array-bytes",
  "serde",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bv",
  "log",
@@ -4584,7 +4584,7 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-output"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4670,7 +4670,7 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -4678,7 +4678,7 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "chrono",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "solana-connection-cache"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "solana-core"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -4771,7 +4771,7 @@ dependencies = [
 
 [[package]]
 name = "solana-download-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "console",
  "indicatif",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "solana-entry"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "crossbeam-channel",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "ahash 0.8.4",
  "blake3",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.28",
@@ -4867,7 +4867,7 @@ dependencies = [
 
 [[package]]
 name = "solana-genesis-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-download-utils",
@@ -4878,7 +4878,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-interface"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4888,7 +4888,7 @@ dependencies = [
 
 [[package]]
 name = "solana-geyser-plugin-manager"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "crossbeam-channel",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "solana-gossip"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bv",
@@ -4958,7 +4958,7 @@ dependencies = [
 
 [[package]]
 name = "solana-ledger"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "bincode",
@@ -5017,7 +5017,7 @@ dependencies = [
 
 [[package]]
 name = "solana-loader-v4-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "rand 0.7.3",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "solana-logger"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -5038,7 +5038,7 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "solana-sdk",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "solana-merkle-tree"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "fast-math",
  "matches",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -5067,7 +5067,7 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "clap 3.1.6",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "ahash 0.8.4",
  "bincode",
@@ -5112,7 +5112,7 @@ dependencies = [
 
 [[package]]
 name = "solana-poh"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "core_affinity",
  "crossbeam-channel",
@@ -5128,7 +5128,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "solana-program-test"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -5232,7 +5232,7 @@ dependencies = [
 
 [[package]]
 name = "solana-pubsub-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "solana-quic-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "console",
  "dialoguer",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -5359,7 +5359,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -5383,7 +5383,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-api"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rpc-client-nonce-utils"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "clap 2.33.3",
  "solana-clap-utils",
@@ -5414,7 +5414,7 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "arrayref",
  "base64 0.21.2",
@@ -5484,7 +5484,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-programs"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "byteorder 1.4.3",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-128bit-dep",
@@ -5520,21 +5520,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-128bit-dep"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alloc"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-alt-bn128"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "array-bytes",
  "solana-program",
@@ -5542,21 +5542,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-call-depth"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-caller-access"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-curve25519"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-zk-token-sdk",
@@ -5564,14 +5564,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-custom-heap"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dep-crate"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "byteorder 1.4.3",
  "solana-address-lookup-table-program",
@@ -5580,21 +5580,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-deprecated-loader"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-dup-accounts"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-error-handling"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "num-derive 0.3.0",
  "num-traits",
@@ -5604,42 +5604,42 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-external-spend"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-finalize"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-get-minimum-delegation"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-inner_instruction_alignment_check"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-instruction-introspection"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-invoked",
@@ -5647,49 +5647,49 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-error"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-ok"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoke-and-return"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-invoked"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-iter"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-log-data"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-many-args"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-many-args-dep",
@@ -5697,14 +5697,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-many-args-dep"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-mem"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-membuiltins"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-mem",
@@ -5722,21 +5722,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-noop"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-panic"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-param-passing"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-param-passing-dep",
@@ -5744,14 +5744,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-param-passing-dep"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-rand"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "getrandom 0.1.14",
  "rand 0.7.3",
@@ -5760,14 +5760,14 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-realloc"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-realloc-invoke"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-sbf-rust-realloc",
@@ -5775,21 +5775,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-ro-account_modify"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-ro-modify"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sanity"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5799,7 +5799,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-secp256k1-recover"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "libsecp256k1 0.7.0",
  "solana-program",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sha"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "blake3",
  "solana-program",
@@ -5815,21 +5815,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-sibling-instructions"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sibling_inner-instructions"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-simulation"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-logger",
  "solana-program",
@@ -5840,21 +5840,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-spoof1"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-spoof1-system"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-sysvar"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
  "solana-program-runtime",
@@ -5864,21 +5864,21 @@ dependencies = [
 
 [[package]]
 name = "solana-sbf-rust-upgradeable"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sbf-rust-upgraded"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "solana-program",
 ]
 
 [[package]]
 name = "solana-sdk"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "assert_matches",
  "base64 0.21.2",
@@ -5929,7 +5929,7 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bs58",
  "proc-macro2 1.0.76",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "solana-send-transaction-service"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "crossbeam-channel",
  "log",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "solana-stake-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-bigtable"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "backoff",
  "bincode",
@@ -5999,7 +5999,7 @@ dependencies = [
 
 [[package]]
 name = "solana-storage-proto"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "bs58",
@@ -6014,7 +6014,7 @@ dependencies = [
 
 [[package]]
 name = "solana-streamer"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-channel",
  "bytes",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "solana-system-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -6057,7 +6057,7 @@ dependencies = [
 
 [[package]]
 name = "solana-test-validator"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "base64 0.21.2",
  "bincode",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "solana-thin-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -6099,7 +6099,7 @@ dependencies = [
 
 [[package]]
 name = "solana-tpu-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "bincode",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "Inflector",
  "base64 0.21.2",
@@ -6146,7 +6146,7 @@ dependencies = [
 
 [[package]]
 name = "solana-udp-client"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "async-trait",
  "solana-connection-cache",
@@ -6159,7 +6159,7 @@ dependencies = [
 
 [[package]]
 name = "solana-validator"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "chrono",
  "clap 2.33.3",
@@ -6220,7 +6220,7 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "log",
  "rustc_version",
@@ -6234,7 +6234,7 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bincode",
  "log",
@@ -6254,7 +6254,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-proof-program"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "bytemuck",
  "getrandom 0.1.14",
@@ -6267,7 +6267,7 @@ dependencies = [
 
 [[package]]
 name = "solana-zk-token-sdk"
-version = "1.16.27"
+version = "1.16.28"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.2",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.16.27"
+version = "1.16.28"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -25,29 +25,29 @@ rand = "0.7"
 serde = "1.0.112"
 serde_json = "1.0.56"
 solana_rbpf = "=0.6.1"
-solana-account-decoder = { path = "../../account-decoder", version = "=1.16.27" }
-solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.16.27" }
-solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.16.27" }
-solana-cli-output = { path = "../../cli-output", version = "=1.16.27" }
-solana-ledger = { path = "../../ledger", version = "=1.16.27" }
-solana-logger = { path = "../../logger", version = "=1.16.27" }
-solana-measure = { path = "../../measure", version = "=1.16.27" }
-solana-program = { path = "../../sdk/program", version = "=1.16.27" }
-solana-program-runtime = { path = "../../program-runtime", version = "=1.16.27" }
-solana-program-test = { path = "../../program-test", version = "=1.16.27" }
-solana-runtime = { path = "../../runtime", version = "=1.16.27" }
-solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=1.16.27" }
-solana-sbf-rust-invoke = { path = "rust/invoke", version = "=1.16.27" }
-solana-sbf-rust-invoked = { path = "rust/invoked", version = "=1.16.27", default-features = false }
-solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=1.16.27" }
-solana-sbf-rust-mem = { path = "rust/mem", version = "=1.16.27" }
-solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=1.16.27" }
-solana-sbf-rust-realloc = { path = "rust/realloc", version = "=1.16.27", default-features = false }
-solana-sbf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.16.27" }
-solana-sdk = { path = "../../sdk", version = "=1.16.27" }
-solana-transaction-status = { path = "../../transaction-status", version = "=1.16.27" }
-solana-validator = { path = "../../validator", version = "=1.16.27" }
-solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.16.27" }
+solana-account-decoder = { path = "../../account-decoder", version = "=1.16.28" }
+solana-address-lookup-table-program = { path = "../../programs/address-lookup-table", version = "=1.16.28" }
+solana-bpf-loader-program = { path = "../bpf_loader", version = "=1.16.28" }
+solana-cli-output = { path = "../../cli-output", version = "=1.16.28" }
+solana-ledger = { path = "../../ledger", version = "=1.16.28" }
+solana-logger = { path = "../../logger", version = "=1.16.28" }
+solana-measure = { path = "../../measure", version = "=1.16.28" }
+solana-program = { path = "../../sdk/program", version = "=1.16.28" }
+solana-program-runtime = { path = "../../program-runtime", version = "=1.16.28" }
+solana-program-test = { path = "../../program-test", version = "=1.16.28" }
+solana-runtime = { path = "../../runtime", version = "=1.16.28" }
+solana-sbf-rust-128bit-dep = { path = "rust/128bit_dep", version = "=1.16.28" }
+solana-sbf-rust-invoke = { path = "rust/invoke", version = "=1.16.28" }
+solana-sbf-rust-invoked = { path = "rust/invoked", version = "=1.16.28", default-features = false }
+solana-sbf-rust-many-args-dep = { path = "rust/many_args_dep", version = "=1.16.28" }
+solana-sbf-rust-mem = { path = "rust/mem", version = "=1.16.28" }
+solana-sbf-rust-param-passing-dep = { path = "rust/param_passing_dep", version = "=1.16.28" }
+solana-sbf-rust-realloc = { path = "rust/realloc", version = "=1.16.28", default-features = false }
+solana-sbf-rust-realloc-invoke = { path = "rust/realloc_invoke", version = "=1.16.28" }
+solana-sdk = { path = "../../sdk", version = "=1.16.28" }
+solana-transaction-status = { path = "../../transaction-status", version = "=1.16.28" }
+solana-validator = { path = "../../validator", version = "=1.16.28" }
+solana-zk-token-sdk = { path = "../../zk-token-sdk", version = "=1.16.28" }
 static_assertions = "1.1.0"
 thiserror = "1.0"
 

--- a/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/fail/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fail"
-version = "1.16.27"
+version = "1.16.28"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.16.27" }
+solana-program = { path = "../../../../program", version = "=1.16.28" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
+++ b/sdk/cargo-build-sbf/tests/crates/noop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noop"
-version = "1.16.27"
+version = "1.16.28"
 description = "Solana SBF test program written in Rust"
 authors = ["Solana Labs Maintainers <maintainers@solanalabs.com>"]
 repository = "https://github.com/solana-labs/solana"
@@ -10,7 +10,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-solana-program = { path = "../../../../program", version = "=1.16.27" }
+solana-program = { path = "../../../../program", version = "=1.16.28" }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Nothing in this commit except the version bump:

```
$ glol -2
44a4117ea5 2024-01-10 22:53:46 -0600  (HEAD -> version_bump_v1.16.28, origin/version_bump_v1.16.28)  will.hickey@solana.com Revert hashbrown version change
8fa19e9c2a 2024-01-10 22:45:44 -0600   will.hickey@solana.com Update version to v1.16.28
$ git diff v1.16..HEAD | grep -vE "^ |^@@ |^--- |^\+\+\+ |^index |^diff |^-( \")?solana.*1.16.27|^\+( \")?solana.*1.16.28|^-version|^\+version"
$
```