### PR TITLE
Scheduler: throttle queued CUs

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -492,10 +492,12 @@ mod tests {
         crate::banking_stage::consumer::TARGET_NUM_TRANSACTIONS_PER_BATCH,
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
+        solana_cost_model::cost_model::CostModel,
         solana_runtime::transaction_priority_details::TransactionPriorityDetails,
         solana_sdk::{
-            compute_budget::ComputeBudgetInstruction, hash::Hash, message::Message, pubkey::Pubkey,
-            signature::Keypair, signer::Signer, system_instruction, transaction::Transaction,
+            compute_budget::ComputeBudgetInstruction, feature_set::FeatureSet, hash::Hash,
+            message::Message, pubkey::Pubkey, signature::Keypair, signer::Signer,
+            system_instruction, transaction::Transaction,
         },
         std::borrow::Borrow,
     };
@@ -568,6 +570,7 @@ mod tests {
             let id = TransactionId::new(index as u64);
             let transaction =
                 prioritized_tranfers(from_keypair.borrow(), to_pubkeys, lamports, priority);
+            let transaction_cost = CostModel::calculate_cost(&transaction, &FeatureSet::default());
             let transaction_ttl = SanitizedTransactionTTL {
                 transaction,
                 max_age_slot: Slot::MAX,
@@ -579,6 +582,7 @@ mod tests {
                     priority,
                     compute_unit_limit: 1,
                 },
+                transaction_cost,
             );
         }
 

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -191,9 +191,7 @@ impl PrioGraphScheduler {
                 saturating_add_assign!(num_scheduled, 1);
 
                 let sanitized_transaction_ttl = transaction_state.transition_to_pending();
-                let cu_limit = transaction_state
-                    .transaction_priority_details()
-                    .compute_unit_limit;
+                let cost = transaction_state.transaction_cost().sum();
 
                 let SanitizedTransactionTTL {
                     transaction,
@@ -203,7 +201,7 @@ impl PrioGraphScheduler {
                 batches.transactions[thread_id].push(transaction);
                 batches.ids[thread_id].push(id.id);
                 batches.max_age_slots[thread_id].push(max_age_slot);
-                saturating_add_assign!(batches.total_cus[thread_id], cu_limit);
+                saturating_add_assign!(batches.total_cus[thread_id], cost);
 
                 // If target batch size is reached, send only this batch.
                 if batches.ids[thread_id].len() >= TARGET_NUM_TRANSACTIONS_PER_BATCH {

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -18,6 +18,7 @@ use {
     },
     crossbeam_channel::RecvTimeoutError,
     solana_accounts_db::transaction_error_metrics::TransactionErrorMetrics,
+    solana_cost_model::cost_model::CostModel,
     solana_measure::measure_us,
     solana_runtime::{bank::Bank, bank_forks::BankForks},
     solana_sdk::{
@@ -342,6 +343,8 @@ impl SchedulerController {
             {
                 saturating_add_assign!(post_transaction_check_count, 1);
                 let transaction_id = self.transaction_id_generator.next();
+
+                let transaction_cost = CostModel::calculate_cost(&transaction, &bank.feature_set);
                 let transaction_ttl = SanitizedTransactionTTL {
                     transaction,
                     max_age_slot: last_slot_in_epoch,
@@ -351,6 +354,7 @@ impl SchedulerController {
                     transaction_id,
                     transaction_ttl,
                     priority_details,
+                    transaction_cost,
                 ) {
                     saturating_add_assign!(self.count_metrics.num_dropped_on_capacity, 1);
                 }

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -5,6 +5,7 @@ use {
     },
     crate::banking_stage::scheduler_messages::TransactionId,
     min_max_heap::MinMaxHeap,
+    solana_cost_model::transaction_cost::TransactionCost,
     solana_runtime::transaction_priority_details::TransactionPriorityDetails,
     std::collections::HashMap,
 };
@@ -125,12 +126,17 @@ impl TransactionStateContainer {
         transaction_id: TransactionId,
         transaction_ttl: SanitizedTransactionTTL,
         transaction_priority_details: TransactionPriorityDetails,
+        transaction_cost: TransactionCost,
     ) -> bool {
         let priority_id =
             TransactionPriorityId::new(transaction_priority_details.priority, transaction_id);
         self.id_to_transaction_state.insert(
             transaction_id,
-            TransactionState::new(transaction_ttl, transaction_priority_details),
+            TransactionState::new(
+                transaction_ttl,
+                transaction_priority_details,
+                transaction_cost,
+            ),
         );
         self.push_id_into_queue(priority_id)
     }
@@ -176,8 +182,10 @@ impl TransactionStateContainer {
 mod tests {
     use {
         super::*,
+        solana_cost_model::cost_model::CostModel,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
+            feature_set::FeatureSet,
             hash::Hash,
             message::Message,
             signature::Keypair,
@@ -188,7 +196,13 @@ mod tests {
         },
     };
 
-    fn test_transaction(priority: u64) -> (SanitizedTransactionTTL, TransactionPriorityDetails) {
+    fn test_transaction(
+        priority: u64,
+    ) -> (
+        SanitizedTransactionTTL,
+        TransactionPriorityDetails,
+        TransactionCost,
+    ) {
         let from_keypair = Keypair::new();
         let ixs = vec![
             system_instruction::transfer(
@@ -199,10 +213,14 @@ mod tests {
             ComputeBudgetInstruction::set_compute_unit_price(priority),
         ];
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
-        let tx = Transaction::new(&[&from_keypair], message, Hash::default());
-
+        let tx = SanitizedTransaction::from_transaction_for_tests(Transaction::new(
+            &[&from_keypair],
+            message,
+            Hash::default(),
+        ));
+        let transaction_cost = CostModel::calculate_cost(&tx, &FeatureSet::default());
         let transaction_ttl = SanitizedTransactionTTL {
-            transaction: SanitizedTransaction::from_transaction_for_tests(tx),
+            transaction: tx,
             max_age_slot: Slot::MAX,
         };
         (
@@ -211,17 +229,20 @@ mod tests {
                 priority,
                 compute_unit_limit: 0,
             },
+            transaction_cost,
         )
     }
 
     fn push_to_container(container: &mut TransactionStateContainer, num: usize) {
         for id in 0..num as u64 {
             let priority = id;
-            let (transaction_ttl, transaction_priority_details) = test_transaction(priority);
+            let (transaction_ttl, transaction_priority_details, transaction_cost) =
+                test_transaction(priority);
             container.insert_new_transaction(
                 TransactionId::new(id),
                 transaction_ttl,
                 transaction_priority_details,
+                transaction_cost,
             );
         }
     }


### PR DESCRIPTION
#### Problem
- In some cases, scheduler queues too much work too early.

#### Summary of Changes
- Only continue scheduling up to 12M outstanding CUs per thread.


Blocked by #34881 
Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
