### PR TITLE
BlockProductionMethod::CentralScheduler as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Release channels have their own copy of this changelog:
   * The default for `--use-snapshot-archives-at-startup` is now `when-newest` (#33883)
     * The default for `solana-ledger-tool`, however, remains `always` (#34228)
   * Added `central-scheduler` option for `--block-production-method` (#33890)
+    * `central-scheduler` as default option for `--block-production-method` (#34891)
   * Updated to Borsh v1
   * Added allow_commission_decrease_at_any_time feature which will allow commission on a vote account to be
     decreased even in the second half of epochs when the commission_updates_only_allowed_in_first_half_of_epoch

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -168,8 +168,8 @@ impl BlockVerificationMethod {
 #[derive(Clone, EnumString, EnumVariantNames, Default, IntoStaticStr, Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum BlockProductionMethod {
-    #[default]
     ThreadLocalMultiIterator,
+    #[default]
     CentralScheduler,
 }
 


### PR DESCRIPTION
#### Problem
- New scheduler is on-average performing better than the multi-iterator approach

#### Summary of Changes
- Change default block-production method to central-scheduler
- Can be opted out of via `--block-production-method thread-local-multi-iterator

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
