### PR TITLE
[zk-token-sdk] Restrict a single-bit of 256-bit batched range proof to 128

### DIFF
--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u128.rs
@@ -41,7 +41,7 @@ impl BatchedRangeProofU128Data {
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
     ) -> Result<Self, ProofGenerationError> {
-        // the sum of the bit lengths must be 64
+        // the sum of the bit lengths must be 128
         let batched_bit_length = bit_lengths
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -44,7 +44,7 @@ impl BatchedRangeProofU256Data {
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
     ) -> Result<Self, ProofGenerationError> {
-        // the sum of the bit lengths must be 64
+        // the sum of the bit lengths must be 256
         let batched_bit_length = bit_lengths
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))

--- a/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/batched_range_proof_u256.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         encryption::pedersen::{PedersenCommitment, PedersenOpening},
         errors::{ProofGenerationError, ProofVerificationError},
-        instruction::batched_range_proof::MAX_COMMITMENTS,
+        instruction::batched_range_proof::{MAX_COMMITMENTS, MAX_SINGLE_BIT_LENGTH},
         range_proof::RangeProof,
     },
     std::convert::TryInto,
@@ -44,6 +44,14 @@ impl BatchedRangeProofU256Data {
         bit_lengths: Vec<usize>,
         openings: Vec<&PedersenOpening>,
     ) -> Result<Self, ProofGenerationError> {
+        // each bit length must be at most 128
+        if bit_lengths
+            .iter()
+            .any(|length| *length > MAX_SINGLE_BIT_LENGTH)
+        {
+            return Err(ProofGenerationError::IllegalCommitmentLength);
+        }
+
         // the sum of the bit lengths must be 256
         let batched_bit_length = bit_lengths
             .iter()
@@ -76,6 +84,13 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
     fn verify_proof(&self) -> Result<(), ProofVerificationError> {
         let (commitments, bit_lengths) = self.context.try_into()?;
         let num_commitments = commitments.len();
+
+        if bit_lengths
+            .iter()
+            .any(|length| *length > MAX_SINGLE_BIT_LENGTH)
+        {
+            return Err(ProofVerificationError::IllegalCommitmentLength);
+        }
 
         if num_commitments > MAX_COMMITMENTS || num_commitments != bit_lengths.len() {
             return Err(ProofVerificationError::IllegalCommitmentLength);

--- a/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
+++ b/zk-token-sdk/src/instruction/batched_range_proof/mod.rs
@@ -14,7 +14,7 @@
 //! the sum of all bit-lengths.
 //!
 //! The maximum number of commitments is fixed at 8. Each bit-length in `[n_1, ..., n_N]` must be a
-//! power-of-two positive integer less than 256.
+//! power-of-two positive integer less than 128.
 
 pub mod batched_range_proof_u128;
 pub mod batched_range_proof_u256;
@@ -37,6 +37,13 @@ use {
 };
 
 const MAX_COMMITMENTS: usize = 8;
+
+/// A bit length in a batched range proof must be at most 128.
+///
+/// A 256-bit range proof on a single Pedersen commitment is meaningless and hence enforce an upper
+/// bound as the largest power-of-two number less than 256.
+#[cfg(not(target_os = "solana"))]
+const MAX_SINGLE_BIT_LENGTH: usize = 128;
 
 /// The context data needed to verify a range-proof for a Pedersen committed value.
 ///


### PR DESCRIPTION
#### Problem
The problem is shared with https://github.com/solana-labs/solana/pull/34747.

#### Summary of Changes
Restrict the bit-length in a 256-bit range proof to 128.

This is a follow-up to https://github.com/solana-labs/solana/pull/34747. Since this part of the logic is gated, it does not need to be backported.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
