### PR TITLE
Exclude partition reward accounts in account hash calculation

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7721,6 +7721,11 @@ impl AccountsDb {
                 zero_lamport_accounts: kind.zero_lamport_accounts(),
                 dir_for_temp_cache_files: transient_accounts_hash_cache_path,
                 active_stats: &self.active_stats,
+                ignore_keys: self
+                    .partition_reward_pda_and_sysvar_address
+                    .lock()
+                    .unwrap()
+                    .copy_partition_reward_pda_and_sysvar_addresses(),
             };
 
             // get raw data by scanning

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -62,7 +62,10 @@ use {
         contains::Contains,
         epoch_accounts_hash::EpochAccountsHashManager,
         in_mem_accounts_index::StartupStats,
-        partitioned_rewards::{PartitionedEpochRewardsConfig, TestPartitionedEpochRewards},
+        partitioned_rewards::{
+            PartitionRewardPDAAndSysvarAddresses, PartitionedEpochRewardsConfig,
+            TestPartitionedEpochRewards,
+        },
         pubkey_bins::PubkeyBinCalculator24,
         read_only_accounts_cache::ReadOnlyAccountsCache,
         rent_collector::RentCollector,
@@ -1558,6 +1561,10 @@ pub struct AccountsDb {
     /// Some time later (to allow for slow calculation time), the bank hash at a slot calculated using 'M' includes the full accounts hash.
     /// Thus, the state of all accounts on a validator is known to be correct at least once per epoch.
     pub epoch_accounts_hash_manager: EpochAccountsHashManager,
+
+    /// Contains the addresses of all partition reward PDA accounts and sysvar
+    /// account.
+    pub partition_reward_pda_and_sysvar_address: Mutex<PartitionRewardPDAAndSysvarAddresses>,
 }
 
 #[derive(Debug, Default)]
@@ -2540,6 +2547,9 @@ impl AccountsDb {
             log_dead_slots: AtomicBool::new(true),
             exhaustively_verify_refcounts: false,
             partitioned_epoch_rewards_config: PartitionedEpochRewardsConfig::default(),
+            partition_reward_pda_and_sysvar_address: Mutex::new(
+                PartitionRewardPDAAndSysvarAddresses::default(),
+            ),
             epoch_accounts_hash_manager: EpochAccountsHashManager::new_invalid(),
             test_skip_rewrites_but_include_in_bank_hash: false,
         }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7933,7 +7933,7 @@ impl AccountsDb {
     pub fn calculate_accounts_delta_hash_internal(
         &self,
         slot: Slot,
-        ignore: Option<Pubkey>,
+        ignore: Option<&HashSet<Pubkey>>,
         mut skipped_rewrites: HashMap<Pubkey, AccountHash>,
     ) -> AccountsDeltaHash {
         let (mut hashes, scan_us, mut accumulate) = self.get_pubkey_hash_for_slot(slot);
@@ -7949,7 +7949,7 @@ impl AccountsDb {
         info!("skipped rewrite hashes {} {}", slot, num_skipped_rewrites);
 
         if let Some(ignore) = ignore {
-            hashes.retain(|k| k.0 != ignore);
+            hashes.retain(|k| !ignore.contains(&k.0));
         }
 
         let accounts_delta_hash =

--- a/accounts-db/src/accounts_hash.rs
+++ b/accounts-db/src/accounts_hash.rs
@@ -1335,6 +1335,7 @@ mod tests {
                 zero_lamport_accounts: ZeroLamportAccounts::Excluded,
                 dir_for_temp_cache_files,
                 active_stats: &ACTIVE_STATS,
+                ignore_keys: HashSet::default(),
             }
         }
     }

--- a/accounts-db/src/partitioned_rewards.rs
+++ b/accounts-db/src/partitioned_rewards.rs
@@ -154,6 +154,10 @@ impl PartitionRewardPDAAndSysvarAddresses {
 
         self.addresses.to_owned()
     }
+
+    pub fn copy_partition_reward_pda_and_sysvar_addresses(&self) -> HashSet<Pubkey> {
+        self.addresses.to_owned()
+    }
 }
 
 #[cfg(test)]

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3619,6 +3619,18 @@ impl Bank {
         info!(
             "create epoch_reward partition data account {} {address} {epoch_rewards_partition_data:#?}", self.slot
         );
+
+        // ignore reward PDA account lamport when we are testing partitioned rewards before the actual feature activation.
+        if !self.is_partitioned_rewards_feature_enabled()
+            && (self
+                .partitioned_epoch_rewards_config()
+                .test_enable_partitioned_rewards
+                && self.get_reward_calculation_num_blocks() == 0
+                && self.partitioned_rewards_stake_account_stores_per_block() == u64::MAX)
+        {
+            self.capitalization
+                .fetch_sub(new_account.lamports(), Relaxed);
+        }
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6936,16 +6936,14 @@ impl Bank {
         self.get_signature_status_slot(signature).is_some()
     }
 
-    fn get_epoch_reward_pda_and_sysvar_addresses(&self) -> HashSet<Pubkey> {
-        let mut addresses = HashSet::default();
-        addresses.insert(sysvar::epoch_rewards::id());
-
-        for epoch in 0..=self.epoch {
-            let pda = get_epoch_rewards_partition_data_address(epoch);
-            addresses.insert(pda);
-        }
-
-        addresses
+    fn get_partition_reward_pda_and_sysvar_addresses(&self) -> HashSet<Pubkey> {
+        self.rc
+            .accounts
+            .accounts_db
+            .partition_reward_pda_and_sysvar_address
+            .lock()
+            .unwrap()
+            .get_partition_reward_pda_and_sysvar_addresses(self.epoch)
     }
 
     /// Hash the `accounts` HashMap. This represents a validator's interpretation
@@ -6958,7 +6956,7 @@ impl Bank {
                 .test_enable_partitioned_rewards
                 && self.get_reward_calculation_num_blocks() == 0
                 && self.partitioned_rewards_stake_account_stores_per_block() == u64::MAX))
-            .then(|| self.get_epoch_reward_pda_and_sysvar_addresses());
+            .then(|| self.get_partition_reward_pda_and_sysvar_addresses());
         let accounts_delta_hash = self
             .rc
             .accounts

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3617,7 +3617,7 @@ impl Bank {
         .unwrap();
         self.store_account_and_update_capitalization(&address, &new_account);
         info!(
-            "create epoch_reward partition data account {address} {epoch_rewards_partition_data:#?}"
+            "create epoch_reward partition data account {} {address} {epoch_rewards_partition_data:#?}", self.slot
         );
     }
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3616,6 +3616,9 @@ impl Bank {
         )
         .unwrap();
         self.store_account_and_update_capitalization(&address, &new_account);
+        info!(
+            "create epoch_reward partition data account {address} {epoch_rewards_partition_data:#?}"
+        );
     }
 
     fn update_recent_blockhashes_locked(&self, locked_blockhash_queue: &BlockhashQueue) {


### PR DESCRIPTION
#### Problem

We can run the validator against mainnet with the new partitioned reward code by enabling `--partitioned-epoch-rewards-force-enable-single-slot` CLI argument. 

Recently, my test node running with the above CLI fails on account hash mismatch. It turns out that the mismatch is coming from the new partition reward account introduced at the epoch, i.e. https://github.com/solana-labs/solana/pull/34624.

In order for this CLI continue to work after https://github.com/solana-labs/solana/pull/34624, we need to ignore the epoch partition reward accounts for account hash calculation.

#### Summary of Changes

Ignore partition reward accounts for account's hash calculation when we force enable partitioned rewards 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
