### PR TITLE
less allocations in pubkeys! macro

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -4667,7 +4667,7 @@ pub mod tests {
         },
         solana_runtime::{
             accounts_background_service::AbsRequestSender, bank::BankTestConfig,
-            commitment::BlockCommitment, non_circulating_supply::non_circulating_accounts,
+            commitment::BlockCommitment, non_circulating_supply::NON_CIRCULATING_ACCOUNTS,
         },
         solana_sdk::{
             account::{Account, WritableAccount},
@@ -5299,7 +5299,7 @@ pub mod tests {
             result.value
         };
         let expected = {
-            let mut non_circulating_accounts: Vec<String> = non_circulating_accounts()
+            let mut non_circulating_accounts: Vec<String> = NON_CIRCULATING_ACCOUNTS
                 .iter()
                 .map(|pubkey| pubkey.to_string())
                 .collect();
@@ -5340,7 +5340,7 @@ pub mod tests {
         let rpc = RpcHandler::start();
 
         // make a non-circulating account one of the largest accounts
-        let non_circulating_key = &non_circulating_accounts()[0];
+        let non_circulating_key = &NON_CIRCULATING_ACCOUNTS[0];
         let bank = rpc.working_bank();
         bank.process_transaction(&system_transaction::transfer(
             &rpc.mint_keypair,

--- a/sdk/macro/src/lib.rs
+++ b/sdk/macro/src/lib.rs
@@ -309,7 +309,7 @@ fn parse_pubkey(
 }
 
 struct Pubkeys {
-    method: Ident,
+    name: Ident,
     num: usize,
     pubkeys: proc_macro2::TokenStream,
 }
@@ -319,7 +319,7 @@ impl Parse for Pubkeys {
             ::solana_sdk::pubkey::Pubkey
         };
 
-        let method = input.parse()?;
+        let name = input.parse()?;
         let _comma: Token![,] = input.parse()?;
         let (num, pubkeys) = if input.peek(syn::LitStr) {
             let id_literal: LitStr = input.parse()?;
@@ -339,36 +339,24 @@ impl Parse for Pubkeys {
             return Err(syn::Error::new_spanned(stream, "unexpected token"));
         };
 
-        Ok(Pubkeys {
-            method,
-            num,
-            pubkeys,
-        })
+        Ok(Pubkeys { name, num, pubkeys })
     }
 }
 
 impl ToTokens for Pubkeys {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let Pubkeys {
-            method,
-            num,
-            pubkeys,
-        } = self;
+        let Pubkeys { name, num, pubkeys } = self;
 
         let pubkey_type = quote! {
             ::solana_sdk::pubkey::Pubkey
         };
         if *num == 1 {
             tokens.extend(quote! {
-                pub fn #method() -> #pubkey_type {
-                    #pubkeys
-                }
+                pub const #name: #pubkey_type = #pubkeys;
             });
         } else {
             tokens.extend(quote! {
-                pub fn #method() -> ::std::vec::Vec<#pubkey_type> {
-                    vec![#pubkeys]
-                }
+                pub const #name: &[#pubkey_type] = &[#pubkeys];
             });
         }
     }


### PR DESCRIPTION
#### Problem

Accessing keys declared with the ` solana_sdk::pubkeys!()` macro does allocations.

Useful for #34686

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
