### PR TITLE
ci: use larger runner for macos stable clippy

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-latest-large
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -61,7 +61,9 @@ pull_request_rules:
         - or:
           - -files~=(\.rs|Cargo\.toml|Cargo\.lock|\.github/scripts/cargo-clippy-before-script\.sh|\.github/workflows/cargo\.yml)$
           - and:
-            - check-success=clippy-stable (macos-latest)
+            - or:
+              - check-success=clippy-stable (macos-latest)
+              - check-success=clippy-stable (macos-latest-large)
             - or:
               - check-success=clippy-nightly (macos-latest)
               - check-success=clippy-nightly (macos-latest-large)


### PR DESCRIPTION
#### Problem

if we can cover the expense, the larger runner can save us more time!

#### Summary of Changes

use larger runner for macos stable clippy