### PR TITLE
[zk-token-proof] include `VerifyBatchRangeProofU256` in the `enable_zk_transfer_with_fee` feature gate

### DIFF
--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -261,6 +261,11 @@ declare_process_instruction!(Entrypoint, 0, |invoke_context| {
             )
         }
         ProofInstruction::VerifyBatchedRangeProofU256 => {
+            // transfer with fee related proofs are not enabled
+            if !enable_zk_transfer_with_fee {
+                return Err(InstructionError::InvalidInstructionData);
+            }
+
             if native_programs_consume_cu {
                 invoke_context
                     .consume_checked(VERIFY_BATCHED_RANGE_PROOF_U256_COMPUTE_UNITS)


### PR DESCRIPTION
#### Problem
The `VerifyBatchRangeProofU256` instruction allows users to create a "batched" range proof on a sequence of commitments. The individual bit-lengths of the encoded values in these commitments must some up to 256. 

Technically this allows a user to create a range proof of a single 256-bit committed value. This is theoretically fine, but since elliptic curve group is defined over a 256-bit prime number, it could lead to some unexpected consequences/security issues in the future. It would be good to restrict the individual bit-lengths in the batched range proof to be at most 128.

#### Summary of Changes
Since `VerifyBatchRangeProofU256` is technically only required for transfer with fee, include the instruction as part of the transfer with fee feature gate.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
