### PR TITLE
Sample peers if input peer missing for repair shred

### DIFF
--- a/core/src/admin_rpc_post_init.rs
+++ b/core/src/admin_rpc_post_init.rs
@@ -1,5 +1,8 @@
 use {
-    crate::repair::{outstanding_requests, serve_repair},
+    crate::{
+        cluster_slots_service::cluster_slots::ClusterSlots,
+        repair::{outstanding_requests::OutstandingRequests, serve_repair::ShredRepairType},
+    },
     solana_gossip::cluster_info::ClusterInfo,
     solana_runtime::bank_forks::BankForks,
     solana_sdk::{pubkey::Pubkey, quic::NotifyKeyUpdate},
@@ -18,6 +21,6 @@ pub struct AdminRpcRequestMetadataPostInit {
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>,
     pub notifies: Vec<Arc<dyn NotifyKeyUpdate + Sync + Send>>,
     pub repair_socket: Arc<UdpSocket>,
-    pub outstanding_repair_requests:
-        Arc<RwLock<outstanding_requests::OutstandingRequests<serve_repair::ShredRepairType>>>,
+    pub outstanding_repair_requests: Arc<RwLock<OutstandingRequests<ShredRepairType>>>,
+    pub cluster_slots: Arc<ClusterSlots>,
 }

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -142,6 +142,7 @@ impl Tvu {
         turbine_quic_endpoint_receiver: Receiver<(Pubkey, SocketAddr, Bytes)>,
         repair_quic_endpoint_sender: AsyncSender<LocalRequest>,
         outstanding_repair_requests: Arc<RwLock<OutstandingShredRepairs>>,
+        cluster_slots: Arc<ClusterSlots>,
     ) -> Result<Self, String> {
         let TvuSockets {
             repair: repair_socket,
@@ -192,7 +193,6 @@ impl Tvu {
             Some(rpc_subscriptions.clone()),
         );
 
-        let cluster_slots = Arc::new(ClusterSlots::default());
         let (ancestor_duplicate_slots_sender, ancestor_duplicate_slots_receiver) = unbounded();
         let (duplicate_slots_sender, duplicate_slots_receiver) = unbounded();
         let (ancestor_hashes_replay_update_sender, ancestor_hashes_replay_update_receiver) =
@@ -448,6 +448,7 @@ pub mod tests {
         let max_complete_rewards_slot = Arc::new(AtomicU64::default());
         let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
         let outstanding_repair_requests = Arc::<RwLock<OutstandingShredRepairs>>::default();
+        let cluster_slots = Arc::new(ClusterSlots::default());
         let tvu = Tvu::new(
             &vote_keypair.pubkey(),
             Arc::new(RwLock::new(vec![Arc::new(vote_keypair)])),
@@ -503,6 +504,7 @@ pub mod tests {
             turbine_quic_endpoint_receiver,
             repair_quic_endpoint_sender,
             outstanding_repair_requests,
+            cluster_slots,
         )
         .expect("assume success");
         exit.store(true, Ordering::Relaxed);

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -1257,6 +1257,8 @@ impl Validator {
 
         let outstanding_repair_requests =
             Arc::<RwLock<repair::repair_service::OutstandingShredRepairs>>::default();
+        let cluster_slots =
+            Arc::new(crate::cluster_slots_service::cluster_slots::ClusterSlots::default());
 
         let tvu = Tvu::new(
             vote_account,
@@ -1311,6 +1313,7 @@ impl Validator {
             turbine_quic_endpoint_receiver,
             repair_quic_endpoint_sender,
             outstanding_repair_requests.clone(),
+            cluster_slots.clone(),
         )?;
 
         if in_wen_restart {
@@ -1389,6 +1392,7 @@ impl Validator {
             notifies: key_notifies,
             repair_socket: Arc::new(node.sockets.repair),
             outstanding_repair_requests,
+            cluster_slots,
         });
 
         Ok(Self {

--- a/validator/src/admin_rpc_service.rs
+++ b/validator/src/admin_rpc_service.rs
@@ -212,7 +212,7 @@ pub trait AdminRpc {
     fn repair_shred_from_peer(
         &self,
         meta: Self::Metadata,
-        pubkey: Pubkey,
+        pubkey: Option<Pubkey>,
         slot: u64,
         shred_index: u64,
     ) -> Result<()>;
@@ -500,7 +500,7 @@ impl AdminRpc for AdminRpcImpl {
     fn repair_shred_from_peer(
         &self,
         meta: Self::Metadata,
-        pubkey: Pubkey,
+        pubkey: Option<Pubkey>,
         slot: u64,
         shred_index: u64,
     ) -> Result<()> {
@@ -509,6 +509,7 @@ impl AdminRpc for AdminRpcImpl {
         meta.with_post_init(|post_init| {
             repair_service::RepairService::request_repair_for_shred_from_peer(
                 post_init.cluster_info.clone(),
+                post_init.cluster_slots.clone(),
                 pubkey,
                 slot,
                 shred_index,
@@ -931,6 +932,9 @@ mod tests {
                     outstanding_repair_requests: Arc::<
                         RwLock<repair_service::OutstandingShredRepairs>,
                     >::default(),
+                    cluster_slots: Arc::new(
+                        solana_core::cluster_slots_service::cluster_slots::ClusterSlots::default(),
+                    ),
                 }))),
                 staked_nodes_overrides: Arc::new(RwLock::new(HashMap::new())),
                 rpc_to_plugin_manager_sender: None,

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1503,6 +1503,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                     Arg::with_name("pubkey")
                         .long("pubkey")
                         .value_name("PUBKEY")
+                        .required(false)
                         .takes_value(true)
                         .validator(is_pubkey)
                         .help("Identity pubkey of the validator to repair from")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -794,7 +794,7 @@ pub fn main() {
             return;
         }
         ("repair-shred-from-peer", Some(subcommand_matches)) => {
-            let pubkey = value_t_or_exit!(subcommand_matches, "pubkey", Pubkey);
+            let pubkey = value_t!(subcommand_matches, "pubkey", Pubkey).ok();
             let slot = value_t_or_exit!(subcommand_matches, "slot", u64);
             let shred_index = value_t_or_exit!(subcommand_matches, "shred", u64);
             let admin_client = admin_rpc_service::connect(&ledger_path);


### PR DESCRIPTION
#### Problem
This builds off of #34771. The repair-shred-from-peer command currently requires a valid peer pubkey to be provided as input and a valid repair socket to exist in cluster info. In the event no pubkey or an invalid pubkey is provided, it would be nice to log this and then sample a random set of validators instead. The idea here is that one of the validators should possess 

#### Summary of Changes

1. Make pubkey input optional
2. When pubkey is not present or no socket can be acquired, sample a random set of 10 validators that are likely to have the slot we're trying to repair (based on LowestSlot data in Gossip)

For testing, spun up a node on testnet and tried issuing this command with the following pubkey inputs:
* valid pubkey `9YVpEeZf8uBoUtzCFC6SSFDDqPt16uKFubNhLvGxeUDy` <-- we requested repair from only this node
* invalid pubkey `9YVpEeZf8uBoUtzCFC6SSFDDqPt16uKFubNhLvGxeUD` <-- we requested repair from random 10 nodes
* no pubkey <-- we requested repair from random 10 nodes