### PR TITLE
Moves create_and_canonicalize_directories() into accounts-db utils

### DIFF
--- a/accounts-db/src/utils.rs
+++ b/accounts-db/src/utils.rs
@@ -85,6 +85,20 @@ pub fn delete_contents_of_path(path: impl AsRef<Path>) {
     }
 }
 
+/// Creates directories if they do not exist, and canonicalizes the paths.
+pub fn create_and_canonicalize_directories(
+    directories: impl IntoIterator<Item = impl AsRef<Path>>,
+) -> std::io::Result<Vec<PathBuf>> {
+    directories
+        .into_iter()
+        .map(|path| {
+            fs::create_dir_all(&path)?;
+            let path = fs::canonicalize(&path)?;
+            Ok(path)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use {super::*, tempfile::TempDir};

--- a/ledger-tool/src/args.rs
+++ b/ledger-tool/src/args.rs
@@ -5,13 +5,14 @@ use {
         accounts_db::{AccountsDb, AccountsDbConfig},
         accounts_index::{AccountsIndexConfig, IndexLimitMb},
         partitioned_rewards::TestPartitionedEpochRewards,
+        utils::create_and_canonicalize_directories,
     },
     solana_clap_utils::input_parsers::pubkeys_of,
     solana_ledger::{
         blockstore_processor::ProcessOptions,
         use_snapshot_archives_at_startup::{self, UseSnapshotArchivesAtStartup},
     },
-    solana_runtime::{runtime_config::RuntimeConfig, snapshot_utils},
+    solana_runtime::runtime_config::RuntimeConfig,
     solana_sdk::clock::Slot,
     std::{
         collections::HashSet,
@@ -116,14 +117,16 @@ pub fn get_accounts_db_config(
         .unwrap_or_else(|| {
             ledger_tool_ledger_path.join(AccountsDb::DEFAULT_ACCOUNTS_HASH_CACHE_DIR)
         });
-    let accounts_hash_cache_path =
-        snapshot_utils::create_and_canonicalize_directories(&[accounts_hash_cache_path])
-            .unwrap_or_else(|err| {
-                eprintln!("Unable to access accounts hash cache path: {err}");
-                std::process::exit(1);
-            })
-            .pop()
-            .unwrap();
+    let accounts_hash_cache_path = create_and_canonicalize_directories([&accounts_hash_cache_path])
+        .unwrap_or_else(|err| {
+            eprintln!(
+                "Unable to access accounts hash cache path '{}': {err}",
+                accounts_hash_cache_path.display(),
+            );
+            std::process::exit(1);
+        })
+        .pop()
+        .unwrap();
 
     AccountsDbConfig {
         index: Some(accounts_index_config),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -530,18 +530,6 @@ pub enum GetSnapshotAccountsHardLinkDirError {
     },
 }
 
-/// Creates directories if they do not exist, and canonicalizes the paths.
-pub fn create_and_canonicalize_directories(directories: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    directories
-        .iter()
-        .map(|path| {
-            fs_err::create_dir_all(path)?;
-            let path = fs_err::canonicalize(path)?;
-            Ok(path)
-        })
-        .collect()
-}
-
 /// Moves and asynchronously deletes the contents of a directory to avoid blocking on it.
 /// The directory is re-created after the move, and should now be empty.
 pub fn move_and_async_delete_path_contents(path: impl AsRef<Path>) {


### PR DESCRIPTION
#### Problem

We're trying to remove the `fs-err` crate. For more information, please refer to https://github.com/solana-labs/solana/pull/34838.

`snapshot_utils::create_and_canonicalize_directories()` still uses fs-err, but doesn't need to. It all doesn't really have anything to do with snapshots.


#### Summary of Changes

* Move create_and_canonicalize_directories() into accounts-db utils
* Replace fs-err with std::fs
* Update callers, and add more info to their error messages