### PR TITLE
Replaces fs-err in tiered storage

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -26,7 +26,7 @@ use {
     solana_sdk::account::ReadableAccount,
     std::{
         borrow::Borrow,
-        fs::OpenOptions,
+        fs::{self, OpenOptions},
         path::{Path, PathBuf},
         sync::OnceLock,
     },
@@ -54,8 +54,11 @@ pub struct TieredStorage {
 
 impl Drop for TieredStorage {
     fn drop(&mut self) {
-        if let Err(err) = fs_err::remove_file(&self.path) {
-            panic!("TieredStorage failed to remove backing storage file: {err}");
+        if let Err(err) = fs::remove_file(&self.path) {
+            panic!(
+                "TieredStorage failed to remove backing storage file '{}': {err}",
+                self.path.display(),
+            );
         }
     }
 }


### PR DESCRIPTION
#### Problem

We're trying to remove the `fs-err` crate. For more information, please refer to https://github.com/solana-labs/solana/pull/34838


#### Summary of Changes

Replace `fs_err` with `std::fs`