### PR TITLE
[TieredStorage] Allow IndexBlock to be written with padding option

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -784,7 +784,7 @@ pub mod tests {
 
             let cursor = footer
                 .index_block_format
-                .write_index_block(&file, &index_writer_entries)
+                .write_index_block(&file, &index_writer_entries, Some(HOT_ACCOUNT_ALIGNMENT))
                 .unwrap();
             footer.owners_block_offset = cursor as u64;
             footer.write_footer_block(&file).unwrap();
@@ -965,7 +965,9 @@ pub mod tests {
             .collect();
 
         // create account data
-        const NUM_ACCOUNTS: usize = 20;
+        // Intentionally use an odd number of accounts here to test the
+        // index block padding.
+        const NUM_ACCOUNTS: usize = 19;
         let account_datas: Vec<_> = (0..NUM_ACCOUNTS)
             .map(|i| vec![i as u8; rng.gen_range(0..4096)])
             .collect();
@@ -1017,13 +1019,15 @@ pub mod tests {
                 .collect();
 
             // write index blocks
+            assert_eq!(current_offset % HOT_ACCOUNT_ALIGNMENT, 0);
             footer.index_block_offset = current_offset as u64;
             current_offset += footer
                 .index_block_format
-                .write_index_block(&file, &index_writer_entries)
+                .write_index_block(&file, &index_writer_entries, Some(HOT_ACCOUNT_ALIGNMENT))
                 .unwrap();
 
             // write owners block
+            assert_eq!(current_offset % HOT_ACCOUNT_ALIGNMENT, 0);
             footer.owners_block_offset = current_offset as u64;
             OwnersBlock::write_owners_block(&file, &owners).unwrap();
 


### PR DESCRIPTION
#### Problem
IndexBlock consists of a list of addresses and a list of AccountOffsets, where
AccountOffset is a u32.  Because of this, when a hot accounts file contains
an odd number of accounts, the resulting offset after the index blook will
cause the footer (which has u64 fields) being unaligned.

#### Summary of Changes
This PR extends IndexBlockFormat::write_index_block() to take an additional
argument for the alignment:

    alignment: Option<usize>
    
When the value is Some, then it will write additional padding bytes to make sure
the resulting offset satisfies the alignment requirement.

#### Test Plan
Updated the existing unit-test to cover the case where index-block requires additional
padding to satisfies the padding requirement.