### PR TITLE
Track transaction performance through various stage using random mask

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,6 +5828,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-metrics-tracker",
  "solana-transaction-status",
  "solana-turbine",
  "solana-unified-scheduler-pool",
@@ -7193,6 +7194,7 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
+ "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -7357,6 +7359,20 @@ dependencies = [
  "solana-streamer",
  "solana-transaction-status",
  "solana-version",
+]
+
+[[package]]
+name = "solana-transaction-metrics-tracker"
+version = "1.19.0"
+dependencies = [
+ "Inflector",
+ "base64 0.21.7",
+ "bincode",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "solana-perf",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7191,6 +7191,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "solana-logger",
+ "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
     "tokens",
     "tpu-client",
     "transaction-dos",
+    "transaction-metrics-tracker",
     "transaction-status",
     "turbine",
     "udp-client",
@@ -378,6 +379,7 @@ solana-system-program = { path = "programs/system", version = "=1.19.0" }
 solana-test-validator = { path = "test-validator", version = "=1.19.0" }
 solana-thin-client = { path = "thin-client", version = "=1.19.0" }
 solana-tpu-client = { path = "tpu-client", version = "=1.19.0", default-features = false }
+solana-transaction-metrics-tracker = { path = "transaction-metrics-tracker", version = "=1.19.0" }
 solana-transaction-status = { path = "transaction-status", version = "=1.19.0" }
 solana-turbine = { path = "turbine", version = "=1.19.0" }
 solana-udp-client = { path = "udp-client", version = "=1.19.0" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,6 +67,7 @@ solana-send-transaction-service = { workspace = true }
 solana-streamer = { workspace = true }
 solana-svm = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-transaction-metrics-tracker = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-turbine = { workspace = true }
 solana-unified-scheduler-pool = { workspace = true }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -223,10 +223,9 @@ impl Consumer {
                             "Banking stage processing took {duration:?} for transaction {:?}",
                             packet.transaction().get_signatures().first()
                         );
-                        inc_new_counter_info!(
-                            "txn-metrics-banking-stage-process-us",
-                            duration.as_micros() as usize
-                        );
+                        payload
+                            .slot_metrics_tracker
+                            .increment_process_sampled_packets_us(duration.as_micros() as u64);
                     } else {
                         // This packet is retried, advance the retry index to the next, as the next packet's index will
                         // certainly be > than this.

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -208,6 +208,33 @@ impl Consumer {
             .slot_metrics_tracker
             .increment_retryable_packets_count(retryable_transaction_indexes.len() as u64);
 
+        // Now we track the performance for the interested transactions which is not in the retryable_transaction_indexes
+        // We assume the retryable_transaction_indexes is already sorted.
+        let mut retryable_idx = 0;
+        for (index, packet) in packets_to_process.iter().enumerate() {
+            if packet.original_packet().meta().is_perf_track_packet() {
+                if let Some(start_time) = packet.start_time() {
+                    if retryable_idx >= retryable_transaction_indexes.len()
+                        || retryable_transaction_indexes[retryable_idx] != index
+                    {
+                        let duration = Instant::now().duration_since(*start_time);
+
+                        debug!(
+                            "Banking stage processing took {duration:?} for transaction {:?}",
+                            packet.transaction().get_signatures().first()
+                        );
+                        inc_new_counter_info!(
+                            "txn-metrics-banking-stage-process-us",
+                            duration.as_micros() as usize
+                        );
+                    } else {
+                        // This packet is retried, advance the retry index to the next, as the next packet's index will
+                        // certainly be > than this.
+                        retryable_idx += 1;
+                    }
+                }
+            }
+        }
         Some(retryable_transaction_indexes)
     }
 

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -13,7 +13,7 @@ use {
             VersionedTransaction,
         },
     },
-    std::{cmp::Ordering, mem::size_of, sync::Arc},
+    std::{cmp::Ordering, mem::size_of, sync::Arc, time::Instant},
     thiserror::Error,
 };
 
@@ -41,10 +41,16 @@ pub struct ImmutableDeserializedPacket {
     message_hash: Hash,
     is_simple_vote: bool,
     compute_budget_details: ComputeBudgetDetails,
+    banking_stage_start_time: Option<Instant>,
 }
 
 impl ImmutableDeserializedPacket {
     pub fn new(packet: Packet) -> Result<Self, DeserializedPacketError> {
+        let banking_stage_start_time = packet
+            .meta()
+            .is_perf_track_packet()
+            .then_some(Instant::now());
+
         let versioned_transaction: VersionedTransaction = packet.deserialize_slice(..)?;
         let sanitized_transaction = SanitizedVersionedTransaction::try_from(versioned_transaction)?;
         let message_bytes = packet_message(&packet)?;
@@ -67,6 +73,7 @@ impl ImmutableDeserializedPacket {
             message_hash,
             is_simple_vote,
             compute_budget_details,
+            banking_stage_start_time,
         })
     }
 
@@ -96,6 +103,10 @@ impl ImmutableDeserializedPacket {
 
     pub fn compute_budget_details(&self) -> ComputeBudgetDetails {
         self.compute_budget_details.clone()
+    }
+
+    pub fn start_time(&self) -> &Option<Instant> {
+        &self.banking_stage_start_time
     }
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction

--- a/core/src/banking_stage/leader_slot_metrics.rs
+++ b/core/src/banking_stage/leader_slot_metrics.rs
@@ -936,6 +936,17 @@ impl LeaderSlotMetricsTracker {
             );
         }
     }
+
+    pub(crate) fn increment_process_sampled_packets_us(&mut self, us: u64) {
+        if let Some(leader_slot_metrics) = &mut self.leader_slot_metrics {
+            leader_slot_metrics
+                .timing_metrics
+                .process_packets_timings
+                .process_sampled_packets_us_hist
+                .increment(us)
+                .unwrap();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/core/src/banking_stage/leader_slot_timing_metrics.rs
+++ b/core/src/banking_stage/leader_slot_timing_metrics.rs
@@ -244,6 +244,9 @@ pub(crate) struct ProcessPacketsTimings {
     // Time spent running the cost model in processing transactions before executing
     // transactions
     pub cost_model_us: u64,
+
+    // banking stage processing time histogram for sampled packets
+    pub process_sampled_packets_us_hist: histogram::Histogram,
 }
 
 impl ProcessPacketsTimings {
@@ -264,6 +267,28 @@ impl ProcessPacketsTimings {
                 i64
             ),
             ("cost_model_us", self.cost_model_us, i64),
+            (
+                "process_sampled_packets_us_90pct",
+                self.process_sampled_packets_us_hist
+                    .percentile(90.0)
+                    .unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_min",
+                self.process_sampled_packets_us_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_max",
+                self.process_sampled_packets_us_hist.maximum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_mean",
+                self.process_sampled_packets_us_hist.mean().unwrap_or(0),
+                i64
+            ),
         );
     }
 }

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -924,6 +924,7 @@ impl ThreadLocalUnprocessedPackets {
                 .iter()
                 .map(|p| (*p).clone())
                 .collect_vec();
+
             let retryable_packets = if let Some(retryable_transaction_indexes) =
                 processing_function(&packets_to_process, payload)
             {

--- a/core/src/sigverify_stage.rs
+++ b/core/src/sigverify_stage.rs
@@ -80,9 +80,9 @@ struct SigVerifierStats {
     verify_batches_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     discard_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
     dedup_packets_pp_us_hist: histogram::Histogram, // per-packet time to call verify_batch
-    sampled_packets_pp_us_hist: histogram::Histogram, // per-packet time do do overall verify for sampled packets
-    batches_hist: histogram::Histogram,               // number of packet batches per verify call
-    packets_hist: histogram::Histogram,               // number of packets per verify call
+    process_sampled_packets_us_hist: histogram::Histogram, // per-packet time do do overall verify for sampled packets
+    batches_hist: histogram::Histogram, // number of packet batches per verify call
+    packets_hist: histogram::Histogram, // number of packets per verify call
     num_deduper_saturations: usize,
     total_batches: usize,
     total_packets: usize,
@@ -185,25 +185,25 @@ impl SigVerifierStats {
                 i64
             ),
             (
-                "sampled_verify_packets_pp_us_90pct",
-                self.sampled_packets_pp_us_hist
+                "process_sampled_packets_us_90pct",
+                self.process_sampled_packets_us_hist
                     .percentile(90.0)
                     .unwrap_or(0),
                 i64
             ),
             (
-                "sampled_verify_packets_pp_us_min",
-                self.sampled_packets_pp_us_hist.minimum().unwrap_or(0),
+                "process_sampled_packets_us_min",
+                self.process_sampled_packets_us_hist.minimum().unwrap_or(0),
                 i64
             ),
             (
-                "sampled_verify_packets_pp_us_max",
-                self.sampled_packets_pp_us_hist.maximum().unwrap_or(0),
+                "process_sampled_packets_us_max",
+                self.process_sampled_packets_us_hist.maximum().unwrap_or(0),
                 i64
             ),
             (
-                "sampled_verify_packets_pp_us_mean",
-                self.sampled_packets_pp_us_hist.mean().unwrap_or(0),
+                "process_sampled_packets_us_mean",
+                self.process_sampled_packets_us_hist.mean().unwrap_or(0),
                 i64
             ),
             (
@@ -414,7 +414,7 @@ impl SigVerifyStage {
                 Signature::from(signature)
             );
             stats
-                .sampled_packets_pp_us_hist
+                .process_sampled_packets_us_hist
                 .increment(duration.as_micros() as u64)
                 .unwrap();
         }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6265,6 +6265,7 @@ dependencies = [
  "quinn-proto",
  "rand 0.8.5",
  "rustls",
+ "solana-measure",
  "solana-metrics",
  "solana-perf",
  "solana-sdk",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4908,6 +4908,7 @@ dependencies = [
  "solana-streamer",
  "solana-svm",
  "solana-tpu-client",
+ "solana-transaction-metrics-tracker",
  "solana-transaction-status",
  "solana-turbine",
  "solana-unified-scheduler-pool",
@@ -6267,6 +6268,7 @@ dependencies = [
  "solana-metrics",
  "solana-perf",
  "solana-sdk",
+ "solana-transaction-metrics-tracker",
  "thiserror",
  "tokio",
  "x509-parser",
@@ -6367,6 +6369,20 @@ dependencies = [
  "solana-sdk",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "solana-transaction-metrics-tracker"
+version = "1.19.0"
+dependencies = [
+ "Inflector",
+ "base64 0.21.7",
+ "bincode",
+ "lazy_static",
+ "log",
+ "rand 0.8.5",
+ "solana-perf",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/sdk/src/packet.rs
+++ b/sdk/src/packet.rs
@@ -33,6 +33,8 @@ bitflags! {
         /// the packet is built.
         /// This field can be removed when the above feature gate is adopted by mainnet-beta.
         const ROUND_COMPUTE_UNIT_PRICE = 0b0010_0000;
+        /// For tracking performance
+        const PERF_TRACK_PACKET  = 0b0100_0000;
     }
 }
 
@@ -229,6 +231,12 @@ impl Meta {
     }
 
     #[inline]
+    pub fn set_track_performance(&mut self, is_performance_track: bool) {
+        self.flags
+            .set(PacketFlags::PERF_TRACK_PACKET, is_performance_track);
+    }
+
+    #[inline]
     pub fn set_simple_vote(&mut self, is_simple_vote: bool) {
         self.flags.set(PacketFlags::SIMPLE_VOTE_TX, is_simple_vote);
     }
@@ -259,6 +267,11 @@ impl Meta {
     #[inline]
     pub fn is_tracer_packet(&self) -> bool {
         self.flags.contains(PacketFlags::TRACER_PACKET)
+    }
+
+    #[inline]
+    pub fn is_perf_track_packet(&self) -> bool {
+        self.flags.contains(PacketFlags::PERF_TRACK_PACKET)
     }
 
     #[inline]

--- a/sdk/src/transaction/versioned/sanitized.rs
+++ b/sdk/src/transaction/versioned/sanitized.rs
@@ -33,6 +33,10 @@ impl SanitizedVersionedTransaction {
         &self.message
     }
 
+    pub fn get_signatures(&self) -> &Vec<Signature> {
+        &self.signatures
+    }
+
     /// Consumes the SanitizedVersionedTransaction, returning the fields individually.
     pub fn destruct(self) -> (Vec<Signature>, SanitizedVersionedMessage) {
         (self.signatures, self.message)

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -26,6 +26,7 @@ quinn = { workspace = true }
 quinn-proto = { workspace = true }
 rand = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration"] }
+solana-measure = { workspace = true }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-sdk = { workspace = true }

--- a/streamer/Cargo.toml
+++ b/streamer/Cargo.toml
@@ -29,6 +29,7 @@ rustls = { workspace = true, features = ["dangerous_configuration"] }
 solana-metrics = { workspace = true }
 solana-perf = { workspace = true }
 solana-sdk = { workspace = true }
+solana-transaction-metrics-tracker = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 x509-parser = { workspace = true }

--- a/streamer/src/nonblocking/quic.rs
+++ b/streamer/src/nonblocking/quic.rs
@@ -715,7 +715,7 @@ async fn packet_batch_sender(
 }
 
 fn track_streamer_fetch_packet_performance(
-    packet_perf_measure: &mut Vec<([u8; 64], Instant)>,
+    packet_perf_measure: &mut [([u8; 64], Instant)],
     stats: &Arc<StreamStats>,
 ) {
     if packet_perf_measure.is_empty() {

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -16,7 +16,7 @@ use {
     std::{
         net::UdpSocket,
         sync::{
-            atomic::{AtomicBool, AtomicUsize, Ordering},
+            atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
             Arc, Mutex, RwLock,
         },
         thread,
@@ -176,6 +176,7 @@ pub struct StreamStats {
     pub(crate) stream_load_ema_overflow: AtomicUsize,
     pub(crate) stream_load_capacity_overflow: AtomicUsize,
     pub(crate) process_sampled_packets_us_hist: Mutex<histogram::Histogram>,
+    pub(crate) perf_track_overhead_us: AtomicU64,
 }
 
 impl StreamStats {
@@ -447,6 +448,11 @@ impl StreamStats {
             (
                 "process_sampled_packets_us_mean",
                 process_sampled_packets_us_hist.mean().unwrap_or(0),
+                i64
+            ),
+            (
+                "perf_track_overhead_us",
+                self.perf_track_overhead_us.swap(0, Ordering::Relaxed),
                 i64
             ),
         );

--- a/streamer/src/quic.rs
+++ b/streamer/src/quic.rs
@@ -17,7 +17,7 @@ use {
         net::UdpSocket,
         sync::{
             atomic::{AtomicBool, AtomicUsize, Ordering},
-            Arc, RwLock,
+            Arc, Mutex, RwLock,
         },
         thread,
         time::{Duration, SystemTime},
@@ -175,10 +175,12 @@ pub struct StreamStats {
     pub(crate) stream_load_ema: AtomicUsize,
     pub(crate) stream_load_ema_overflow: AtomicUsize,
     pub(crate) stream_load_capacity_overflow: AtomicUsize,
+    pub(crate) process_sampled_packets_us_hist: Mutex<histogram::Histogram>,
 }
 
 impl StreamStats {
     pub fn report(&self, name: &'static str) {
+        let process_sampled_packets_us_hist = self.process_sampled_packets_us_hist.lock().unwrap();
         datapoint_info!(
             name,
             (
@@ -423,6 +425,28 @@ impl StreamStats {
             (
                 "stream_load_capacity_overflow",
                 self.stream_load_capacity_overflow.load(Ordering::Relaxed),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_90pct",
+                process_sampled_packets_us_hist
+                    .percentile(90.0)
+                    .unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_min",
+                process_sampled_packets_us_hist.minimum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_max",
+                process_sampled_packets_us_hist.maximum().unwrap_or(0),
+                i64
+            ),
+            (
+                "process_sampled_packets_us_mean",
+                process_sampled_packets_us_hist.mean().unwrap_or(0),
                 i64
             ),
         );

--- a/transaction-metrics-tracker/Cargo.toml
+++ b/transaction-metrics-tracker/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "solana-transaction-metrics-tracker"
+description = "Solana transaction metrics tracker"
+documentation = "https://docs.rs/solana-transaction-metrics-tracker"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+Inflector = { workspace = true }
+base64 = { workspace = true }
+bincode = { workspace = true }
+# Update this borsh dependency to the workspace version once
+lazy_static = { workspace = true }
+log = { workspace = true }
+rand = { workspace = true }
+solana-perf = { workspace = true }
+solana-sdk = { workspace = true }
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -1,0 +1,54 @@
+use {
+    lazy_static::lazy_static,
+    log::*,
+    rand::Rng,
+    solana_perf::sigverify::PacketError,
+    solana_sdk::{packet::Packet, short_vec::decode_shortu16_len, signature::SIGNATURE_BYTES},
+};
+
+// The mask is 12 bits long (1<<12 = 4096), it means the probability of matching
+// the transaction is 1/4096 assuming the portion being matched is random.
+lazy_static! {
+    static ref TXN_MASK: u16 = rand::thread_rng().gen_range(0..4096);
+}
+
+/// Check if a transaction given its signature matches the randomly selected mask.
+/// The signaure should be from the reference of Signature
+pub fn should_track_transaction(signature: &[u8; SIGNATURE_BYTES]) -> bool {
+    // We do not use the highest signature byte as it is not really random
+    let match_portion: u16 = u16::from_le_bytes([signature[61], signature[62]]) >> 4;
+    trace!("Matching txn: {match_portion:b} {:b}", *TXN_MASK);
+    *TXN_MASK == match_portion
+}
+
+/// Check if a transaction packet's signature matches the mask.
+/// This does a rudimentry verification to make sure the packet at least
+/// contains the signature data and it returns the reference to the signature.
+pub fn signature_if_should_track_packet(
+    packet: &Packet,
+) -> Result<Option<&[u8; SIGNATURE_BYTES]>, PacketError> {
+    let signature = get_signature_from_packet(packet)?;
+    Ok(should_track_transaction(signature).then_some(signature))
+}
+
+/// Get the signature of the transaction packet
+/// This does a rudimentry verification to make sure the packet at least
+/// contains the signature data and it returns the reference to the signature.
+pub fn get_signature_from_packet(packet: &Packet) -> Result<&[u8; SIGNATURE_BYTES], PacketError> {
+    let (sig_len_untrusted, sig_start) = packet
+        .data(..)
+        .and_then(|bytes| decode_shortu16_len(bytes).ok())
+        .ok_or(PacketError::InvalidShortVec)?;
+
+    if sig_len_untrusted < 1 {
+        return Err(PacketError::InvalidSignatureLen);
+    }
+
+    let signature = packet
+        .data(sig_start..sig_start.saturating_add(SIGNATURE_BYTES))
+        .ok_or(PacketError::InvalidSignatureLen)?;
+    let signature = signature
+        .try_into()
+        .map_err(|_| PacketError::InvalidSignatureLen)?;
+    Ok(signature)
+}

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -134,7 +134,7 @@ mod tests {
             Hash::new_unique(),
         );
         let mut sig = [0x0; SIGNATURE_BYTES];
-        sig[61] = ((*TXN_MASK & 0xf as u16) << 4) as u8;
+        sig[61] = ((*TXN_MASK & 0xf_u16) << 4) as u8;
         sig[62] = (*TXN_MASK >> 4) as u8;
 
         let sig = Signature::from(sig);
@@ -146,7 +146,7 @@ mod tests {
             Ok(sig) => {
                 assert!(sig.is_some());
             }
-            Err(_) => assert!(false, "Expected to get a matching signature!"),
+            Err(_) => panic!("Expected to get a matching signature!"),
         }
 
         // Invalid signature length

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -40,7 +40,6 @@ pub fn get_signature_from_packet(packet: &Packet) -> Result<&[u8; SIGNATURE_BYTE
         .and_then(|bytes| decode_shortu16_len(bytes).ok())
         .ok_or(PacketError::InvalidShortVec)?;
 
-    println!("Sig length is okay!!");
     if sig_len_untrusted < 1 {
         return Err(PacketError::InvalidSignatureLen);
     }

--- a/transaction-metrics-tracker/src/lib.rs
+++ b/transaction-metrics-tracker/src/lib.rs
@@ -101,7 +101,7 @@ mod tests {
         // We generate a random one
         let mut rng = rand::thread_rng();
         let random_number: u8 = rng.gen_range(0..=15);
-        sig[61] = ((*TXN_MASK & 0xf as u16) << 4) as u8 | random_number;
+        sig[61] = ((*TXN_MASK & 0xf_u16) << 4) as u8 | random_number;
         sig[62] = (*TXN_MASK >> 4) as u8;
 
         let track = should_track_transaction(&sig);


### PR DESCRIPTION
#### Problem

Enable the system to track transaction processing performance through various stage based on probability. 
#### Summary of Changes
Based on the https://docs.google.com/document/d/1ig1rC0dk-ddi33JIqG9EZ4ZSq9xAJpT9fQTPaZFi_vw/edit. 
We use a randomly generated 12 bits integer as a mask to match the transaction's signature. If it is matched, we mark the packet for tracking for performance in the Meta's mask. This is used efficiently down stream without doing mask matching. For these matched packets we report processing time for: fetch, sigverify and banking stage.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
