### PR TITLE
Remove congestion multiplier from calculate fee

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6661,6 +6661,17 @@ impl Bank {
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* debugging_features */
             ));
+
+        // genesis_config loaded by accounts_db::open_genesis_config() from ledger
+        // has it's lamports_per_signature set to zero; bank sets its value correctly
+        // after the first block with a transaction in it. This is a hack to mimic
+        // the process.
+        let derived_fee_rate_governor =
+            FeeRateGovernor::new_derived(&genesis_config.fee_rate_governor, 0);
+        // new bank's fee_structure.lamports_per_signature should be inline with
+        // what's configured in GenesisConfig
+        self.fee_structure.lamports_per_signature =
+            derived_fee_rate_governor.lamports_per_signature;
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3335,7 +3335,6 @@ fn test_bank_parent_account_spend() {
     let key2 = Keypair::new();
     let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
-    println!("==== amount {}", amount);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -80,17 +80,10 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
+        _lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
-        // Fee based on compute units and signatures
-        let congestion_multiplier = if lamports_per_signature == 0 {
-            0.0 // test only
-        } else {
-            1.0 // multiplier that has no effect
-        };
-
         let signature_fee = message
             .num_signatures()
             .saturating_mul(self.lamports_per_signature);
@@ -122,12 +115,11 @@ impl FeeStructure {
                     .unwrap_or_default()
             });
 
-        ((budget_limits
+        (budget_limits
             .prioritization_fee
             .saturating_add(signature_fee)
             .saturating_add(write_lock_fee)
             .saturating_add(compute_fee) as f64)
-            * congestion_multiplier)
             .round() as u64
     }
 }


### PR DESCRIPTION
#### Problem

`congestion_multiplier` variable in `sdk::fee_structure::calculate_fee(...)` does not have to do with congestion, it actually zeros out transaction fee for tests that don't handle transaction fees - those tests sets fee rate to zero in genesis config.

It is better to sync up fee_structure with fee_rate_governor during bank initialization to support those tests.

#### Summary of Changes
- set fee_structure.lamports_per_signature by fee_rate_governor during bank initialization
- remove `congestion_multiplier` in calculation_fee()

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
