### PR TITLE
fix buffer size for updateable program buffer rent exempt fee calculation

### DIFF
--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -116,7 +116,7 @@ pub fn load_upgradeable_buffer<T: Client>(
     let program = load_program_from_file(name);
     let buffer_pubkey = buffer_keypair.pubkey();
     let buffer_authority_pubkey = buffer_authority_keypair.pubkey();
-    let program_buffer_bytes = UpgradeableLoaderState::size_of_programdata(program.len());
+    let program_buffer_bytes = UpgradeableLoaderState::size_of_buffer(program.len());
 
     bank_client
         .send_and_confirm_message(


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/pull/34722, we are using the wrong metadata size (i.e. program metadata) for program buffer account rent-exempt lamport calculation, i.e. 45bytes vs 37btes. 


#### Summary of Changes

Fix the wrong metadata size by using the correct size_of_buffer fn.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
