### PR TITLE
Moves create_all_accounts_run_and_snapshot_dirs() into accounts-db utils

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -68,7 +68,7 @@ use {
         rent_collector::RentCollector,
         sorted_storages::SortedStorages,
         storable_accounts::StorableAccounts,
-        u64_align,
+        u64_align, utils,
         verify_accounts_hash_in_background::VerifyAccountsHashInBackground,
     },
     blake3::traits::digest::Digest,
@@ -1197,82 +1197,6 @@ impl AccountStorageEntry {
     }
 }
 
-/// To allow generating a bank snapshot directory with full state information, we need to
-/// hardlink account appendvec files from the runtime operation directory to a snapshot
-/// hardlink directory.  This is to create the run/ and snapshot sub directories for an
-/// account_path provided by the user.  These two sub directories are on the same file
-/// system partition to allow hard-linking.
-pub fn create_accounts_run_and_snapshot_dirs(
-    account_dir: impl AsRef<Path>,
-) -> std::io::Result<(PathBuf, PathBuf)> {
-    let run_path = account_dir.as_ref().join("run");
-    let snapshot_path = account_dir.as_ref().join("snapshot");
-    if (!run_path.is_dir()) || (!snapshot_path.is_dir()) {
-        // If the "run/" or "snapshot" sub directories do not exist, the directory may be from
-        // an older version for which the appendvec files are at this directory.  Clean up
-        // them first.
-        // This will be done only once when transitioning from an old image without run directory
-        // to this new version using run and snapshot directories.
-        // The run/ content cleanup will be done at a later point.  The snapshot/ content persists
-        // across the process boot, and will be purged by the account_background_service.
-        if fs::remove_dir_all(&account_dir).is_err() {
-            delete_contents_of_path(&account_dir);
-        }
-        fs::create_dir_all(&run_path)?;
-        fs::create_dir_all(&snapshot_path)?;
-    }
-
-    Ok((run_path, snapshot_path))
-}
-
-/// For all account_paths, create the run/ and snapshot/ sub directories.
-/// If an account_path directory does not exist, create it.
-/// It returns (account_run_paths, account_snapshot_paths) or error
-pub fn create_all_accounts_run_and_snapshot_dirs(
-    account_paths: &[PathBuf],
-) -> std::io::Result<(Vec<PathBuf>, Vec<PathBuf>)> {
-    let mut run_dirs = Vec::with_capacity(account_paths.len());
-    let mut snapshot_dirs = Vec::with_capacity(account_paths.len());
-    for account_path in account_paths {
-        // create the run/ and snapshot/ sub directories for each account_path
-        let (run_dir, snapshot_dir) = create_accounts_run_and_snapshot_dirs(account_path)?;
-        run_dirs.push(run_dir);
-        snapshot_dirs.push(snapshot_dir);
-    }
-    Ok((run_dirs, snapshot_dirs))
-}
-
-/// Delete the files and subdirectories in a directory.
-/// This is useful if the process does not have permission
-/// to delete the top level directory it might be able to
-/// delete the contents of that directory.
-pub fn delete_contents_of_path(path: impl AsRef<Path>) {
-    match fs::read_dir(&path) {
-        Err(err) => {
-            warn!(
-                "Failed to delete contents of '{}': could not read dir: {err}",
-                path.as_ref().display(),
-            )
-        }
-        Ok(dir_entries) => {
-            for entry in dir_entries.flatten() {
-                let sub_path = entry.path();
-                let result = if sub_path.is_dir() {
-                    fs::remove_dir_all(&sub_path)
-                } else {
-                    fs::remove_file(&sub_path)
-                };
-                if let Err(err) = result {
-                    warn!(
-                        "Failed to delete contents of '{}': {err}",
-                        sub_path.display(),
-                    );
-                }
-            }
-        }
-    }
-}
-
 pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBuf>)> {
     let temp_dirs: IoResult<Vec<TempDir>> = (0..count).map(|_| TempDir::new()).collect();
     let temp_dirs = temp_dirs?;
@@ -1280,7 +1204,8 @@ pub fn get_temp_accounts_paths(count: u32) -> IoResult<(Vec<TempDir>, Vec<PathBu
     let paths: IoResult<Vec<_>> = temp_dirs
         .iter()
         .map(|temp_dir| {
-            create_accounts_run_and_snapshot_dirs(temp_dir).map(|(run_dir, _snapshot_dir)| run_dir)
+            utils::create_accounts_run_and_snapshot_dirs(temp_dir)
+                .map(|(run_dir, _snapshot_dir)| run_dir)
         })
         .collect();
     let paths = paths?;

--- a/accounts-db/src/lib.rs
+++ b/accounts-db/src/lib.rs
@@ -46,6 +46,7 @@ pub mod storable_accounts;
 pub mod tiered_storage;
 pub mod transaction_error_metrics;
 pub mod transaction_results;
+pub mod utils;
 mod verify_accounts_hash_in_background;
 pub mod waitable_condvar;
 

--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -1,0 +1,119 @@
+use {
+    log::*,
+    std::{
+        fs,
+        path::{Path, PathBuf},
+    },
+};
+
+pub const ACCOUNTS_RUN_DIR: &str = "run";
+pub const ACCOUNTS_SNAPSHOT_DIR: &str = "snapshot";
+
+/// For all account_paths, create the run/ and snapshot/ sub directories.
+/// If an account_path directory does not exist, create it.
+/// It returns (account_run_paths, account_snapshot_paths) or error
+pub fn create_all_accounts_run_and_snapshot_dirs(
+    account_paths: &[PathBuf],
+) -> std::io::Result<(Vec<PathBuf>, Vec<PathBuf>)> {
+    let mut run_dirs = Vec::with_capacity(account_paths.len());
+    let mut snapshot_dirs = Vec::with_capacity(account_paths.len());
+    for account_path in account_paths {
+        // create the run/ and snapshot/ sub directories for each account_path
+        let (run_dir, snapshot_dir) = create_accounts_run_and_snapshot_dirs(account_path)?;
+        run_dirs.push(run_dir);
+        snapshot_dirs.push(snapshot_dir);
+    }
+    Ok((run_dirs, snapshot_dirs))
+}
+
+/// To allow generating a bank snapshot directory with full state information, we need to
+/// hardlink account appendvec files from the runtime operation directory to a snapshot
+/// hardlink directory.  This is to create the run/ and snapshot sub directories for an
+/// account_path provided by the user.  These two sub directories are on the same file
+/// system partition to allow hard-linking.
+pub fn create_accounts_run_and_snapshot_dirs(
+    account_dir: impl AsRef<Path>,
+) -> std::io::Result<(PathBuf, PathBuf)> {
+    let run_path = account_dir.as_ref().join(ACCOUNTS_RUN_DIR);
+    let snapshot_path = account_dir.as_ref().join(ACCOUNTS_SNAPSHOT_DIR);
+    if (!run_path.is_dir()) || (!snapshot_path.is_dir()) {
+        // If the "run/" or "snapshot" sub directories do not exist, the directory may be from
+        // an older version for which the appendvec files are at this directory.  Clean up
+        // them first.
+        // This will be done only once when transitioning from an old image without run directory
+        // to this new version using run and snapshot directories.
+        // The run/ content cleanup will be done at a later point.  The snapshot/ content persists
+        // across the process boot, and will be purged by the account_background_service.
+        if fs::remove_dir_all(&account_dir).is_err() {
+            delete_contents_of_path(&account_dir);
+        }
+        fs::create_dir_all(&run_path)?;
+        fs::create_dir_all(&snapshot_path)?;
+    }
+
+    Ok((run_path, snapshot_path))
+}
+
+/// Delete the files and subdirectories in a directory.
+/// This is useful if the process does not have permission
+/// to delete the top level directory it might be able to
+/// delete the contents of that directory.
+pub fn delete_contents_of_path(path: impl AsRef<Path>) {
+    match fs::read_dir(&path) {
+        Err(err) => {
+            warn!(
+                "Failed to delete contents of '{}': could not read dir: {err}",
+                path.as_ref().display(),
+            )
+        }
+        Ok(dir_entries) => {
+            for entry in dir_entries.flatten() {
+                let sub_path = entry.path();
+                let result = if sub_path.is_dir() {
+                    fs::remove_dir_all(&sub_path)
+                } else {
+                    fs::remove_file(&sub_path)
+                };
+                if let Err(err) = result {
+                    warn!(
+                        "Failed to delete contents of '{}': {err}",
+                        sub_path.display(),
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, tempfile::TempDir};
+
+    #[test]
+    pub fn test_create_all_accounts_run_and_snapshot_dirs() {
+        let (_tmp_dirs, account_paths): (Vec<TempDir>, Vec<PathBuf>) = (0..4)
+            .map(|_| {
+                let tmp_dir = tempfile::TempDir::new().unwrap();
+                let account_path = tmp_dir.path().join("accounts");
+                (tmp_dir, account_path)
+            })
+            .unzip();
+
+        // create the `run/` and `snapshot/` dirs, and ensure they're there
+        let (account_run_paths, account_snapshot_paths) =
+            create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap();
+        account_run_paths.iter().all(|path| path.is_dir());
+        account_snapshot_paths.iter().all(|path| path.is_dir());
+
+        // delete a `run/` and `snapshot/` dir, then re-create it
+        let account_path_first = account_paths.first().unwrap();
+        delete_contents_of_path(account_path_first);
+        assert!(account_path_first.exists());
+        assert!(!account_path_first.join(ACCOUNTS_RUN_DIR).exists());
+        assert!(!account_path_first.join(ACCOUNTS_SNAPSHOT_DIR).exists());
+
+        _ = create_all_accounts_run_and_snapshot_dirs(&account_paths).unwrap();
+        account_run_paths.iter().all(|path| path.is_dir());
+        account_snapshot_paths.iter().all(|path| path.is_dir());
+    }
+}

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -3,7 +3,9 @@ use {
     clap::{value_t, value_t_or_exit, values_t_or_exit, ArgMatches},
     crossbeam_channel::unbounded,
     log::*,
-    solana_accounts_db::hardened_unpack::open_genesis_config,
+    solana_accounts_db::{
+        hardened_unpack::open_genesis_config, utils::create_all_accounts_run_and_snapshot_dirs,
+    },
     solana_core::{
         accounts_hash_verifier::AccountsHashVerifier, validator::BlockVerificationMethod,
     },
@@ -35,8 +37,8 @@ use {
         snapshot_config::SnapshotConfig,
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
-            self, clean_orphaned_account_snapshot_dirs, create_all_accounts_run_and_snapshot_dirs,
-            move_and_async_delete_path_contents, SnapshotError,
+            self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
+            SnapshotError,
         },
     },
     solana_sdk::{
@@ -68,7 +70,7 @@ pub(crate) enum LoadAndProcessLedgerError {
     CleanOrphanedAccountSnapshotDirectories(#[source] SnapshotError),
 
     #[error("failed to create all run and snapshot directories: {0}")]
-    CreateAllAccountsRunAndSnapshotDirectories(#[source] SnapshotError),
+    CreateAllAccountsRunAndSnapshotDirectories(#[source] std::io::Error),
 
     #[error("custom accounts path is not supported with seconday blockstore access")]
     CustomAccountsPathUnsupported(#[source] BlockstoreError),

--- a/local-cluster/src/integration_tests.rs
+++ b/local-cluster/src/integration_tests.rs
@@ -17,7 +17,7 @@ use {
         validator_configs::*,
     },
     log::*,
-    solana_accounts_db::accounts_db::create_accounts_run_and_snapshot_dirs,
+    solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
     solana_core::{
         consensus::{tower_storage::FileTowerStorage, Tower, SWITCH_FORK_THRESHOLD},
         validator::{is_snapshot_config_valid, ValidatorConfig},

--- a/local-cluster/src/local_cluster.rs
+++ b/local-cluster/src/local_cluster.rs
@@ -6,7 +6,7 @@ use {
     },
     itertools::izip,
     log::*,
-    solana_accounts_db::accounts_db::create_accounts_run_and_snapshot_dirs,
+    solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
     solana_client::{connection_cache::ConnectionCache, thin_client::ThinClient},
     solana_core::{
         consensus::tower_storage::FileTowerStorage,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -7,7 +7,7 @@ use {
     rand::seq::IteratorRandom,
     serial_test::serial,
     solana_accounts_db::{
-        accounts_db::create_accounts_run_and_snapshot_dirs, hardened_unpack::open_genesis_config,
+        hardened_unpack::open_genesis_config, utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_client::thin_client::ThinClient,
     solana_core::{

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -19,11 +19,12 @@ use {
     regex::Regex,
     solana_accounts_db::{
         account_storage::AccountStorageMap,
-        accounts_db::{self, AccountStorageEntry, AtomicAppendVecId},
+        accounts_db::{AccountStorageEntry, AtomicAppendVecId},
         accounts_file::AccountsFileError,
         append_vec::AppendVec,
         hardened_unpack::{self, ParallelSelector, UnpackError},
         shared_buffer_reader::{SharedBuffer, SharedBufferReader},
+        utils::delete_contents_of_path,
     },
     solana_measure::{measure, measure::Measure},
     solana_sdk::{clock::Slot, hash::Hash},
@@ -44,7 +45,10 @@ use {
     thiserror::Error,
 };
 #[cfg(feature = "dev-context-only-utils")]
-use {hardened_unpack::UnpackedAppendVecMap, rayon::prelude::*};
+use {
+    hardened_unpack::UnpackedAppendVecMap, rayon::prelude::*,
+    solana_accounts_db::utils::create_accounts_run_and_snapshot_dirs,
+};
 
 mod archive_format;
 pub mod snapshot_storage_rebuilder;
@@ -536,14 +540,6 @@ pub fn create_and_canonicalize_directories(directories: &[PathBuf]) -> Result<Ve
             Ok(path)
         })
         .collect()
-}
-
-/// Delete the files and subdirectories in a directory.
-/// This is useful if the process does not have permission
-/// to delete the top level directory it might be able to
-/// delete the contents of that directory.
-pub(crate) fn delete_contents_of_path(path: impl AsRef<Path>) {
-    accounts_db::delete_contents_of_path(path)
 }
 
 /// Moves and asynchronously deletes the contents of a directory to avoid blocking on it.
@@ -1168,17 +1164,6 @@ fn check_deserialize_file_consumed(
     }
 
     Ok(())
-}
-
-/// For all account_paths, create the run/ and snapshot/ sub directories.
-/// If an account_path directory does not exist, create it.
-/// It returns (account_run_paths, account_snapshot_paths) or error
-pub fn create_all_accounts_run_and_snapshot_dirs(
-    account_paths: &[PathBuf],
-) -> Result<(Vec<PathBuf>, Vec<PathBuf>)> {
-    accounts_db::create_all_accounts_run_and_snapshot_dirs(account_paths).map_err(|err| {
-        SnapshotError::IoWithSource(err, "Unable to create account run and snapshot directories")
-    })
 }
 
 /// Return account path from the appendvec path after checking its format.
@@ -2074,9 +2059,7 @@ pub fn verify_snapshot_archive(
 ) {
     let temp_dir = tempfile::TempDir::new().unwrap();
     let unpack_dir = temp_dir.path();
-    let unpack_account_dir = accounts_db::create_accounts_run_and_snapshot_dirs(unpack_dir)
-        .unwrap()
-        .0;
+    let unpack_account_dir = create_accounts_run_and_snapshot_dirs(unpack_dir).unwrap().0;
     untar_snapshot_in(
         snapshot_archive,
         unpack_dir,
@@ -2254,9 +2237,7 @@ pub fn should_take_incremental_snapshot(
 #[cfg(feature = "dev-context-only-utils")]
 pub fn create_tmp_accounts_dir_for_tests() -> (TempDir, PathBuf) {
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let account_dir = accounts_db::create_accounts_run_and_snapshot_dirs(&tmp_dir)
-        .unwrap()
-        .0;
+    let account_dir = create_accounts_run_and_snapshot_dirs(&tmp_dir).unwrap().0;
     (tmp_dir, account_dir)
 }
 

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -4,9 +4,9 @@ use {
     crossbeam_channel::Receiver,
     log::*,
     solana_accounts_db::{
-        accounts_db::{create_accounts_run_and_snapshot_dirs, AccountsDbConfig},
-        accounts_index::AccountsIndexConfig,
+        accounts_db::AccountsDbConfig, accounts_index::AccountsIndexConfig,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
+        utils::create_accounts_run_and_snapshot_dirs,
     },
     solana_cli_output::CliAccount,
     solana_client::rpc_request::MAX_MULTIPLE_ACCOUNTS,

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -14,6 +14,7 @@ use {
             AccountsIndexConfig, IndexLimitMb,
         },
         partitioned_rewards::TestPartitionedEpochRewards,
+        utils::create_all_accounts_run_and_snapshot_dirs,
     },
     solana_clap_utils::input_parsers::{keypair_of, keypairs_of, pubkey_of, value_of},
     solana_core::{
@@ -48,8 +49,7 @@ use {
         snapshot_bank_utils::DISABLED_SNAPSHOT_ARCHIVE_INTERVAL,
         snapshot_config::{SnapshotConfig, SnapshotUsage},
         snapshot_utils::{
-            self, create_all_accounts_run_and_snapshot_dirs, create_and_canonicalize_directories,
-            ArchiveFormat, SnapshotVersion,
+            self, create_and_canonicalize_directories, ArchiveFormat, SnapshotVersion,
         },
     },
     solana_sdk::{


### PR DESCRIPTION
#### Problem

We're trying to remove the `fs-err` crate. For more information, please refer to https://github.com/solana-labs/solana/pull/34838.

Basically the last hold-outs are in snapshot_utils. And while looking at the code, I saw that `snapshot_utils::create_all_accounts_run_and_snapshot_dirs()` et al just wrap functions inside `accounts_db.rs`, and then change the returned error type. Also strange, the test for this function is in `snapshot_bank_utils.rs`. 

These functions are kind of for snapshots, but more for accounts-db. And there's no need for the wrapper functions. So lets have all the code and tests in a single location.


#### Summary of Changes

* Move the `create_all_accounts_run_and_snapshot_dirs()` et al functions into a new `utils` module within the `accounts-db` crate.
* Move the tests too
* Remove the wrapper functions in `snapshot_utils.rs`
* Update all the callers

Note that basically zero code was changed in the move. I did add constants for the `"run"` and `"snapshot"` string literals though.

This PR is a prereq to further cleanup `snapshot_utils.rs`.