### PR TITLE
Cleanup after simplify_writable_program_account_check feature activation

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1036,10 +1036,9 @@ fn test_rent_exempt_executable_account() {
         transfer_lamports,
         genesis_config.hash(),
     );
-
-    assert_eq!(
+    assert_matches!(
         bank.process_transaction(&tx),
-        Err(TransactionError::InvalidWritableAccount)
+        Err(TransactionError::InstructionError(0, _))
     );
     assert_eq!(bank.get_balance(&account_pubkey), account_balance);
 }


### PR DESCRIPTION
#### Problem
`simplify_writable_program_account_check` is active on all clusters now. The code can be cleaned up.

#### Summary of Changes
Code cleanup.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
