### PR TITLE
[clap-v3-utils] Replace `pubkeys_sigs_of` with `try_pubkeys_sigs_of`

### DIFF
--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -11,7 +11,7 @@
 
 use {
     crate::{
-        input_parsers::{pubkeys_sigs_of, STDOUT_OUTFILE_TOKEN},
+        input_parsers::{signer::try_pubkeys_sigs_of, STDOUT_OUTFILE_TOKEN},
         offline::{SIGNER_ARG, SIGN_ONLY_ARG},
         ArgConstant,
     },
@@ -807,7 +807,9 @@ pub fn signer_from_path_with_config(
             }
         }
         SignerSourceKind::Pubkey(pubkey) => {
-            let presigner = pubkeys_sigs_of(matches, SIGNER_ARG.name)
+            let presigner = try_pubkeys_sigs_of(matches, SIGNER_ARG.name)
+                .ok()
+                .flatten()
                 .as_ref()
                 .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {

--- a/clap-v3-utils/src/keypair.rs
+++ b/clap-v3-utils/src/keypair.rs
@@ -807,9 +807,7 @@ pub fn signer_from_path_with_config(
             }
         }
         SignerSourceKind::Pubkey(pubkey) => {
-            let presigner = try_pubkeys_sigs_of(matches, SIGNER_ARG.name)
-                .ok()
-                .flatten()
+            let presigner = try_pubkeys_sigs_of(matches, SIGNER_ARG.name)?
                 .as_ref()
                 .and_then(|presigners| presigner_from_pubkey_sigs(&pubkey, presigners));
             if let Some(presigner) = presigner {


### PR DESCRIPTION
#### Problem
Due to the differences in the way `value_of` and `is_present` functions behave in clap-v2 and clap-v3, the `try_` versions of different key parsers were added in https://github.com/solana-labs/solana/pull/33184. However, that PR missed a point in the logic in `signer_from_path_with_config` where `pubkeys_sigs_of` is still used instead of `try_pubkeys_sigs_of`. The panicking behavior of `pubkeys_sigs_of` when called on a non pre-specified argument, it is blocking the token-cli from being upgraded to clap-v3.

#### Summary of Changes
I replaced the `pubkeys_sigs_of` with `try_pubkeys_sigs_of` when parsing `SignerSourceKind::Pubkey`. 

Technically, to be consistent with the rest of the module, we should call `try_pubkeys_sigs_of(matches, SIGNER_ARG.name)?`. However, this changes the behavior of the function. In clap-v2, if `pubkeys_sigs_of(matches, SIGNER_ARG.name)` is called when `SIGNER_ARG.name` is not pre-specified as a clap argument, then it returns `None`. Therefore, instead of returning error, I invoked `.ok().flatten()` on the resulting result value.

There is a bigger PR in the works https://github.com/solana-labs/solana/pull/34678 to clean up parsing of signer source. However, I just wanted to make sure that this change goes into 1.18, hence a smaller PR here.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
