### PR TITLE
Fix determination of staked QUIC connections

### DIFF
--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -28,7 +28,8 @@ use {
         signature::{Keypair, Signer},
     },
     solana_streamer::{
-        nonblocking::quic::compute_max_allowed_uni_streams, streamer::StakedNodes,
+        nonblocking::quic::{compute_max_allowed_uni_streams, ConnectionPeerType},
+        streamer::StakedNodes,
         tls_certificates::new_self_signed_tls_certificate,
     },
     std::{
@@ -132,17 +133,21 @@ impl QuicConfig {
     }
 
     fn compute_max_parallel_streams(&self) -> usize {
-        let (stake, total_stake) = self.maybe_client_pubkey.map_or((0, 0), |pubkey| {
-            self.maybe_staked_nodes.as_ref().map_or((0, 0), |stakes| {
-                let rstakes = stakes.read().unwrap();
-                rstakes
-                    .get_node_stake(&pubkey)
-                    .map_or((0, rstakes.total_stake()), |stake| {
-                        (stake, rstakes.total_stake())
-                    })
-            })
-        });
-        compute_max_allowed_uni_streams(stake, total_stake)
+        let (client_type, total_stake) =
+            self.maybe_client_pubkey
+                .map_or((ConnectionPeerType::Unstaked, 0), |pubkey| {
+                    self.maybe_staked_nodes.as_ref().map_or(
+                        (ConnectionPeerType::Unstaked, 0),
+                        |stakes| {
+                            let rstakes = stakes.read().unwrap();
+                            rstakes.get_node_stake(&pubkey).map_or(
+                                (ConnectionPeerType::Unstaked, rstakes.total_stake()),
+                                |stake| (ConnectionPeerType::Staked(stake), rstakes.total_stake()),
+                            )
+                        },
+                    )
+                });
+        compute_max_allowed_uni_streams(client_type, total_stake)
     }
 
     pub fn update_client_certificate(

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -482,10 +482,15 @@ async fn setup_connection(
                         stats.clone(),
                     ),
                     |(pubkey, stake, total_stake, max_stake, min_stake)| {
+                        let peer_type = if stake > 0 {
+                            ConnectionPeerType::Staked(stake)
+                        } else {
+                            ConnectionPeerType::Unstaked
+                        };
                         NewConnectionHandlerParams {
                             packet_sender,
                             remote_pubkey: Some(pubkey),
-                            peer_type: ConnectionPeerType::Staked(stake),
+                            peer_type,
                             total_stake,
                             max_connections_per_peer,
                             stats: stats.clone(),

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -90,7 +90,7 @@ pub enum ConnectionPeerType {
 }
 
 impl ConnectionPeerType {
-    fn staked(&self) -> bool {
+    fn is_staked(&self) -> bool {
         matches!(self, ConnectionPeerType::Staked(_))
     }
 }
@@ -741,7 +741,7 @@ async fn handle_connection(
                         let _ = stream.stop(VarInt::from_u32(STREAM_STOP_CODE_THROTTLING));
                         continue;
                     }
-                    if params.peer_type.staked() {
+                    if params.peer_type.is_staked() {
                         stream_load_ema.increment_load();
                     }
                     stream_counter.stream_count.fetch_add(1, Ordering::Relaxed);
@@ -792,7 +792,7 @@ async fn handle_connection(
                             }
                         }
                         stats.total_streams.fetch_sub(1, Ordering::Relaxed);
-                        if params.peer_type.staked() {
+                        if params.peer_type.is_staked() {
                             stream_load_ema.update_ema_if_needed();
                         }
                     });
@@ -877,7 +877,7 @@ async fn handle_chunk(
                     accum.meta.size = std::cmp::max(accum.meta.size, end_of_chunk);
                 }
 
-                if peer_type.staked() {
+                if peer_type.is_staked() {
                     stats
                         .total_staked_chunks_received
                         .fetch_add(1, Ordering::Relaxed);
@@ -1079,7 +1079,7 @@ impl ConnectionTable {
         if has_connection_capacity {
             let exit = Arc::new(AtomicBool::new(false));
             let last_update = Arc::new(AtomicU64::new(last_update));
-            let stream_counter = if peer_type.staked() {
+            let stream_counter = if peer_type.is_staked() {
                 connection_entry
                     .first()
                     .map(|entry| entry.stream_counter.clone())


### PR DESCRIPTION
#### Problem
The usage of `ConnectionPeerType` to determine if a connection is staked is incorrect. The `peer_type` is an attribute of the `connection_table` where a QUIC connection gets stored. We maintain two tables, one for staked connections, and the other for unstaked connections. But if the staked connection is full, the new connections get stored in the unstaked connection table, even if the peer is a staked client. So `ConnectionPeerType` can incorrectly mark a staked connection as unstaked.

Peer's stake correctly identifies if the connection is from a staked client or not. 

#### Summary of Changes
Update code to use peer's stake to determine if the connection is from a staked client.
Remove `ConnectionPeerType` and its usage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
