### PR TITLE
ci: use openssl 3.1.1 for Windows build

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -47,7 +47,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          choco install openssl
+          choco install openssl --version=3.1.1
           if [[ -d "C:\Program Files\OpenSSL" ]]; then
             echo "OPENSSL_DIR: C:\Program Files\OpenSSL"
             export OPENSSL_DIR="C:\Program Files\OpenSSL"


### PR DESCRIPTION
#### Problem

the latest openssl (3.2.0) broke Windows builds:

https://github.com/solana-labs/solana/actions/runs/7537712991/job/20517067308

#### Summary of Changes

use 3.1.1 (the previous version) for Windows builds.