### PR TITLE
Use parent blockhash to seed EpochRewardsHasher

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2355,9 +2355,13 @@ impl Bank {
             .unwrap_or_default();
 
         let num_partitions = self.get_reward_distribution_num_blocks(&stake_rewards.stake_rewards);
+        let parent_blockhash = self
+            .parent()
+            .expect("Partitioned rewards calculation must still have access to parent Bank.")
+            .last_blockhash();
         let stake_rewards_by_partition = hash_rewards_into_partitions(
             std::mem::take(&mut stake_rewards.stake_rewards),
-            &self.parent_hash(),
+            &parent_blockhash,
             num_partitions as usize,
         );
 

--- a/runtime/src/epoch_rewards_hasher.rs
+++ b/runtime/src/epoch_rewards_hasher.rs
@@ -42,10 +42,10 @@ fn hash_to_partition(hash: u64, partitions: usize) -> usize {
 
 pub(crate) fn hash_rewards_into_partitions(
     stake_rewards: StakeRewards,
-    parent_block_hash: &Hash,
+    parent_blockhash: &Hash,
     num_partitions: usize,
 ) -> Vec<StakeRewards> {
-    let hasher = EpochRewardsHasher::new(num_partitions, parent_block_hash);
+    let hasher = EpochRewardsHasher::new(num_partitions, parent_blockhash);
     let mut result = vec![vec![]; num_partitions];
 
     for reward in stake_rewards {


### PR DESCRIPTION
#### Problem
Partitioned rewards code requires exposing the parent bank's hash to clients trying to find stake rewards, because that is the seed used for the partition hasher: https://github.com/solana-labs/solana/blob/166be2995ee76e51a343f04e41d348cfeb1cc8d9/runtime/src/bank.rs#L2360

The EpochRewardsHasher calls this the `parent_block_hash` https://github.com/solana-labs/solana/blob/166be2995ee76e51a343f04e41d348cfeb1cc8d9/runtime/src/epoch_rewards_hasher.rs#L45, so it's unclear which hash was intended.

Either way, it will certainly be easier for clients if we use the blockhash, since this is already stored in block metadata (and can be easily looked up).

#### Summary of Changes
Update `Bank::calculate_rewards_for_partitioning()` to pass the parent blockhash to `EpochRewardsHasher::calculate_rewards_for_partitioning()`
