### PR TITLE
Snapshot archive uses version file from bank snapshot

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -20,9 +20,9 @@ use {
             get_storages_to_serialize, hard_link_storages_to_snapshot,
             rebuild_storages_from_snapshot_dir, serialize_snapshot_data_file,
             verify_and_unarchive_snapshots, verify_unpacked_snapshots_dir_and_version,
-            write_snapshot_version_file, AddBankSnapshotError, ArchiveFormat, BankSnapshotInfo,
-            BankSnapshotType, SnapshotError, SnapshotRootPaths, SnapshotVersion,
-            StorageAndNextAppendVecId, UnpackedSnapshotsDirAndVersion, VerifySlotDeltasError,
+            AddBankSnapshotError, ArchiveFormat, BankSnapshotInfo, BankSnapshotType, SnapshotError,
+            SnapshotRootPaths, SnapshotVersion, StorageAndNextAppendVecId,
+            UnpackedSnapshotsDirAndVersion, VerifySlotDeltasError,
         },
         status_cache,
     },
@@ -135,9 +135,11 @@ pub fn add_bank_snapshot(
                 .map_err(|err| AddBankSnapshotError::SerializeStatusCache(Box::new(err)))?);
 
         let version_path = bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
-        let (_, measure_write_version_file) =
-            measure!(write_snapshot_version_file(version_path, snapshot_version)
-                .map_err(AddBankSnapshotError::WriteSnapshotVersionFile)?);
+        let (_, measure_write_version_file) = measure!(fs_err::write(
+            version_path,
+            snapshot_version.as_str().as_bytes()
+        )
+        .map_err(AddBankSnapshotError::WriteSnapshotVersionFile)?);
 
         // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
         let state_complete_path =

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -653,14 +653,6 @@ pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {
     }
 }
 
-/// Write the snapshot version as a file into the bank snapshot directory
-pub fn write_snapshot_version_file(
-    version_file: impl AsRef<Path>,
-    version: SnapshotVersion,
-) -> std::io::Result<()> {
-    fs_err::write(version_file, version.as_str().as_bytes())
-}
-
 /// Make a snapshot archive out of the snapshot package
 pub fn archive_snapshot_package(
     snapshot_package: &SnapshotPackage,
@@ -696,7 +688,6 @@ pub fn archive_snapshot_package(
 
     let staging_accounts_dir = staging_dir.path().join("accounts");
     let staging_snapshots_dir = staging_dir.path().join("snapshots");
-    let staging_version_file = staging_dir.path().join(SNAPSHOT_VERSION_FILENAME);
 
     // Create staging/accounts/
     fs_err::create_dir_all(&staging_accounts_dir)
@@ -725,6 +716,12 @@ pub fn archive_snapshot_package(
     symlink::symlink_file(src_status_cache, staging_status_cache)
         .map_err(|e| SnapshotError::IoWithSource(e, "create status cache symlink"))?;
 
+    // The bank snapshot has the version file, so symlink it to the correct staging path
+    let staging_version_file = staging_dir.path().join(SNAPSHOT_VERSION_FILENAME);
+    let src_version_file = src_snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
+    symlink::symlink_file(src_version_file, staging_version_file)
+        .map_err(|e| SnapshotError::IoWithSource(e, "create version file symlink"))?;
+
     // Add the AppendVecs into the compressible list
     for storage in snapshot_package.snapshot_storages.iter() {
         storage.flush()?;
@@ -744,9 +741,6 @@ pub fn archive_snapshot_package(
             return Err(SnapshotError::StoragePathSymlinkInvalid);
         }
     }
-
-    write_snapshot_version_file(staging_version_file, snapshot_package.snapshot_version)
-        .map_err(|err| SnapshotError::IoWithSource(err, "write snapshot version file"))?;
 
     // Tar the staging directory into the archive at `archive_path`
     let archive_path = tar_dir.join(format!(
@@ -2550,7 +2544,7 @@ mod tests {
             fs_err::File::create(status_cache_file).unwrap();
 
             let version_path = snapshot_dir.join(SNAPSHOT_VERSION_FILENAME);
-            write_snapshot_version_file(version_path, SnapshotVersion::default()).unwrap();
+            fs_err::write(version_path, SnapshotVersion::default().as_str().as_bytes()).unwrap();
 
             // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
             let state_complete_path = snapshot_dir.join(SNAPSHOT_STATE_COMPLETE_FILENAME);


### PR DESCRIPTION
#### Problem

When creating a snapshot archive, it needs a snapshot version file. Currently, we create that file from the snapshot version inside the snapshot package. However, we already wrote a snapshot version file as part of snapshotting the bank previously. So there's no need to write this file twice (and it'll make cleaning up the errors later easier too)!


#### Summary of Changes

Similar to the status cache, symlink the snapshot version file from the bank snapshot into the snapshot archive's staging directory.