### PR TITLE
Replaces fs-err for some snapshot errors

### DIFF
--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -27,7 +27,6 @@ use {
         status_cache,
     },
     bincode::{config::Options, serialize_into},
-    fs_err,
     log::*,
     solana_accounts_db::{
         accounts_db::{
@@ -49,6 +48,7 @@ use {
     },
     std::{
         collections::HashSet,
+        fs,
         io::{BufWriter, Write},
         num::NonZeroUsize,
         path::{Path, PathBuf},
@@ -85,8 +85,9 @@ pub fn add_bank_snapshot(
                 bank_snapshot_dir,
             ));
         }
-        fs_err::create_dir_all(&bank_snapshot_dir)
-            .map_err(AddBankSnapshotError::CreateSnapshotDir)?;
+        fs::create_dir_all(&bank_snapshot_dir).map_err(|err| {
+            AddBankSnapshotError::CreateSnapshotDir(err, bank_snapshot_dir.clone())
+        })?;
 
         // the bank snapshot is stored as bank_snapshots_dir/slot/slot.BANK_SNAPSHOT_PRE_FILENAME_EXTENSION
         let bank_snapshot_path = bank_snapshot_dir
@@ -135,18 +136,19 @@ pub fn add_bank_snapshot(
                 .map_err(|err| AddBankSnapshotError::SerializeStatusCache(Box::new(err)))?);
 
         let version_path = bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_VERSION_FILENAME);
-        let (_, measure_write_version_file) = measure!(fs_err::write(
-            version_path,
-            snapshot_version.as_str().as_bytes()
+        let (_, measure_write_version_file) = measure!(fs::write(
+            &version_path,
+            snapshot_version.as_str().as_bytes(),
         )
-        .map_err(AddBankSnapshotError::WriteSnapshotVersionFile)?);
+        .map_err(|err| AddBankSnapshotError::WriteSnapshotVersionFile(err, version_path))?);
 
         // Mark this directory complete so it can be used.  Check this flag first before selecting for deserialization.
         let state_complete_path =
             bank_snapshot_dir.join(snapshot_utils::SNAPSHOT_STATE_COMPLETE_FILENAME);
         let (_, measure_write_state_complete_file) =
-            measure!(fs_err::File::create(state_complete_path)
-                .map_err(AddBankSnapshotError::CreateStateCompleteFile)?);
+            measure!(fs::File::create(&state_complete_path).map_err(|err| {
+                AddBankSnapshotError::CreateStateCompleteFile(err, state_complete_path)
+            })?);
 
         measure_everything.stop();
 

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -30,7 +30,7 @@ use {
     std::{
         cmp::Ordering,
         collections::{HashMap, HashSet},
-        fmt,
+        fmt, fs,
         io::{BufReader, BufWriter, Error as IoError, ErrorKind, Read, Seek, Write},
         num::NonZeroUsize,
         path::{Path, PathBuf},
@@ -407,8 +407,8 @@ pub enum AddBankSnapshotError {
     #[error("bank snapshot dir already exists '{0}'")]
     SnapshotDirAlreadyExists(PathBuf),
 
-    #[error("failed to create snapshot dir: {0}")]
-    CreateSnapshotDir(#[source] IoError),
+    #[error("failed to create snapshot dir '{1}': {0}")]
+    CreateSnapshotDir(#[source] IoError, PathBuf),
 
     #[error("failed to hard link storages: {0}")]
     HardLinkStorages(#[source] HardLinkStoragesToSnapshotError),
@@ -419,11 +419,11 @@ pub enum AddBankSnapshotError {
     #[error("failed to serialize status cache: {0}")]
     SerializeStatusCache(#[source] Box<SnapshotError>),
 
-    #[error("failed to write snapshot version file: {0}")]
-    WriteSnapshotVersionFile(#[source] IoError),
+    #[error("failed to write snapshot version file '{1}': {0}")]
+    WriteSnapshotVersionFile(#[source] IoError, PathBuf),
 
-    #[error("failed to mark snapshot as 'complete': {0}")]
-    CreateStateCompleteFile(#[source] IoError),
+    #[error("failed to mark snapshot as 'complete': failed to create file '{1}': {0}")]
+    CreateStateCompleteFile(#[source] IoError, PathBuf),
 }
 
 /// Errors that can happen in `hard_link_storages_to_snapshot()`
@@ -448,8 +448,8 @@ pub enum GetSnapshotAccountsHardLinkDirError {
     #[error("invalid account storage path '{0}'")]
     GetAccountPath(PathBuf),
 
-    #[error("failed to create the snapshot hard link dir: {0}")]
-    CreateSnapshotHardLinkDir(#[source] IoError),
+    #[error("failed to create the snapshot hard link dir '{1}': {0}")]
+    CreateSnapshotHardLinkDir(#[source] IoError, PathBuf),
 
     #[error("failed to symlink snapshot hard link dir '{link}' to '{original}': {source}")]
     SymlinkSnapshotHardLinkDir {
@@ -1137,8 +1137,12 @@ fn get_snapshot_accounts_hardlink_dir(
             appendvec_path.display(),
             snapshot_hardlink_dir.display()
         );
-        fs_err::create_dir_all(&snapshot_hardlink_dir)
-            .map_err(GetSnapshotAccountsHardLinkDirError::CreateSnapshotHardLinkDir)?;
+        fs::create_dir_all(&snapshot_hardlink_dir).map_err(|err| {
+            GetSnapshotAccountsHardLinkDirError::CreateSnapshotHardLinkDir(
+                err,
+                snapshot_hardlink_dir.clone(),
+            )
+        })?;
         let symlink_path = hardlinks_dir.as_ref().join(format!("account_path_{idx}"));
         symlink::symlink_dir(&snapshot_hardlink_dir, &symlink_path).map_err(|err| {
             GetSnapshotAccountsHardLinkDirError::SymlinkSnapshotHardLinkDir {


### PR DESCRIPTION
#### Problem

The `fs-err` create does not include source errors when displaying the error. The solana repo's convention *is* to include the source error in the message, so we end up losing the underlying cause of an IO error if fs_err is used.

Here's more info about the issue that I raised on the fs-err repo: https://github.com/andrewhickman/fs-err/issues/51. Turns out their behavior is desired, and likely the most idiomatically correct Rust way. But we're not going to change the solana repo's error reporting anytime soon. Instead, we should replace the use of fs-err with regular std::fs.

Related: https://github.com/solana-labs/solana/pull/34799


#### Summary of Changes

Replace fs-err for all the AddBankSnapshotError and GetSnapshotAccountsHardLinkDirError errors