### PR TITLE
fee calculated with provided lamports_per_signature

### DIFF
--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -93,7 +93,7 @@ impl FeeStructure {
 
         let signature_fee = message
             .num_signatures()
-            .saturating_mul(self.lamports_per_signature);
+            .saturating_mul(lamports_per_signature);
         let write_lock_fee = message
             .num_write_locks()
             .saturating_mul(self.lamports_per_write_lock);


### PR DESCRIPTION
#### Problem

Everywhere in code, it always fetches `lamports_per_signature` from nonce account for durable transaction, otherwise from current bank, before passes it into `calculate_fee(transaction.message, lamports_per_signature, ...)`, so transaction fee could be calculated based on its corresponding `lamports_per_signature`.

In current codebase, `calculate_fee(....)` ignores passed in `lamports_per_signature` parameter with regard calculating fee, instead always using the one from current bank.

Is this the correct behavior? If so, does nonce account still need to store `lamports_per_signature`; otherwise if proposed change should be accepted?

#### Summary of Changes
- use lamports_per_signature parameter to calculate transaction fee.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
