### PR TITLE
use intended lamports_per_signature for fee_structure

### DIFF
--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -624,7 +624,10 @@ mod tests {
             &RentCollector::default(),
             error_counters,
             &all_features_except(exclude_features),
-            &FeeStructure::default(),
+            &FeeStructure {
+                lamports_per_signature,
+                ..FeeStructure::default()
+            },
         )
     }
 


### PR DESCRIPTION
#### Problem
FeeStructure used in tests should be initialized with intended `lamports_per_signature`.  Using `FeeStructure::default()` only works if `lamports_per_signature == 0 or 5_000`.

#### Summary of Changes
- Initialize FeeStructure with intended lamports_per_signature for tests

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
