### PR TITLE
Replaces fs-err in remove_tmp_snapshot_archives()

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -30,7 +30,7 @@ use {
     std::{
         cmp::Ordering,
         collections::{HashMap, HashSet},
-        fmt,
+        fmt, fs,
         io::{BufReader, BufWriter, Error as IoError, ErrorKind, Read, Seek, Write},
         num::NonZeroUsize,
         path::{Path, PathBuf},
@@ -641,12 +641,15 @@ pub fn remove_tmp_snapshot_archives(snapshot_archives_dir: impl AsRef<Path>) {
             {
                 let path = entry.path();
                 let result = if path.is_dir() {
-                    fs_err::remove_dir_all(path)
+                    fs::remove_dir_all(&path)
                 } else {
-                    fs_err::remove_file(path)
+                    fs::remove_file(&path)
                 };
                 if let Err(err) = result {
-                    warn!("Failed to remove temporary snapshot archive: {err}");
+                    warn!(
+                        "Failed to remove temporary snapshot archive '{}': {err}",
+                        path.display(),
+                    );
                 }
             }
         }


### PR DESCRIPTION
#### Problem

The `fs-err` create does not include source errors when displaying the error. The solana repo's convention *is* to include the source error in the message, so we end up losing the underlying cause of an IO error if fs_err is used.

Here's more info about the issue that I raised on the fs-err repo: https://github.com/andrewhickman/fs-err/issues/51. Turns out their behavior is desired, and likely the most idiomatically correct Rust way. But we're not going to change the solana repo's error reporting anytime soon. Instead, we should replace the use of fs-err with regular std::fs.

Related: https://github.com/solana-labs/solana/pull/34799


#### Summary of Changes

Replace fs-err in `remove_tmp_snapshot_archives()`