### PR TITLE
use staked connection for bench-tps in net scripts

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -392,7 +392,6 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("client-node-id")
                 .value_name("PATH")
                 .takes_value(true)
-                .requires("json_rpc_url")
                 .validator(is_keypair)
                 .help("File containing the node identity (keypair) of a validator with active stake. This allows communicating with network using staked connection"),
         )

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -68,6 +68,9 @@ solana-bench-tps)
   net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/config/bench-tps"$clientIndex".yml ./client-accounts.yml
 
+  net/scripts/rsync-retry.sh -vPrc \
+    "$entrypointIp":~/solana/config/validator-identity-1.json ./validator-identity.json
+
   args=()
 
   if ${TPU_CLIENT}; then
@@ -87,6 +90,8 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
+      --bind-address $entrypointIp \
+      --client-node-id ./validator-identity.json \
       ${args[*]} \
   "
   ;;


### PR DESCRIPTION
#### Problem

After adding throttling to streamer bench-tps shows  ~50tps. To fix this we use staked connection. 

#### Summary of Changes

