### PR TITLE
Define epoch-rewards partition data program id

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -140,7 +140,7 @@ use {
         },
         epoch_info::EpochInfo,
         epoch_rewards_partition_data::{
-            get_epoch_rewards_partition_data_address, EpochRewardsPartitionDataVersion, HasherKind,
+            get_epoch_rewards_partition_data_address, EpochRewardsPartitionDataVersion,
             PartitionData,
         },
         epoch_schedule::EpochSchedule,
@@ -3603,7 +3603,6 @@ impl Bank {
         let epoch_rewards_partition_data = EpochRewardsPartitionDataVersion::V0(PartitionData {
             num_partitions,
             parent_blockhash,
-            hasher_kind: HasherKind::Sip13,
         });
         let address = get_epoch_rewards_partition_data_address(self.epoch());
 

--- a/sdk/program/src/epoch_rewards_partition_data.rs
+++ b/sdk/program/src/epoch_rewards_partition_data.rs
@@ -32,7 +32,7 @@ pub struct PartitionData {
 
 pub fn get_epoch_rewards_partition_data_address(epoch: u64) -> Pubkey {
     let (address, _bump_seed) = Pubkey::find_program_address(
-        &[b"EpochRewardsPartitionData", &epoch.to_le_bytes()],
+        &[b"EpochRewards", b"PartitionData", &epoch.to_le_bytes()],
         &crate::sysvar::id(),
     );
     address

--- a/sdk/program/src/epoch_rewards_partition_data.rs
+++ b/sdk/program/src/epoch_rewards_partition_data.rs
@@ -8,6 +8,14 @@ pub enum EpochRewardsPartitionDataVersion {
     V0(PartitionData),
 }
 
+impl EpochRewardsPartitionDataVersion {
+    pub fn get_hasher_kind(&self) -> HasherKind {
+        match self {
+            EpochRewardsPartitionDataVersion::V0(_) => HasherKind::Sip13,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum HasherKind {
     Sip13,
@@ -20,8 +28,6 @@ pub struct PartitionData {
     pub num_partitions: usize,
     /// Blockhash of the last block of the previous epoch, used to create EpochRewardsHasher
     pub parent_blockhash: Hash,
-    /// Kind of hasher used to generate partitions
-    pub hasher_kind: HasherKind,
 }
 
 pub fn get_epoch_rewards_partition_data_address(epoch: u64) -> Pubkey {

--- a/sdk/program/src/epoch_rewards_partition_data.rs
+++ b/sdk/program/src/epoch_rewards_partition_data.rs
@@ -28,7 +28,7 @@ pub struct PartitionData {
 pub fn get_epoch_rewards_partition_data_address(epoch: u64) -> Pubkey {
     let (address, _bump_seed) = Pubkey::find_program_address(
         &[b"EpochRewardsPartitionData", &epoch.to_le_bytes()],
-        &crate::stake::program::id(),
+        &crate::sysvar::id(),
     );
     address
 }

--- a/sdk/program/src/epoch_rewards_partition_data.rs
+++ b/sdk/program/src/epoch_rewards_partition_data.rs
@@ -8,7 +8,6 @@ pub enum EpochRewardsPartitionDataVersion {
     V0(PartitionData),
 }
 
-#[repr(u8)]
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum HasherKind {
     Sip13,


### PR DESCRIPTION
#### Problem
If the epoch-rewards partition data accounts are owned by the Stake program, parsers try to deserialize them as StakeState variants. This feels icky.

#### Summary of Changes
Use the sysvar program id to own these PDAs
Also, remove storage of HasherKind to save 4 bytes and provide mapping fn instead.
