### PR TITLE
Fix ahash building on MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ edition = "2021"
 
 [workspace.dependencies]
 aes-gcm-siv = "0.10.3"
-ahash = "=0.8.4"
+ahash = ">=0.8.4,<=0.8.6"
 anyhow = "1.0.75"
 ark-bn254 = "0.4.0"
 ark-ec = "0.4.0"


### PR DESCRIPTION
#### Problem
`ahash@0.8.4` produces a compile error when targeting aarch64. This is fixed in `0.8.5`. I haven't seen any issues building with `0.8.6` either.

#### Summary of Changes
Changed `ahash` lock to allow `0.8.4`, `0.8.5`, and `0.8.6`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
