### PR TITLE
Update link to system tuning guide in error message

### DIFF
--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1674,7 +1674,10 @@ pub fn main() {
         if SystemMonitorService::check_os_network_limits() {
             info!("OS network limits test passed.");
         } else {
-            eprintln!("OS network limit test failed. See: https://docs.solanalabs.com/operations/guides/validator-start#system-tuning");
+            eprintln!(
+                "OS network limit test failed. See: \
+                https://docs.solanalabs.com/validator/get-started/setup-a-validator#system-tuning"
+            );
             exit(1);
         }
     }


### PR DESCRIPTION
#### Problem
The old link is dated and no longer exists

https://docs.solanalabs.com/operations/guides/validator-start#system-tuning ==> Invalid (old)
https://docs.solanalabs.com/validator/get-started/setup-a-validator#system-tuning ==> Valid (new)