### PR TITLE
Add rpc support for partitioned rewards

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -537,6 +537,8 @@ impl JsonRpcRequestProcessor {
                 .get_epoch(self.get_slot(slot_context)?)
                 .saturating_sub(1),
         };
+        // Rewards for this epoch are found in the first confirmed block of the next epoch
+        let first_slot_in_epoch = epoch_schedule.get_first_slot_in_epoch(epoch.saturating_add(1));
 
         let bank = self.get_bank_with_config(slot_context)?;
 
@@ -546,9 +548,6 @@ impl JsonRpcRequestProcessor {
         {
             Ok(vec![])
         } else {
-            // Rewards for this epoch are found in the first confirmed block of the next epoch
-            let first_slot_in_epoch =
-                epoch_schedule.get_first_slot_in_epoch(epoch.saturating_add(1));
             if first_slot_in_epoch < first_available_block {
                 if self.bigtable_ledger_storage.is_some() {
                     return Err(RpcCustomError::LongTermStorageSlotSkipped {

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -591,15 +591,15 @@ impl JsonRpcRequestProcessor {
 
         let bank = self.get_bank_with_config(slot_context)?;
 
-        let mut reward_map: HashMap<String, (Reward, Slot)> = {
-            let first_confirmed_block_in_epoch = *self
-                .get_blocks_with_limit(first_slot_in_epoch, 1, config.commitment)
-                .await?
-                .first()
-                .ok_or(RpcCustomError::BlockNotAvailable {
-                    slot: first_slot_in_epoch,
-                })?;
+        let first_confirmed_block_in_epoch = *self
+            .get_blocks_with_limit(first_slot_in_epoch, 1, config.commitment)
+            .await?
+            .first()
+            .ok_or(RpcCustomError::BlockNotAvailable {
+                slot: first_slot_in_epoch,
+            })?;
 
+        let mut reward_map: HashMap<String, (Reward, Slot)> = {
             let addresses: Vec<String> =
                 addresses.iter().map(|pubkey| pubkey.to_string()).collect();
 
@@ -645,15 +645,15 @@ impl JsonRpcRequestProcessor {
 
             let block_list = self
                 .get_blocks_with_limit(
-                    first_slot_in_epoch,
-                    partition_data.num_partitions + 1,
+                    first_confirmed_block_in_epoch + 1,
+                    partition_data.num_partitions,
                     config.commitment,
                 )
                 .await?;
 
             for (partition_index, addresses) in partition_index_addresses.iter() {
                 let slot = *block_list
-                    .get(partition_index.saturating_add(1))
+                    .get(*partition_index)
                     .ok_or_else(Error::internal_error)?;
 
                 let index_reward_map = self.get_reward_map(slot, addresses, &config).await?;

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -527,7 +527,7 @@ impl JsonRpcRequestProcessor {
         &self,
         slot: Slot,
         addresses: &[String],
-        reward_type_filter: F,
+        reward_type_filter: &F,
         config: &RpcEpochConfig,
     ) -> Result<HashMap<String, (Reward, Slot)>>
     where
@@ -612,7 +612,7 @@ impl JsonRpcRequestProcessor {
             self.get_reward_map(
                 first_confirmed_block_in_epoch,
                 &addresses,
-                |reward_type| -> bool {
+                &|reward_type| -> bool {
                     reward_type == RewardType::Voting
                         || (!partitioned_epoch_reward_enabled && reward_type == RewardType::Staking)
                 },
@@ -671,7 +671,7 @@ impl JsonRpcRequestProcessor {
                     .get_reward_map(
                         slot,
                         addresses,
-                        |reward_type| -> bool { reward_type == RewardType::Staking },
+                        &|reward_type| -> bool { reward_type == RewardType::Staking },
                         &config,
                     )
                     .await?;

--- a/validator/src/bin/solana-test-validator.rs
+++ b/validator/src/bin/solana-test-validator.rs
@@ -19,7 +19,6 @@ use {
         account::AccountSharedData,
         clock::Slot,
         epoch_schedule::EpochSchedule,
-        feature_set,
         native_token::sol_to_lamports,
         pubkey::Pubkey,
         rent::Rent,
@@ -349,9 +348,7 @@ fn main() {
         exit(1);
     });
 
-    let mut features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
-    // Remove this when client support is ready for the enable_partitioned_epoch_reward feature
-    features_to_deactivate.push(feature_set::enable_partitioned_epoch_reward::id());
+    let features_to_deactivate = pubkeys_of(&matches, "deactivate_feature").unwrap_or_default();
 
     if TestValidatorGenesis::ledger_exists(&ledger_path) {
         for (name, long) in &[


### PR DESCRIPTION
#### Problem
Since https://github.com/solana-labs/solana/pull/34624, we can pull the PartitionData PDA to create the hasher to locate specific rewards.

#### Summary of Changes
- Add branch for partitioned rewards in `get_inflation_rewards`
- Remove feature deactivation in solana-test-validator
