### PR TITLE
Removes fs-err dependency from accounts-db crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,6 @@ dependencies = [
  "ed25519-dalek",
  "flate2",
  "fnv",
- "fs-err",
  "im",
  "index_list",
  "itertools",

--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -21,7 +21,6 @@ crossbeam-channel = { workspace = true }
 dashmap = { workspace = true, features = ["rayon", "raw-api"] }
 flate2 = { workspace = true }
 fnv = { workspace = true }
-fs-err = { workspace = true }
 im = { workspace = true, features = ["rayon", "serde"] }
 index_list = { workspace = true }
 itertools = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4679,7 +4679,6 @@ dependencies = [
  "dashmap",
  "flate2",
  "fnv",
- "fs-err",
  "im",
  "index_list",
  "itertools",


### PR DESCRIPTION
#### Problem

The fs-err dependency is not used by the accounts-db crate.


#### Summary of Changes

Remove it.