### PR TITLE
consumer bench same number of txs per iteration

### DIFF
--- a/core/benches/consumer.rs
+++ b/core/benches/consumer.rs
@@ -139,6 +139,16 @@ fn bench_process_and_record_transactions(
     batch_size: usize,
     apply_cost_tracker_during_replay: bool,
 ) {
+    const TRANSACTIONS_PER_ITERATION: usize = 64;
+    assert_eq!(
+        TRANSACTIONS_PER_ITERATION % batch_size,
+        0,
+        "batch_size must be a factor of \
+        `TRANSACTIONS_PER_ITERATION` ({TRANSACTIONS_PER_ITERATION}) \
+        so that bench results are easily comparable"
+    );
+    let batches_per_iteration = TRANSACTIONS_PER_ITERATION / batch_size;
+
     let BenchFrame {
         bank,
         ledger_path: _ledger_path,
@@ -152,12 +162,17 @@ fn bench_process_and_record_transactions(
     let mut transaction_iter = transactions.chunks(batch_size);
 
     bencher.iter(move || {
-        let summary =
-            consumer.process_and_record_transactions(&bank, transaction_iter.next().unwrap(), 0);
-        assert!(summary
-            .execute_and_commit_transactions_output
-            .commit_transactions_result
-            .is_ok());
+        for _ in 0..batches_per_iteration {
+            let summary = consumer.process_and_record_transactions(
+                &bank,
+                transaction_iter.next().unwrap(),
+                0,
+            );
+            assert!(summary
+                .execute_and_commit_transactions_output
+                .commit_transactions_result
+                .is_ok());
+        }
     });
 
     exit.store(true, Ordering::Relaxed);


### PR DESCRIPTION
#### Problem
Comment https://github.com/solana-labs/solana/pull/34717#discussion_r1448378961 for similar benchmark of the block-validation execution path. Bench results of different batch sizes are directly comparable if we always execute the same number of txs per bench iteration.

#### Summary of Changes
Run same number of txs per bench iteration in consumer benchmarks.

#### Sample result

before

```
running 6 tests
test bench_process_and_record_transactions_full_batch                        ... bench:     940,906 ns/iter (+/- 150,107)
test bench_process_and_record_transactions_full_batch_disable_tx_cost_update ... bench:     954,505 ns/iter (+/- 148,716)
test bench_process_and_record_transactions_half_batch                        ... bench:     486,423 ns/iter (+/- 95,842)
test bench_process_and_record_transactions_half_batch_disable_tx_cost_update ... bench:     495,185 ns/iter (+/- 117,344)
test bench_process_and_record_transactions_unbatched                         ... bench:      38,111 ns/iter (+/- 5,206)
test bench_process_and_record_transactions_unbatched_disable_tx_cost_update  ... bench:      39,969 ns/iter (+/- 11,277)

```

after

```
running 6 tests
test bench_process_and_record_transactions_full_batch                        ... bench:     906,828 ns/iter (+/- 125,829)
test bench_process_and_record_transactions_full_batch_disable_tx_cost_update ... bench:     938,470 ns/iter (+/- 181,095)
test bench_process_and_record_transactions_half_batch                        ... bench:     961,736 ns/iter (+/- 209,425)
test bench_process_and_record_transactions_half_batch_disable_tx_cost_update ... bench:     968,375 ns/iter (+/- 162,750)
test bench_process_and_record_transactions_unbatched                         ... bench:   2,492,309 ns/iter (+/- 718,294)
test bench_process_and_record_transactions_unbatched_disable_tx_cost_update  ... bench:   2,528,124 ns/iter (+/- 566,048)

```

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
