### PR TITLE
Removes unused snapshot errors

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -310,9 +310,6 @@ pub enum SnapshotError {
     #[error("source({1}) - I/O error: {0}")]
     IoWithSource(std::io::Error, &'static str),
 
-    #[error("source({1}) - I/O error: {0}, file: {2}")]
-    IoWithSourceAndFile(#[source] std::io::Error, &'static str, PathBuf),
-
     #[error("could not get file name from path: {0}")]
     PathToFileNameError(PathBuf),
 


### PR DESCRIPTION
#### Problem

There are unused snapshot errors that wrap a `std::io::Error`. These ones in particular can be annoying when printing, because sometimes the source error (i.e. `std::io::Error`) does include *its* source in the error message, and sometimes it does not. This makes logging errors inconsistent.

Longterm, we'll have specific errors for each case, and thus will not have this ambiguity. In the meantime, prevent new uses of ambiguous IO errors.


#### Summary of Changes

- Removes unused SnapshotNewFromDirError::Io variant
- Removes unused SnapshotError::IoWithSourceAndFile variant