### PR TITLE
Remove the Blockstore thread pool used for fetching Entries

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3273,6 +3273,7 @@ impl Blockstore {
 
             let last_shred = range_shreds.last().unwrap();
             assert!(last_shred.data_complete() || last_shred.last_in_slot());
+            trace!("{:?} data shreds in last FEC set", data_shreds.len());
 
             let deshred_payload = Shredder::deshred(range_shreds).map_err(|e| {
                 BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
@@ -3280,7 +3281,6 @@ impl Blockstore {
                 ))))
             })?;
 
-            debug!("{:?} shreds in last FEC set", data_shreds.len());
             let range_entries =
                 bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|e| {
                     BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3207,7 +3207,7 @@ impl Blockstore {
     ///   completed_ranges = [..., (s_i, e_i), (s_i+1, e_i+1), ...]
     /// Then, the following statements are true:
     ///   s_i < e_i < s_i+1 < e_i+1
-    ///   e_i == s_i+1
+    ///   e_i == s_i+1 + 1
     fn get_slot_entries_in_block(
         &self,
         slot: Slot,

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -44,7 +44,6 @@ use {
         datapoint_debug, datapoint_error,
         poh_timing_point::{send_poh_timing_point, PohTimingSender, SlotPohTimingInfo},
     },
-    solana_rayon_threadlimit::get_max_thread_count,
     solana_runtime::bank::Bank,
     solana_sdk::{
         account::ReadableAccount,
@@ -97,11 +96,6 @@ pub use {
 // get_max_thread_count to match number of threads in the old code.
 // see: https://github.com/solana-labs/solana/pull/24853
 lazy_static! {
-    static ref PAR_THREAD_POOL: ThreadPool = rayon::ThreadPoolBuilder::new()
-        .num_threads(get_max_thread_count())
-        .thread_name(|i| format!("solBstore{i:02}"))
-        .build()
-        .unwrap();
     static ref PAR_THREAD_POOL_ALL_CPUS: ThreadPool = rayon::ThreadPoolBuilder::new()
         .num_threads(num_cpus::get())
         .thread_name(|i| format!("solBstoreAll{i:02}"))
@@ -3097,29 +3091,7 @@ impl Blockstore {
             .map(|(_, end_index)| u64::from(*end_index) - start_index + 1)
             .unwrap_or(0);
 
-        let entries: Result<Vec<Vec<Entry>>> = if completed_ranges.len() <= 1 {
-            completed_ranges
-                .into_iter()
-                .map(|(start_index, end_index)| {
-                    self.get_entries_in_data_block(slot, start_index, end_index, Some(&slot_meta))
-                })
-                .collect()
-        } else {
-            PAR_THREAD_POOL.install(|| {
-                completed_ranges
-                    .into_par_iter()
-                    .map(|(start_index, end_index)| {
-                        self.get_entries_in_data_block(
-                            slot,
-                            start_index,
-                            end_index,
-                            Some(&slot_meta),
-                        )
-                    })
-                    .collect()
-            })
-        };
-        let entries: Vec<Entry> = entries?.into_iter().flatten().collect();
+        let entries = self.get_slot_entries_in_block(slot, completed_ranges, Some(&slot_meta))?;
         Ok((entries, num_shreds, slot_meta.is_full()))
     }
 
@@ -3229,14 +3201,24 @@ impl Blockstore {
             .collect()
     }
 
-    pub fn get_entries_in_data_block(
+    /// Fetch the entries corresponding to all of the shred indices in `completed_ranges`
+    /// This function takes advantage of the fact that `completed_ranges` are both
+    /// contiguous and in sorted order. To clarify, suppose completed_ranges is as follows:
+    ///   completed_ranges = [..., (s_i, e_i), (s_i+1, e_i+1), ...]
+    /// Then, the following statements are true:
+    ///   s_i < e_i < s_i+1 < e_i+1
+    ///   e_i == s_i+1
+    fn get_slot_entries_in_block(
         &self,
         slot: Slot,
-        start_index: u32,
-        end_index: u32,
+        completed_ranges: CompletedRanges,
         slot_meta: Option<&SlotMeta>,
     ) -> Result<Vec<Entry>> {
-        let keys: Vec<(Slot, u64)> = (start_index..=end_index)
+        assert!(!completed_ranges.is_empty());
+
+        let (total_start_index, _) = *completed_ranges.first().unwrap();
+        let (_, total_end_index) = *completed_ranges.last().unwrap();
+        let keys: Vec<(Slot, u64)> = (total_start_index..=total_end_index)
             .map(|index| (slot, u64::from(index)))
             .collect();
 
@@ -3246,7 +3228,6 @@ impl Blockstore {
             .into_iter()
             .collect();
         let data_shreds = data_shreds?;
-
         let data_shreds: Result<Vec<Shred>> =
             data_shreds
                 .into_iter()
@@ -3262,8 +3243,8 @@ impl Blockstore {
                                     idx,
                                     slot_meta.consumed,
                                     slot_meta.completed_data_indexes,
-                                    start_index,
-                                    end_index
+                                    total_start_index,
+                                    total_end_index
                                 );
                             }
                         }
@@ -3281,21 +3262,46 @@ impl Blockstore {
                 })
                 .collect();
         let data_shreds = data_shreds?;
-        let last_shred = data_shreds.last().unwrap();
-        assert!(last_shred.data_complete() || last_shred.last_in_slot());
 
-        let deshred_payload = Shredder::deshred(&data_shreds).map_err(|e| {
-            BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                "Could not reconstruct data block from constituent shreds, error: {e:?}"
-            ))))
-        })?;
+        let mut entries = vec![];
+        for (start_index, end_index) in completed_ranges.iter() {
+            // The indices from completed_ranges refer to shred indices in the
+            // block; map those indices to indices within data_shreds
+            let start_index = (*start_index - total_start_index) as usize;
+            let end_index = (*end_index - total_start_index) as usize;
+            let range_shreds = &data_shreds[start_index..=end_index];
 
-        debug!("{:?} shreds in last FEC set", data_shreds.len(),);
-        bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|e| {
-            BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
-                "could not reconstruct entries: {e:?}"
-            ))))
-        })
+            let last_shred = range_shreds.last().unwrap();
+            assert!(last_shred.data_complete() || last_shred.last_in_slot());
+
+            let deshred_payload = Shredder::deshred(range_shreds).map_err(|e| {
+                BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(format!(
+                    "could not reconstruct entries buffer from shreds: {e:?}"
+                ))))
+            })?;
+
+            debug!("{:?} shreds in last FEC set", data_shreds.len());
+            let range_entries =
+                bincode::deserialize::<Vec<Entry>>(&deshred_payload).map_err(|e| {
+                    BlockstoreError::InvalidShredData(Box::new(bincode::ErrorKind::Custom(
+                        format!("could not reconstruct entries: {e:?}"),
+                    )))
+                })?;
+
+            entries.extend(range_entries);
+        }
+        Ok(entries)
+    }
+
+    // TODO: probably delete this entry point, used by completed_data_sets_service.rs
+    pub fn get_entries_in_data_block(
+        &self,
+        slot: Slot,
+        start_index: u32,
+        end_index: u32,
+        slot_meta: Option<&SlotMeta>,
+    ) -> Result<Vec<Entry>> {
+        self.get_slot_entries_in_block(slot, vec![(start_index, end_index)], slot_meta)
     }
 
     fn get_any_valid_slot_entries(&self, slot: Slot, start_index: u64) -> Vec<Entry> {

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3217,9 +3217,9 @@ impl Blockstore {
     ) -> Result<Vec<Entry>> {
         assert!(!completed_ranges.is_empty());
 
-        let (total_start_index, _) = *completed_ranges.first().unwrap();
-        let (_, total_end_index) = *completed_ranges.last().unwrap();
-        let keys: Vec<(Slot, u64)> = (total_start_index..=total_end_index)
+        let (all_ranges_start_index, _) = *completed_ranges.first().unwrap();
+        let (_, all_ranges_end_index) = *completed_ranges.last().unwrap();
+        let keys: Vec<(Slot, u64)> = (all_ranges_start_index..=all_ranges_end_index)
             .map(|index| (slot, u64::from(index)))
             .collect();
 
@@ -3244,8 +3244,8 @@ impl Blockstore {
                                     idx,
                                     slot_meta.consumed,
                                     slot_meta.completed_data_indexes,
-                                    total_start_index,
-                                    total_end_index
+                                    all_ranges_start_index,
+                                    all_ranges_end_index
                                 );
                             }
                         }
@@ -3268,10 +3268,10 @@ impl Blockstore {
             .into_iter()
             .map(|(start_index, end_index)| {
                 // The indices from completed_ranges refer to shred indices in the
-                // block; map those indices to indices within data_shreds
-                let start_index = (start_index - total_start_index) as usize;
-                let end_index = (end_index - total_start_index) as usize;
-                let range_shreds = &data_shreds[start_index..=end_index];
+                // entire block; map those indices to indices within data_shreds
+                let range_start_index = (start_index - all_ranges_start_index) as usize;
+                let range_end_index = (end_index - all_ranges_start_index) as usize;
+                let range_shreds = &data_shreds[range_start_index..=range_end_index];
 
                 let last_shred = range_shreds.last().unwrap();
                 assert!(last_shred.data_complete() || last_shred.last_in_slot());

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -3293,7 +3293,6 @@ impl Blockstore {
         Ok(entries)
     }
 
-    // TODO: probably delete this entry point, used by completed_data_sets_service.rs
     pub fn get_entries_in_data_block(
         &self,
         slot: Slot,


### PR DESCRIPTION
#### Problem
Retrieving entries from the Blockstore is a necessary for several uses-cases:
1. Feeding entries to `ReplayStage`
2. Feeding entries to `CompletedDataSetService`
3. Feeding entries to RPC calls such as `getBlock`

While these operations all occur in different threads, the implementation of the `Blockstore` function utilizes a thread-pool to parallelize the operation of fetching / deshreding / deserializing shreds into entries. That thread pool is currently set to scale with the number of cores on the machine. Several problems with this:
- The thread pool is shared between all of these cases, but replay is the most critical and should not be prone to potential jitter/latency as a result of another operation utilizing the thread pool
- The thread pool is very overprovisioned; CPU utilization of these threads from both a validator and an RPC node in the public pool would indicate that many of the threads in the pool aren't seeing much to any activity.
    - Looking at CPU utilization per thread, some of the threads in the pool are seeing `< 0.1%` usage
- In steady state operation, blocks are streamed to the validator and get replayed immediately. `ReplayStage` is greedy and tries to replay entries as soon as possible; this means that the block is fetched in many small chunks as opposed to one call that fetches the entire block at once. Many small chunks spread over time means there is no need for large "parallelization"

#### Summary of Changes
Remove the thread pool that the `Entry` fetch method had been using. This method previously parallelized over completed ranges (a completed range is a range of shreds that should be deserialized into a `Vec<Entry>` together), giving one completed range to one rayon thread. Now, the method looks up all completed ranges it might want to fetch with a single call to rocksdb `multi_get()`.

#### Performance Impact
Background for several metrics of interest which are on a per-slot basis:
- `replay-slot-stats.fetch_entries`: The total amount of time spent fetching entries
- `replay-slot-stats.num_execute_batches`: The total number of calls `ReplayStage` makes to `blockstore_processor::confirm_slot()` that result in transactions getting executed. This is the same number of times that the `Blockstore` method to fetch entries is getting called
- `replay-slot-stats.confirmation_time_us`: The total amount of time spent within `blockstore_processor::confirm_slot()`;  this is inclusive of both fetch entry time as well as everything else (ie actual tx execution)

Summarizing some key points from some of the comments below:
- The removal of this thread pool does increase `replay-slot-stats.fetch_entries`. Average numbers on my node would suggest an increase from ~3.5k ms to ~5.5k ms
- `replay-slot-stats.num_execute_batches` has been observed to have an average value of ~70 over the past two weeks
- Noting that we're spending ~2 ms more to fetch (on average), that is `~2 ms / 70 ~= 29 us` per call to fetch entries
- The ability to complete replay of a slot is dependent on all the shreds having been received. Once the last shred has been received, there will be exactly 1 more call to `confirm_slot()` (and thus to fetch entries). So, in isolation, it might appear that we've "delayed" being able to complete a block by ~29 us (on average)
- However, `replay-slot-stats.confirmation_time_us` looks pretty consistent for my node before and after making the change to remove the thread-pool. **This value staying consistent would suggest that while fetch time is growing marginally, we are at least breaking even by avoiding the thread-pool**