### PR TITLE
harden cli tests

### DIFF
--- a/cli/tests/nonce.rs
+++ b/cli/tests/nonce.rs
@@ -249,7 +249,7 @@ fn test_create_account_with_seed() {
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        sol_to_lamports(ONE_SIG_FEE),
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );

--- a/cli/tests/stake.rs
+++ b/cli/tests/stake.rs
@@ -1276,7 +1276,7 @@ fn test_stake_authorize_with_fee_payer() {
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        fee_one_sig,
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );

--- a/cli/tests/transfer.rs
+++ b/cli/tests/transfer.rs
@@ -34,7 +34,7 @@ fn test_transfer() {
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        fee_one_sig,
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );
@@ -325,13 +325,14 @@ fn test_transfer() {
 #[test]
 fn test_transfer_multisession_signing() {
     solana_logger::setup();
-    let fee = FeeStructure::default().get_max_fee(2, 0);
+    let fee_one_sig = FeeStructure::default().get_max_fee(1, 0);
+    let fee_two_sig = FeeStructure::default().get_max_fee(2, 0);
     let mint_keypair = Keypair::new();
     let mint_pubkey = mint_keypair.pubkey();
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        fee_one_sig,
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );
@@ -355,7 +356,7 @@ fn test_transfer_multisession_signing() {
         &rpc_client,
         &CliConfig::recent_for_tests(),
         &offline_fee_payer_signer.pubkey(),
-        sol_to_lamports(1.0) + 2 * fee,
+        sol_to_lamports(1.0) + 2 * fee_two_sig,
     )
     .unwrap();
     check_balance!(
@@ -364,7 +365,7 @@ fn test_transfer_multisession_signing() {
         &offline_from_signer.pubkey(),
     );
     check_balance!(
-        sol_to_lamports(1.0) + 2 * fee,
+        sol_to_lamports(1.0) + 2 * fee_two_sig,
         &rpc_client,
         &offline_fee_payer_signer.pubkey(),
     );
@@ -467,7 +468,7 @@ fn test_transfer_multisession_signing() {
         &offline_from_signer.pubkey(),
     );
     check_balance!(
-        sol_to_lamports(1.0) + fee,
+        sol_to_lamports(1.0) + fee_two_sig,
         &rpc_client,
         &offline_fee_payer_signer.pubkey(),
     );
@@ -483,7 +484,7 @@ fn test_transfer_all() {
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        fee,
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );
@@ -592,7 +593,7 @@ fn test_transfer_with_seed() {
     let faucet_addr = run_local_faucet(mint_keypair, None);
     let test_validator = TestValidator::with_custom_fees(
         mint_pubkey,
-        1,
+        fee,
         Some(faucet_addr),
         SocketAddrSpace::Unspecified,
     );


### PR DESCRIPTION
#### Problem
TestValidator can be created with custom specified target_lamportds_per_signature
```
    pub fn with_custom_fees(
        mint_address: Pubkey,
        target_lamports_per_signature: u64,
        faucet_addr: Option<SocketAddr>,
        socket_addr_space: SocketAddrSpace,
    ) -> Self 
```

Cli tests uses `with_custom_fees()` but with `target_lamports_per_signature == 1`. This works accidentally because `calculate_fee()` currently uses fee_structure's default `lamports_per_signature` so long fee_rate_governor.lamport_per_signature <> 0.

`Calculate_fee()` is going to change (eg. be corrected). But in any case, cli tests should use correct value in setting up TestValidator.

#### Summary of Changes
- setting up TestValidator with correct target_lamports_per_signature

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
