### PR TITLE
[TieredStorage] In-memory struct for writing OwnersBlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5316,6 +5316,7 @@ dependencies = [
  "fnv",
  "im",
  "index_list",
+ "indexmap 2.1.0",
  "itertools",
  "lazy_static",
  "libsecp256k1",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -23,6 +23,7 @@ flate2 = { workspace = true }
 fnv = { workspace = true }
 im = { workspace = true, features = ["rayon", "serde"] }
 index_list = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -825,11 +825,11 @@ pub mod tests {
 
             let mut owners_table = OwnersTable::new();
             addresses.iter().for_each(|owner_address| {
-                owners_table.check_and_add(owner_address);
+                owners_table.insert(owner_address);
             });
             footer
                 .owners_block_format
-                .write_owners_block(&file, owners_table.owners().into_iter())
+                .write_owners_block(&file, &owners_table)
                 .unwrap();
 
             // while the test only focuses on account metas, writing a footer
@@ -899,11 +899,11 @@ pub mod tests {
 
             let mut owners_table = OwnersTable::new();
             owner_addresses.iter().for_each(|owner_address| {
-                owners_table.check_and_add(owner_address);
+                owners_table.insert(owner_address);
             });
             footer
                 .owners_block_format
-                .write_owners_block(&file, owners_table.owners())
+                .write_owners_block(&file, &owners_table)
                 .unwrap();
 
             // while the test only focuses on account metas, writing a footer
@@ -1039,11 +1039,11 @@ pub mod tests {
             footer.owners_block_offset = current_offset as u64;
             let mut owners_table = OwnersTable::new();
             owners.iter().for_each(|owner_address| {
-                owners_table.check_and_add(owner_address);
+                owners_table.insert(owner_address);
             });
             footer
                 .owners_block_format
-                .write_owners_block(&file, owners_table.owners())
+                .write_owners_block(&file, &owners_table)
                 .unwrap();
 
             footer.write_footer_block(&file).unwrap();

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -470,7 +470,7 @@ pub mod tests {
             hot::{HotAccountMeta, HotStorageReader},
             index::{AccountIndexWriterEntry, IndexBlockFormat, IndexOffset},
             meta::{AccountMetaFlags, AccountMetaOptionalFields, TieredAccountMeta},
-            owners::OwnersBlockFormat,
+            owners::{OwnersBlockFormat, OwnersTable},
         },
         assert_matches::assert_matches,
         memoffset::offset_of,
@@ -823,9 +823,13 @@ pub mod tests {
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
 
+            let mut owners_table = OwnersTable::new();
+            addresses.iter().for_each(|owner_address| {
+                owners_table.check_and_add(owner_address);
+            });
             footer
                 .owners_block_format
-                .write_owners_block(&file, &addresses)
+                .write_owners_block(&file, owners_table.owners())
                 .unwrap();
 
             // while the test only focuses on account metas, writing a footer
@@ -893,9 +897,13 @@ pub mod tests {
             // the owners_block_offset set to the end of the accounts blocks.
             footer.owners_block_offset = footer.index_block_offset;
 
+            let mut owners_table = OwnersTable::new();
+            owner_addresses.iter().for_each(|owner_address| {
+                owners_table.check_and_add(owner_address);
+            });
             footer
                 .owners_block_format
-                .write_owners_block(&file, &owner_addresses)
+                .write_owners_block(&file, owners_table.owners())
                 .unwrap();
 
             // while the test only focuses on account metas, writing a footer
@@ -1029,9 +1037,13 @@ pub mod tests {
 
             // write owners block
             footer.owners_block_offset = current_offset as u64;
+            let mut owners_table = OwnersTable::new();
+            owners.iter().for_each(|owner_address| {
+                owners_table.check_and_add(owner_address);
+            });
             footer
                 .owners_block_format
-                .write_owners_block(&file, &owners)
+                .write_owners_block(&file, owners_table.owners())
                 .unwrap();
 
             footer.write_footer_block(&file).unwrap();

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -823,7 +823,7 @@ pub mod tests {
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
 
-            let mut owners_table = OwnersTable::new();
+            let mut owners_table = OwnersTable::default();
             addresses.iter().for_each(|owner_address| {
                 owners_table.insert(owner_address);
             });
@@ -897,7 +897,7 @@ pub mod tests {
             // the owners_block_offset set to the end of the accounts blocks.
             footer.owners_block_offset = footer.index_block_offset;
 
-            let mut owners_table = OwnersTable::new();
+            let mut owners_table = OwnersTable::default();
             owner_addresses.iter().for_each(|owner_address| {
                 owners_table.insert(owner_address);
             });
@@ -1037,7 +1037,7 @@ pub mod tests {
 
             // write owners block
             footer.owners_block_offset = current_offset as u64;
-            let mut owners_table = OwnersTable::new();
+            let mut owners_table = OwnersTable::default();
             owners.iter().for_each(|owner_address| {
                 owners_table.insert(owner_address);
             });

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -829,7 +829,7 @@ pub mod tests {
             });
             footer
                 .owners_block_format
-                .write_owners_block(&file, owners_table.owners())
+                .write_owners_block(&file, owners_table.owners().into_iter())
                 .unwrap();
 
             // while the test only focuses on account metas, writing a footer

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -81,14 +81,14 @@ impl OwnersBlockFormat {
 /// The in-memory representation of owners block for write.
 /// It manages a set of unique addresses of account owners.
 #[derive(Debug)]
-pub(crate) struct OwnersTable<'owner> {
-    owners_set: IndexSet<&'owner Pubkey>,
+pub(crate) struct OwnersTable<'a> {
+    owners_set: IndexSet<&'a Pubkey>,
 }
 
 /// OwnersBlock is persisted as a consecutive bytes of pubkeys without any
 /// meta-data.  For each account meta, it has a owner_offset field to
 /// access its owner's address in the OwnersBlock.
-impl<'owner> OwnersTable<'owner> {
+impl<'a> OwnersTable<'a> {
     pub(crate) fn new() -> Self {
         Self {
             owners_set: IndexSet::new(),
@@ -98,7 +98,7 @@ impl<'owner> OwnersTable<'owner> {
     /// Add the specified pubkey as the owner into the OwnersWriterTable
     /// if the specified pubkey has not existed in the OwnersWriterTable
     /// yet.  In any case, the function returns its OwnerOffset.
-    pub(crate) fn insert(&mut self, pubkey: &'owner Pubkey) -> OwnerOffset {
+    pub(crate) fn insert(&mut self, pubkey: &'a Pubkey) -> OwnerOffset {
         let (offset, _existed) = self.owners_set.insert_full(pubkey);
 
         OwnerOffset(offset as u32)

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -41,7 +41,7 @@ pub enum OwnersBlockFormat {
 
 impl OwnersBlockFormat {
     /// Persists the provided owners' addresses into the specified file.
-    pub(crate) fn write_owners_block<'a>(
+    pub fn write_owners_block<'a>(
         &self,
         file: &TieredStorageFile,
         owners_table: &OwnersTable,
@@ -81,7 +81,7 @@ impl OwnersBlockFormat {
 /// The in-memory representation of owners block for write.
 /// It manages a set of unique addresses of account owners.
 #[derive(Debug)]
-pub(crate) struct OwnersTable<'a> {
+pub struct OwnersTable<'a> {
     owners_set: IndexSet<&'a Pubkey>,
 }
 
@@ -89,7 +89,7 @@ pub(crate) struct OwnersTable<'a> {
 /// meta-data.  For each account meta, it has a owner_offset field to
 /// access its owner's address in the OwnersBlock.
 impl<'a> OwnersTable<'a> {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             owners_set: IndexSet::new(),
         }
@@ -98,7 +98,7 @@ impl<'a> OwnersTable<'a> {
     /// Add the specified pubkey as the owner into the OwnersWriterTable
     /// if the specified pubkey has not existed in the OwnersWriterTable
     /// yet.  In any case, the function returns its OwnerOffset.
-    pub(crate) fn insert(&mut self, pubkey: &'a Pubkey) -> OwnerOffset {
+    pub fn insert(&mut self, pubkey: &'a Pubkey) -> OwnerOffset {
         let (offset, _existed) = self.owners_set.insert_full(pubkey);
 
         OwnerOffset(offset as u32)

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -41,7 +41,7 @@ pub enum OwnersBlockFormat {
 
 impl OwnersBlockFormat {
     /// Persists the provided owners' addresses into the specified file.
-    pub fn write_owners_block<'a>(
+    pub fn write_owners_block(
         &self,
         file: &TieredStorageFile,
         owners_table: &OwnersTable,
@@ -80,7 +80,7 @@ impl OwnersBlockFormat {
 
 /// The in-memory representation of owners block for write.
 /// It manages a set of unique addresses of account owners.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OwnersTable<'a> {
     owners_set: IndexSet<&'a Pubkey>,
 }
@@ -89,12 +89,6 @@ pub struct OwnersTable<'a> {
 /// meta-data.  For each account meta, it has a owner_offset field to
 /// access its owner's address in the OwnersBlock.
 impl<'a> OwnersTable<'a> {
-    pub fn new() -> Self {
-        Self {
-            owners_set: IndexSet::new(),
-        }
-    }
-
     /// Add the specified pubkey as the owner into the OwnersWriterTable
     /// if the specified pubkey has not existed in the OwnersWriterTable
     /// yet.  In any case, the function returns its OwnerOffset.
@@ -133,7 +127,7 @@ mod tests {
         {
             let file = TieredStorageFile::new_writable(&path).unwrap();
 
-            let mut owners_table = OwnersTable::new();
+            let mut owners_table = OwnersTable::default();
             addresses.iter().for_each(|owner_address| {
                 owners_table.insert(owner_address);
             });
@@ -163,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_owners_table() {
-        let mut owners_table = OwnersTable::new();
+        let mut owners_table = OwnersTable::default();
         const NUM_OWNERS: usize = 99;
 
         let addresses: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)

--- a/accounts-db/src/tiered_storage/owners.rs
+++ b/accounts-db/src/tiered_storage/owners.rs
@@ -49,7 +49,7 @@ impl OwnersBlockFormat {
         match self {
             Self::AddressesOnly => {
                 let mut bytes_written = 0;
-                for address in owners_table.owners_set.iter() {
+                for address in &owners_table.owners_set {
                     bytes_written += file.write_pod(*address)?;
                 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4681,7 +4681,6 @@ dependencies = [
  "fnv",
  "im",
  "index_list",
- "indexmap 2.1.0",
  "itertools",
  "lazy_static",
  "log",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "fnv",
  "im",
  "index_list",
+ "indexmap 2.1.0",
  "itertools",
  "lazy_static",
  "log",

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -80,7 +80,6 @@ walkdir = "2"
 bincode = { workspace = true }
 byteorder = { workspace = true }
 elf = { workspace = true }
-indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 miow = { workspace = true }

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -80,6 +80,7 @@ walkdir = "2"
 bincode = { workspace = true }
 byteorder = { workspace = true }
 elf = { workspace = true }
+indexmap = { workspace = true }
 itertools = { workspace = true }
 log = { workspace = true }
 miow = { workspace = true }


### PR DESCRIPTION
#### Problem
To write the owners-block, it requires an in-memory struct that maintains
a set of unique owner addresses while providing a look-up function to
obtain the OwnerOffset with the specified owner address. 

#### Summary of Changes
This PR adds OwnersTable, the in-memory struct that maintains
a set of unique owner addresses while providing a look-up function to
obtain the OwnerOffset with the specified owner address.

#### Test Plan
A new unit-test is added.
