### PR TITLE
use staked connection for bench-tps in net scripts

### DIFF
--- a/multinode-demo/bench-tps.sh
+++ b/multinode-demo/bench-tps.sh
@@ -20,10 +20,13 @@ usage() {
 }
 
 args=("$@")
+default_arg --url "http://127.0.0.1:8899"
 default_arg --entrypoint "127.0.0.1:8001"
 default_arg --faucet "127.0.0.1:9900"
 default_arg --duration 90
 default_arg --tx-count 50000
 default_arg --thread-batch-sleep-ms 0
+default_arg --bind-address "127.0.0.1"
+default_arg --client-node-id "${SOLANA_CONFIG_DIR}/bootstrap-validator/identity.json"
 
 $solana_bench_tps "${args[@]}"

--- a/net/net.sh
+++ b/net/net.sh
@@ -26,6 +26,8 @@ usage() {
                                          -c bench-tps=2="--tx_count 25000"
                                      This will start 2 bench-tps clients, and supply "--tx_count 25000"
                                      to the bench-tps client.
+--use-unstaked-connection          - Use unstaked connection. By default, staked connection with
+                                     bootstrap node credendials is used.
 EOM
 )
   cat <<EOF
@@ -444,7 +446,8 @@ startClient() {
     startCommon "$ipAddress"
     ssh "${sshOptions[@]}" -f "$ipAddress" \
       "./solana/net/remote/remote-client.sh $deployMethod $entrypointIp \
-      $clientToRun \"$RUST_LOG\" \"$benchTpsExtraArgs\" $clientIndex $clientType"
+      $clientToRun \"$RUST_LOG\" \"$benchTpsExtraArgs\" $clientIndex $clientType \
+      $maybeUseUnstakedConnection"
   ) >> "$logFile" 2>&1 || {
     cat "$logFile"
     echo "^^^ +++"
@@ -832,6 +835,7 @@ extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
 clientType=thin-client
+maybeUseUnstakedConnection=""
 
 command=$1
 [[ -n $command ]] || usage
@@ -976,6 +980,9 @@ while [[ -n $1 ]]; do
           ;;
       esac
       shift 2
+    elif [[ $1 = --use-unstaked-connection ]]; then
+      maybeUseUnstakedConnection="$1"
+      shift 1
     else
       usage "Unknown long option: $1"
     fi

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -76,10 +76,8 @@ solana-bench-tps)
 
   if ${TPU_CLIENT}; then
     args+=(--use-tpu-client)
-    args+=(--url "http://$entrypointIp:8899")
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
-    args+=(--url "http://$entrypointIp:8899")
   else
     args+=(--entrypoint "$entrypointIp:8001")
   fi
@@ -96,6 +94,7 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
+      --url "http://$entrypointIp:8899" \
       ${args[*]} \
   "
   ;;

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -68,6 +68,9 @@ solana-bench-tps)
   net/scripts/rsync-retry.sh -vPrc \
     "$entrypointIp":~/solana/config/bench-tps"$clientIndex".yml ./client-accounts.yml
 
+  net/scripts/rsync-retry.sh -vPrc \
+    "$entrypointIp":~/solana/config/validator-identity-1.json ./validator-identity.json
+
   args=()
 
   if ${TPU_CLIENT}; then
@@ -87,6 +90,8 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
+      --bind-address $entrypointIp \
+      --client-node-id ./validator-identity.json \
       ${args[*]} \
   "
   ;;

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -12,6 +12,7 @@ fi
 benchTpsExtraArgs="$5"
 clientIndex="$6"
 clientType="${7:-thin-client}"
+maybeUseUnstakedConnection="$8"
 
 missing() {
   echo "Error: $1 not specified"
@@ -83,6 +84,11 @@ solana-bench-tps)
     args+=(--entrypoint "$entrypointIp:8001")
   fi
 
+  if [[ -z "$maybeUseUnstakedConnection" ]]; then
+    args+=(--bind-address "$entrypointIp")
+    args+=(--client-node-id ./validator-identity.json)
+  fi
+
   clientCommand="\
     solana-bench-tps \
       --duration 7500 \
@@ -90,8 +96,6 @@ solana-bench-tps)
       --threads $threadCount \
       $benchTpsExtraArgs \
       --read-client-keys ./client-accounts.yml \
-      --bind-address $entrypointIp \
-      --client-node-id ./validator-identity.json \
       ${args[*]} \
   "
   ;;


### PR DESCRIPTION
#### Problem

After adding throttling to streamer bench-tps shows ~50tps. To fix this we use staked connection.

The same as https://github.com/solana-labs/solana/pull/34749

#### Summary of Changes
