### PR TITLE
Add PartitionData reward type

### DIFF
--- a/accounts-db/src/rent_debits.rs
+++ b/accounts-db/src/rent_debits.rs
@@ -19,7 +19,8 @@ impl RentDebit {
             reward_type: RewardType::Rent,
             lamports: rent_debit,
             post_balance: self.post_balance,
-            commission: None, // Not applicable
+            commission: None,     // Not applicable
+            num_partitions: None, // Not applicable
         })
     }
 }

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -16,6 +16,8 @@ pub struct RewardInfo {
     pub post_balance: u64,
     /// Vote account commission when the reward was credited, only present for voting and staking rewards
     pub commission: Option<u8>,
+    /// Number of partitions calculated for epoch rewards, only present for RewardType::PartitionData
+    pub num_partitions: Option<usize>,
 }
 
 #[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -96,8 +98,9 @@ impl StakeReward {
             stake_reward_info: RewardInfo {
                 reward_type: RewardType::Staking,
                 lamports: rng.gen_range(1..200),
-                post_balance: 0,  /* unused atm */
-                commission: None, /* unused atm */
+                post_balance: 0,      /* unused atm */
+                commission: None,     /* unused atm */
+                num_partitions: None, // Not relevant
             },
 
             stake_account: validator_stake_account,

--- a/cli-output/src/display.rs
+++ b/cli-output/src/display.rs
@@ -812,6 +812,7 @@ mod test {
                 post_balance: 9_900,
                 reward_type: Some(RewardType::Rent),
                 commission: None,
+                num_partitions: None,
             }]),
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData {
@@ -891,6 +892,7 @@ Rewards:
                 post_balance: 14_900,
                 reward_type: Some(RewardType::Rent),
                 commission: None,
+                num_partitions: None,
             }]),
             loaded_addresses,
             return_data: Some(TransactionReturnData {

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -65,6 +65,7 @@ impl RewardsRecorderService {
                         post_balance: reward_info.post_balance,
                         reward_type: Some(reward_info.reward_type),
                         commission: reward_info.commission,
+                        num_partitions: reward_info.num_partitions,
                     })
                     .collect();
 

--- a/geyser-plugin-interface/src/geyser_plugin_interface.rs
+++ b/geyser-plugin-interface/src/geyser_plugin_interface.rs
@@ -8,7 +8,7 @@ use {
         signature::Signature,
         transaction::SanitizedTransaction,
     },
-    solana_transaction_status::{Reward, TransactionStatusMeta},
+    solana_transaction_status::{Reward, RewardType, TransactionStatusMeta},
     std::{any::Any, error, io},
     thiserror::Error,
 };
@@ -217,7 +217,7 @@ pub enum ReplicaEntryInfoVersions<'a> {
 pub struct ReplicaBlockInfo<'a> {
     pub slot: Slot,
     pub blockhash: &'a str,
-    pub rewards: &'a [Reward],
+    pub rewards: &'a [DeprecatedReward],
     pub block_time: Option<UnixTimestamp>,
     pub block_height: Option<u64>,
 }
@@ -230,7 +230,7 @@ pub struct ReplicaBlockInfoV2<'a> {
     pub parent_blockhash: &'a str,
     pub slot: Slot,
     pub blockhash: &'a str,
-    pub rewards: &'a [Reward],
+    pub rewards: &'a [DeprecatedReward],
     pub block_time: Option<UnixTimestamp>,
     pub block_height: Option<u64>,
     pub executed_transaction_count: u64,
@@ -240,6 +240,31 @@ pub struct ReplicaBlockInfoV2<'a> {
 #[derive(Clone, Debug)]
 #[repr(C)]
 pub struct ReplicaBlockInfoV3<'a> {
+    pub parent_slot: Slot,
+    pub parent_blockhash: &'a str,
+    pub slot: Slot,
+    pub blockhash: &'a str,
+    pub rewards: &'a [DeprecatedReward],
+    pub block_time: Option<UnixTimestamp>,
+    pub block_height: Option<u64>,
+    pub executed_transaction_count: u64,
+    pub entry_count: u64,
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct DeprecatedReward {
+    pub pubkey: String,
+    pub lamports: i64,
+    pub post_balance: u64,
+    pub reward_type: Option<RewardType>,
+    pub commission: Option<u8>,
+}
+
+/// Adding num_partitions field to each Reward.
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub struct ReplicaBlockInfoV4<'a> {
     pub parent_slot: Slot,
     pub parent_blockhash: &'a str,
     pub slot: Slot,
@@ -256,6 +281,7 @@ pub enum ReplicaBlockInfoVersions<'a> {
     V0_0_1(&'a ReplicaBlockInfo<'a>),
     V0_0_2(&'a ReplicaBlockInfoV2<'a>),
     V0_0_3(&'a ReplicaBlockInfoV3<'a>),
+    V0_0_4(&'a ReplicaBlockInfoV4<'a>),
 }
 
 /// Errors returned by plugin calls

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -92,6 +92,7 @@ impl BlockMetadataNotifierImpl {
                 post_balance: reward.post_balance,
                 reward_type: Some(reward.reward_type),
                 commission: reward.commission,
+                num_partitions: reward.num_partitions,
             })
             .collect()
     }

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -6,7 +6,7 @@ use {
     log::*,
     solana_accounts_db::stake_rewards::RewardInfo,
     solana_geyser_plugin_interface::geyser_plugin_interface::{
-        ReplicaBlockInfoV3, ReplicaBlockInfoVersions,
+        ReplicaBlockInfoV4, ReplicaBlockInfoVersions,
     },
     solana_measure::measure::Measure,
     solana_metrics::*,
@@ -52,7 +52,7 @@ impl BlockMetadataNotifier for BlockMetadataNotifierImpl {
                 executed_transaction_count,
                 entry_count,
             );
-            let block_info = ReplicaBlockInfoVersions::V0_0_3(&block_info);
+            let block_info = ReplicaBlockInfoVersions::V0_0_4(&block_info);
             match plugin.notify_block_metadata(block_info) {
                 Err(err) => {
                     error!(
@@ -107,8 +107,8 @@ impl BlockMetadataNotifierImpl {
         block_height: Option<u64>,
         executed_transaction_count: u64,
         entry_count: u64,
-    ) -> ReplicaBlockInfoV3<'a> {
-        ReplicaBlockInfoV3 {
+    ) -> ReplicaBlockInfoV4<'a> {
+        ReplicaBlockInfoV4 {
             parent_slot,
             parent_blockhash,
             slot,

--- a/ledger/benches/protobuf.rs
+++ b/ledger/benches/protobuf.rs
@@ -24,6 +24,7 @@ fn create_rewards() -> Rewards {
             post_balance: std::u64::MAX,
             reward_type: Some(RewardType::Fee),
             commission: None,
+            num_partitions: None,
         })
         .collect()
 }

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -10138,6 +10138,7 @@ pub mod tests {
                 post_balance: std::u64::MAX,
                 reward_type: Some(RewardType::Fee),
                 commission: None,
+                num_partitions: None,
             })
             .collect();
         let protobuf_rewards: generated::Rewards = rewards.into();
@@ -10211,6 +10212,7 @@ pub mod tests {
                 post_balance: 42,
                 reward_type: Some(RewardType::Rent),
                 commission: None,
+                num_partitions: None,
             }]),
             loaded_addresses: LoadedAddresses::default(),
             return_data: Some(TransactionReturnData {

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -135,6 +135,7 @@ impl TransactionStatusService {
                                     post_balance: reward_info.post_balance,
                                     reward_type: Some(reward_info.reward_type),
                                     commission: reward_info.commission,
+                                    num_partitions: reward_info.num_partitions,
                                 })
                                 .collect(),
                         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1622,7 +1622,10 @@ impl Bank {
         // (total_rewards, distributed_rewards, credit_end_exclusive), total capital will increase by (total_rewards - distributed_rewards)
         self.create_epoch_rewards_sysvar(total_rewards, distributed_rewards, credit_end_exclusive);
 
-        self.create_epoch_rewards_partition_data_account(num_partitions, parent_blockhash);
+        self.create_epoch_rewards_partition_data_account_and_record_reward(
+            num_partitions,
+            parent_blockhash,
+        );
 
         datapoint_info!(
             "epoch-rewards-status-update",
@@ -3599,7 +3602,8 @@ impl Bank {
     }
 
     /// Create the persistent PDA containing the epoch-rewards data
-    fn create_epoch_rewards_partition_data_account(
+    /// Also record a RewardType::PartitionData reward to store num_partitions in historical ledger
+    fn create_epoch_rewards_partition_data_account_and_record_reward(
         &self,
         num_partitions: usize,
         parent_blockhash: Hash,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3156,6 +3156,7 @@ impl Bank {
                                 lamports: i64::try_from(stakers_reward).unwrap(),
                                 post_balance,
                                 commission: Some(vote_state.commission),
+                                num_partitions: None,
                             },
                             stake_account,
                         });
@@ -3263,6 +3264,7 @@ impl Bank {
                                 lamports: i64::try_from(stakers_reward).unwrap(),
                                 post_balance,
                                 commission: Some(vote_state.commission),
+                                num_partitions: None,
                             },
                             stake_account,
                         });
@@ -3398,6 +3400,7 @@ impl Bank {
                             lamports: vote_rewards as i64,
                             post_balance: vote_account.lamports(),
                             commission: Some(commission),
+                            num_partitions: None,
                         },
                     ))
                 },
@@ -3448,6 +3451,7 @@ impl Bank {
                         lamports: vote_rewards as i64,
                         post_balance: vote_account.lamports(),
                         commission: Some(commission),
+                        num_partitions: None,
                     },
                 ));
                 result
@@ -3616,6 +3620,19 @@ impl Bank {
         )
         .unwrap();
         self.store_account_and_update_capitalization(&address, &new_account);
+
+        let mut rewards = self.rewards.write().unwrap();
+        rewards.reserve(1);
+        rewards.push((
+            address,
+            RewardInfo {
+                reward_type: RewardType::PartitionData,
+                lamports: 0,
+                post_balance: 0,
+                commission: None,
+                num_partitions: Some(num_partitions),
+            },
+        ));
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -67,6 +67,7 @@ impl Bank {
                                 lamports: deposit as i64,
                                 post_balance,
                                 commission: None,
+                                num_partitions: None,
                             },
                         ));
                     }
@@ -227,6 +228,7 @@ impl Bank {
                                     lamports: rent_to_be_paid as i64,
                                     post_balance,
                                     commission: None,
+                                    num_partitions: None,
                                 },
                             ));
                         }

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -605,7 +605,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "12WNiuA7qeLU8JFweQszX5sCnCj1fYnYV4i9DeACqhQD")]
+        #[frozen_abi(digest = "DfXLwhHMqjEFsGJP46xjahMC9Ci8pX35QsWa6e5j3obf")]
         #[derive(Serialize, AbiExample)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper_newer")]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1986,6 +1986,7 @@ where
                     lamports: 0,
                     post_balance: bank1.get_balance(&vote_id),
                     commission: Some(0),
+                    num_partitions: None,
                 }
             ),
             (
@@ -1995,6 +1996,7 @@ where
                     lamports: validator_rewards as i64,
                     post_balance: bank1.get_balance(&stake_id),
                     commission: Some(0),
+                    num_partitions: None,
                 }
             )
         ]
@@ -2589,6 +2591,7 @@ fn test_bank_tx_fee() {
                 lamports: expected_fee_collected as i64,
                 post_balance: initial_balance + expected_fee_collected,
                 commission: None,
+                num_partitions: None,
             }
         )]
     );
@@ -2624,6 +2627,7 @@ fn test_bank_tx_fee() {
                 lamports: expected_fee_collected as i64,
                 post_balance: initial_balance + 2 * expected_fee_collected,
                 commission: None,
+                num_partitions: None,
             }
         )]
     );
@@ -2699,6 +2703,7 @@ fn test_bank_tx_compute_unit_fee() {
                 lamports: expected_fee_collected as i64,
                 post_balance: initial_balance + expected_fee_collected,
                 commission: None,
+                num_partitions: None,
             }
         )]
     );
@@ -2734,6 +2739,7 @@ fn test_bank_tx_compute_unit_fee() {
                 lamports: expected_fee_collected as i64,
                 post_balance: initial_balance + 2 * expected_fee_collected,
                 commission: None,
+                num_partitions: None,
             }
         )]
     );
@@ -12967,6 +12973,7 @@ fn test_store_vote_accounts_partitioned() {
                 lamports: p.1.vote_rewards as i64,
                 post_balance: p.1.vote_rewards,
                 commission: Some(p.1.commission),
+                num_partitions: None,
             };
             vote_rewards_account.rewards.push((p.0, info));
             vote_rewards_account
@@ -13320,6 +13327,7 @@ fn test_calc_vote_accounts_to_store_normal() {
                         lamports: vote_rewards as i64,
                         post_balance: vote_account.lamports(),
                         commission: Some(commission),
+                        num_partitions: None,
                     }
                 );
                 assert_eq!(rewards.0, pubkey);
@@ -13511,6 +13519,7 @@ fn test_calculate_stake_vote_rewards() {
             lamports: vote_rewards as i64,
             post_balance: vote_account.lamports(),
             commission: Some(commision),
+            num_partitions: None,
         }
     );
     assert_eq!(&rewards.0, vote_pubkey);
@@ -13530,6 +13539,7 @@ fn test_calculate_stake_vote_rewards() {
         lamports: rewards,
         post_balance: original_stake_lamport + rewards as u64,
         commission: Some(commision),
+        num_partitions: None,
     };
     assert_eq!(
         stake_reward_calculation.stake_rewards[0].stake_reward_info,

--- a/sdk/src/reward_type.rs
+++ b/sdk/src/reward_type.rs
@@ -8,6 +8,7 @@ pub enum RewardType {
     Rent,
     Staking,
     Voting,
+    PartitionData,
 }
 
 impl fmt::Display for RewardType {
@@ -20,6 +21,7 @@ impl fmt::Display for RewardType {
                 RewardType::Rent => "rent",
                 RewardType::Staking => "staking",
                 RewardType::Voting => "voting",
+                RewardType::PartitionData => "partition",
             }
         )
     }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -295,6 +295,7 @@ impl From<StoredConfirmedBlockReward> for Reward {
             post_balance: 0,
             reward_type: None,
             commission: None,
+            num_partitions: None,
         }
     }
 }

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -127,6 +127,7 @@ message Reward {
     uint64 post_balance = 3;
     RewardType reward_type = 4;
     string commission = 5;
+    optional uint32 num_partitions = 6;
 }
 
 message Rewards {

--- a/storage-proto/proto/confirmed_block.proto
+++ b/storage-proto/proto/confirmed_block.proto
@@ -118,6 +118,7 @@ enum RewardType {
     Rent = 2;
     Staking = 3;
     Voting = 4;
+    PartitionData = 5;
 }
 
 message Reward {

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -1233,6 +1233,7 @@ mod test {
             post_balance: 321,
             reward_type: None,
             commission: None,
+            num_partitions: None,
         };
         let gen_reward: generated::Reward = reward.clone().into();
         assert_eq!(reward, gen_reward.into());

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -102,6 +102,7 @@ impl From<Reward> for generated::Reward {
                 Some(RewardType::PartitionData) => generated::RewardType::PartitionData,
             } as i32,
             commission: reward.commission.map(|c| c.to_string()).unwrap_or_default(),
+            num_partitions: reward.num_partitions.map(|num| num as u32),
         }
     }
 }
@@ -122,6 +123,7 @@ impl From<generated::Reward> for Reward {
                 _ => None,
             },
             commission: reward.commission.parse::<u8>().ok(),
+            num_partitions: reward.num_partitions.map(|num| num as usize),
         }
     }
 }

--- a/storage-proto/src/convert.rs
+++ b/storage-proto/src/convert.rs
@@ -99,6 +99,7 @@ impl From<Reward> for generated::Reward {
                 Some(RewardType::Rent) => generated::RewardType::Rent,
                 Some(RewardType::Staking) => generated::RewardType::Staking,
                 Some(RewardType::Voting) => generated::RewardType::Voting,
+                Some(RewardType::PartitionData) => generated::RewardType::PartitionData,
             } as i32,
             commission: reward.commission.map(|c| c.to_string()).unwrap_or_default(),
         }
@@ -117,6 +118,7 @@ impl From<generated::Reward> for Reward {
                 2 => Some(RewardType::Rent),
                 3 => Some(RewardType::Staking),
                 4 => Some(RewardType::Voting),
+                5 => Some(RewardType::PartitionData),
                 _ => None,
             },
             commission: reward.commission.parse::<u8>().ok(),

--- a/storage-proto/src/lib.rs
+++ b/storage-proto/src/lib.rs
@@ -28,6 +28,8 @@ pub struct StoredExtendedReward {
     reward_type: Option<RewardType>,
     #[serde(deserialize_with = "default_on_eof")]
     commission: Option<u8>,
+    #[serde(deserialize_with = "default_on_eof")]
+    num_partitions: Option<usize>,
 }
 
 impl From<StoredExtendedReward> for Reward {
@@ -38,6 +40,7 @@ impl From<StoredExtendedReward> for Reward {
             post_balance,
             reward_type,
             commission,
+            num_partitions,
         } = value;
         Self {
             pubkey,
@@ -45,6 +48,7 @@ impl From<StoredExtendedReward> for Reward {
             post_balance,
             reward_type,
             commission,
+            num_partitions,
         }
     }
 }
@@ -57,6 +61,7 @@ impl From<Reward> for StoredExtendedReward {
             post_balance,
             reward_type,
             commission,
+            num_partitions,
         } = value;
         Self {
             pubkey,
@@ -64,6 +69,7 @@ impl From<Reward> for StoredExtendedReward {
             post_balance,
             reward_type,
             commission,
+            num_partitions,
         }
     }
 }

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -623,6 +623,7 @@ pub struct Reward {
     pub post_balance: u64, // Account balance in lamports after `lamports` was applied
     pub reward_type: Option<RewardType>,
     pub commission: Option<u8>, // Vote account commission when the reward was credited, only present for voting and staking rewards
+    pub num_partitions: Option<usize>, // Number of partitions calculated for partitioned epoch rewards, only present for RewardType::PartitionData
 }
 
 pub type Rewards = Vec<Reward>;


### PR DESCRIPTION
#### Problem
See problem description on https://github.com/solana-labs/solana/pull/34624
The PDA that PR adds will be useful for clients querying a running RPC node for rewards. However, other clients may only have access to historical ledger.

#### Summary of Changes
Add a new RewardType::PartitionData to record the `num_partitions` in an optional Reward field. This reward gets written to the first block of an epoch (essentially replacing the list of stake and vote rewards in epochs before partitioned-rewards feature activation)
To find a specific reward, clients can examine the rewards in the first block of the epoch to get the `num_partitions` and use the `previous_blockhash` in the block metadata to create an EpochRewardsHasher.

- [x] Needs rebase on https://github.com/solana-labs/solana/pull/34624
