### PR TITLE
Add feature for tracking dynamic reserved account set

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -31,7 +31,6 @@ use {
     },
     solana_svm::transaction_results::TransactionExecutionResult,
     std::{
-        convert::TryFrom,
         io,
         net::{Ipv4Addr, SocketAddr},
         sync::{atomic::AtomicBool, Arc, RwLock},
@@ -418,7 +417,7 @@ impl Banks for BanksServer {
         commitment: CommitmentLevel,
     ) -> Option<u64> {
         let bank = self.bank(commitment);
-        let sanitized_message = SanitizedMessage::try_from(message).ok()?;
+        let sanitized_message = SanitizedMessage::try_from_legacy_message(message).ok()?;
         bank.get_fee_for_message(&sanitized_message)
     }
 }

--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -178,6 +178,7 @@ fn simulate_transaction(
         MessageHash::Compute,
         Some(false), // is_simple_vote_tx
         bank,
+        &bank.reserved_account_keys,
     ) {
         Err(err) => {
             return BanksTransactionResultWithSimulation {
@@ -332,6 +333,7 @@ impl Banks for BanksServer {
             MessageHash::Compute,
             Some(false), // is_simple_vote_tx
             bank.as_ref(),
+            &bank.reserved_account_keys,
         ) {
             Ok(tx) => tx,
             Err(err) => return Some(Err(err)),
@@ -417,7 +419,8 @@ impl Banks for BanksServer {
         commitment: CommitmentLevel,
     ) -> Option<u64> {
         let bank = self.bank(commitment);
-        let sanitized_message = SanitizedMessage::try_from_legacy_message(message).ok()?;
+        let sanitized_message =
+            SanitizedMessage::try_from_legacy_message(message, &bank.reserved_account_keys).ok()?;
         bank.get_fee_for_message(&sanitized_message)
     }
 }

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -866,6 +866,7 @@ mod tests {
             nonce_account::verify_nonce_account,
             poh_config::PohConfig,
             pubkey::Pubkey,
+            reserved_account_keys::ReservedAccountKeys,
             signature::Keypair,
             signer::Signer,
             system_instruction, system_program, system_transaction,
@@ -2032,6 +2033,7 @@ mod tests {
             MessageHash::Compute,
             Some(false),
             bank.as_ref(),
+            &ReservedAccountKeys::empty(),
         )
         .unwrap();
 

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -5,6 +5,7 @@ use {
         feature_set,
         hash::Hash,
         message::Message,
+        pubkey::Pubkey,
         sanitize::SanitizeError,
         short_vec::decode_shortu16_len,
         signature::Signature,
@@ -13,7 +14,7 @@ use {
             VersionedTransaction,
         },
     },
-    std::{cmp::Ordering, mem::size_of, sync::Arc},
+    std::{cmp::Ordering, collections::HashSet, mem::size_of, sync::Arc},
     thiserror::Error,
 };
 
@@ -105,6 +106,7 @@ impl ImmutableDeserializedPacket {
         feature_set: &Arc<feature_set::FeatureSet>,
         votes_only: bool,
         address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Option<SanitizedTransaction> {
         if votes_only && !self.is_simple_vote() {
             return None;
@@ -114,6 +116,7 @@ impl ImmutableDeserializedPacket {
             *self.message_hash(),
             self.is_simple_vote(),
             address_loader,
+            reserved_account_keys,
         )
         .ok()?;
         tx.verify_precompiles(feature_set).ok()?;

--- a/core/src/banking_stage/latest_unprocessed_votes.rs
+++ b/core/src/banking_stage/latest_unprocessed_votes.rs
@@ -283,6 +283,7 @@ impl LatestUnprocessedVotes {
                                 &bank.feature_set,
                                 bank.vote_only_bank(),
                                 bank.as_ref(),
+                                &bank.reserved_account_keys,
                             )
                         {
                             if forward_packet_batches_by_accounts.try_add_packet(

--- a/core/src/banking_stage/read_write_account_set.rs
+++ b/core/src/banking_stage/read_write_account_set.rs
@@ -139,6 +139,7 @@ mod tests {
             MessageHash::Compute,
             Some(false),
             bank,
+            &bank.reserved_account_keys,
         )
         .unwrap()
     }

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -375,7 +375,12 @@ impl SchedulerController {
             let (transactions, fee_budget_limits_vec): (Vec<_>, Vec<_>) = chunk
                 .iter()
                 .filter_map(|packet| {
-                    packet.build_sanitized_transaction(feature_set, vote_only, bank.as_ref())
+                    packet.build_sanitized_transaction(
+                        feature_set,
+                        vote_only,
+                        bank.as_ref(),
+                        &bank.reserved_account_keys,
+                    )
                 })
                 .inspect(|_| saturating_add_assign!(post_sanitization_count, 1))
                 .filter(|tx| {

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -310,6 +310,7 @@ mod tests {
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction,
             message::Message,
+            reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signer},
             system_instruction, system_transaction,
             transaction::{SimpleAddressLoader, Transaction},
@@ -490,6 +491,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(2, txs.count());
@@ -500,6 +502,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(0, txs.count());
@@ -519,6 +522,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(3, txs.count());
@@ -529,6 +533,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(2, txs.count());
@@ -548,6 +553,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(3, txs.count());
@@ -558,6 +564,7 @@ mod tests {
                     &Arc::new(FeatureSet::default()),
                     votes_only,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             });
             assert_eq!(3, txs.count());

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -153,9 +153,13 @@ fn consume_scan_should_process_packet(
     }
 
     // Try to sanitize the packet
-    let (maybe_sanitized_transaction, sanitization_time_us) = measure_us!(
-        packet.build_sanitized_transaction(&bank.feature_set, bank.vote_only_bank(), bank)
-    );
+    let (maybe_sanitized_transaction, sanitization_time_us) = measure_us!(packet
+        .build_sanitized_transaction(
+            &bank.feature_set,
+            bank.vote_only_bank(),
+            bank,
+            &bank.reserved_account_keys,
+        ));
 
     payload
         .slot_metrics_tracker
@@ -770,7 +774,12 @@ impl ThreadLocalUnprocessedPackets {
                 .enumerate()
                 .filter_map(|(packet_index, deserialized_packet)| {
                     deserialized_packet
-                        .build_sanitized_transaction(&bank.feature_set, bank.vote_only_bank(), bank)
+                        .build_sanitized_transaction(
+                            &bank.feature_set,
+                            bank.vote_only_bank(),
+                            bank,
+                            &bank.reserved_account_keys,
+                        )
                         .map(|transaction| (transaction, packet_index))
                 })
                 .unzip();

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -270,6 +270,7 @@ mod tests {
         crate::transaction_cost::*,
         solana_sdk::{
             hash::Hash,
+            reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signer},
             system_transaction,
             transaction::{
@@ -332,6 +333,7 @@ mod tests {
             MessageHash::Compute,
             Some(true),
             SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty(),
         )
         .unwrap();
 

--- a/cost-model/src/transaction_cost.rs
+++ b/cost-model/src/transaction_cost.rs
@@ -172,6 +172,7 @@ mod tests {
             feature_set::FeatureSet,
             hash::Hash,
             message::SimpleAddressLoader,
+            reserved_account_keys::ReservedAccountKeys,
             signer::keypair::Keypair,
             transaction::{MessageHash, SanitizedTransaction, VersionedTransaction},
         },
@@ -200,6 +201,7 @@ mod tests {
             MessageHash::Compute,
             Some(true),
             SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty(),
         )
         .unwrap();
 
@@ -209,6 +211,7 @@ mod tests {
             MessageHash::Compute,
             Some(false),
             SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty(),
         )
         .unwrap();
 

--- a/entry/benches/entry_sigverify.rs
+++ b/entry/benches/entry_sigverify.rs
@@ -5,6 +5,7 @@ use {
     solana_perf::test_tx::test_tx,
     solana_sdk::{
         hash::Hash,
+        reserved_account_keys::ReservedAccountKeys,
         transaction::{
             Result, SanitizedTransaction, SimpleAddressLoader, TransactionVerificationMode,
             VersionedTransaction,
@@ -40,6 +41,7 @@ fn bench_gpusigverify(bencher: &mut Bencher) {
                     message_hash,
                     None,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             }?;
 
@@ -81,6 +83,7 @@ fn bench_cpusigverify(bencher: &mut Bencher) {
                     message_hash,
                     None,
                     SimpleAddressLoader::Disabled,
+                    &ReservedAccountKeys::empty(),
                 )
             }?;
 

--- a/entry/src/entry.rs
+++ b/entry/src/entry.rs
@@ -946,6 +946,7 @@ mod tests {
         solana_sdk::{
             hash::{hash, Hash},
             pubkey::Pubkey,
+            reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signer},
             system_transaction,
             transaction::{
@@ -1039,6 +1040,7 @@ mod tests {
                         message_hash,
                         None,
                         SimpleAddressLoader::Disabled,
+                        &ReservedAccountKeys::empty(),
                     )
                 }?;
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2626,7 +2626,7 @@ fn main() {
                         for (pubkey, warped_account) in all_accounts {
                             // Don't output sysvars; it's always updated but not related to
                             // inflation.
-                            if solana_sdk::sysvar::is_sysvar_id(&pubkey) {
+                            if solana_sdk::sysvar::check_id(warped_account.owner()) {
                                 continue;
                             }
 

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -643,9 +643,9 @@ struct AccountsScanner {
 
 impl AccountsScanner {
     /// Returns true if this account should be included in the output
-    fn should_process_account(&self, account: &AccountSharedData, pubkey: &Pubkey) -> bool {
+    fn should_process_account(&self, account: &AccountSharedData, _pubkey: &Pubkey) -> bool {
         solana_accounts_db::accounts::Accounts::is_loadable(account.lamports())
-            && (self.config.include_sysvars || !solana_sdk::sysvar::is_sysvar_id(pubkey))
+            && (self.config.include_sysvars || !solana_sdk::sysvar::check_id(account.owner()))
     }
 
     fn maybe_output_account<S>(

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -643,7 +643,7 @@ struct AccountsScanner {
 
 impl AccountsScanner {
     /// Returns true if this account should be included in the output
-    fn should_process_account(&self, account: &AccountSharedData, _pubkey: &Pubkey) -> bool {
+    fn should_process_account(&self, account: &AccountSharedData) -> bool {
         solana_accounts_db::accounts::Accounts::is_loadable(account.lamports())
             && (self.config.include_sysvars || !solana_sdk::sysvar::check_id(account.owner()))
     }
@@ -688,8 +688,8 @@ impl AccountsScanner {
         };
 
         let scan_func = |account_tuple: Option<(&Pubkey, AccountSharedData, Slot)>| {
-            if let Some((pubkey, account, slot)) = account_tuple
-                .filter(|(pubkey, account, _)| self.should_process_account(account, pubkey))
+            if let Some((pubkey, account, slot)) =
+                account_tuple.filter(|(_, account, _)| self.should_process_account(account))
             {
                 total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
                 self.maybe_output_account(
@@ -710,7 +710,7 @@ impl AccountsScanner {
                 if let Some((account, slot)) = self
                     .bank
                     .get_account_modified_slot_with_fixed_root(pubkey)
-                    .filter(|(account, _)| self.should_process_account(account, pubkey))
+                    .filter(|(account, _)| self.should_process_account(account))
                 {
                     total_accounts_stats.accumulate_account(pubkey, &account, rent_collector);
                     self.maybe_output_account(
@@ -727,7 +727,7 @@ impl AccountsScanner {
                 .get_program_accounts(program_pubkey, &ScanConfig::default())
                 .unwrap()
                 .iter()
-                .filter(|(pubkey, account)| self.should_process_account(account, pubkey))
+                .filter(|(_, account)| self.should_process_account(account))
                 .for_each(|(pubkey, account)| {
                     total_accounts_stats.accumulate_account(pubkey, account, rent_collector);
                     self.maybe_output_account(

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -187,7 +187,6 @@ mod tests {
             secp256k1_instruction::new_secp256k1_instruction,
             secp256k1_program, system_program,
         },
-        std::convert::TryFrom,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -200,7 +199,7 @@ mod tests {
     }
 
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message).unwrap()
     }
 
     #[test]

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -184,6 +184,7 @@ mod tests {
             native_loader::{self, create_loadable_account_for_test},
             pubkey::Pubkey,
             rent::Rent,
+            reserved_account_keys::ReservedAccountKeys,
             secp256k1_instruction::new_secp256k1_instruction,
             secp256k1_program, system_program,
         },
@@ -199,7 +200,7 @@ mod tests {
     }
 
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message, &ReservedAccountKeys::empty()).unwrap()
     }
 
     #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -200,7 +200,7 @@ fn execute_transactions(
                     }
                     .expect("lamports_per_signature must be available");
                     let fee = bank.get_fee_for_message_with_lamports_per_signature(
-                        &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
+                        &SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap(),
                         lamports_per_signature,
                     );
 
@@ -3705,7 +3705,7 @@ fn test_program_fees() {
         Some(&mint_keypair.pubkey()),
     );
 
-    let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
+    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
     let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
@@ -3729,7 +3729,7 @@ fn test_program_fees() {
         ],
         Some(&mint_keypair.pubkey()),
     );
-    let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
+    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
     let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -80,6 +80,7 @@ use {
         message::Message,
         pubkey::Pubkey,
         rent::Rent,
+        reserved_account_keys::ReservedAccountKeys,
         signature::{Keypair, Signer},
         system_program,
         transaction::{SanitizedTransaction, Transaction, TransactionError},
@@ -200,7 +201,11 @@ fn execute_transactions(
                     }
                     .expect("lamports_per_signature must be available");
                     let fee = bank.get_fee_for_message_with_lamports_per_signature(
-                        &SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap(),
+                        &SanitizedMessage::try_from_legacy_message(
+                            tx.message().clone(),
+                            &ReservedAccountKeys::empty(),
+                        )
+                        .unwrap(),
                         lamports_per_signature,
                     );
 
@@ -3705,7 +3710,9 @@ fn test_program_fees() {
         Some(&mint_keypair.pubkey()),
     );
 
-    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
+    let sanitized_message =
+        SanitizedMessage::try_from_legacy_message(message.clone(), &ReservedAccountKeys::empty())
+            .unwrap();
     let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
@@ -3729,7 +3736,9 @@ fn test_program_fees() {
         ],
         Some(&mint_keypair.pubkey()),
     );
-    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
+    let sanitized_message =
+        SanitizedMessage::try_from_legacy_message(message.clone(), &ReservedAccountKeys::empty())
+            .unwrap();
     let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,

--- a/rpc-client/src/nonblocking/rpc_client.rs
+++ b/rpc-client/src/nonblocking/rpc_client.rs
@@ -675,7 +675,7 @@ impl RpcClient {
         'sending: for _ in 0..SEND_RETRIES {
             let signature = self.send_transaction(transaction).await?;
 
-            let recent_blockhash = if transaction.uses_durable_nonce() {
+            let recent_blockhash = if transaction.maybe_uses_durable_nonce() {
                 let (recent_blockhash, ..) = self
                     .get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                     .await?;
@@ -753,7 +753,7 @@ impl RpcClient {
         commitment: CommitmentConfig,
         config: RpcSendTransactionConfig,
     ) -> ClientResult<Signature> {
-        let recent_blockhash = if transaction.uses_durable_nonce() {
+        let recent_blockhash = if transaction.maybe_uses_durable_nonce() {
             self.get_latest_blockhash_with_commitment(CommitmentConfig::processed())
                 .await?
                 .0

--- a/rpc-client/src/rpc_client.rs
+++ b/rpc-client/src/rpc_client.rs
@@ -45,7 +45,7 @@ use {
         message::{v0, Message as LegacyMessage},
         pubkey::Pubkey,
         signature::Signature,
-        transaction::{self, uses_durable_nonce, Transaction, VersionedTransaction},
+        transaction::{self, maybe_uses_durable_nonce, Transaction, VersionedTransaction},
     },
     solana_transaction_status::{
         EncodedConfirmedBlock, EncodedConfirmedTransactionWithStatusMeta, TransactionStatus,
@@ -80,7 +80,7 @@ impl SerializableMessage for v0::Message {}
 pub trait SerializableTransaction: Serialize {
     fn get_signature(&self) -> &Signature;
     fn get_recent_blockhash(&self) -> &Hash;
-    fn uses_durable_nonce(&self) -> bool;
+    fn maybe_uses_durable_nonce(&self) -> bool;
 }
 impl SerializableTransaction for Transaction {
     fn get_signature(&self) -> &Signature {
@@ -89,8 +89,8 @@ impl SerializableTransaction for Transaction {
     fn get_recent_blockhash(&self) -> &Hash {
         &self.message.recent_blockhash
     }
-    fn uses_durable_nonce(&self) -> bool {
-        uses_durable_nonce(self).is_some()
+    fn maybe_uses_durable_nonce(&self) -> bool {
+        maybe_uses_durable_nonce(self).is_some()
     }
 }
 impl SerializableTransaction for VersionedTransaction {
@@ -100,8 +100,8 @@ impl SerializableTransaction for VersionedTransaction {
     fn get_recent_blockhash(&self) -> &Hash {
         self.message.recent_blockhash()
     }
-    fn uses_durable_nonce(&self) -> bool {
-        self.uses_durable_nonce()
+    fn maybe_uses_durable_nonce(&self) -> bool {
+        self.maybe_uses_durable_nonce()
     }
 }
 

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5067,7 +5067,7 @@ pub mod tests {
             let prioritization_fee_cache = &self.meta.prioritization_fee_cache;
             let transactions: Vec<_> = transactions
                 .into_iter()
-                .map(|tx| SanitizedTransaction::try_from_legacy_transaction(tx).unwrap())
+                .map(SanitizedTransaction::from_transaction_for_tests)
                 .collect();
             prioritization_fee_cache.update(&bank, transactions.iter());
         }

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -225,6 +225,7 @@ pub(crate) mod tests {
             nonce_info::{NonceFull, NoncePartial},
             pubkey::Pubkey,
             rent_debits::RentDebits,
+            reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signature, Signer},
             system_transaction,
             transaction::{
@@ -335,6 +336,7 @@ pub(crate) mod tests {
             MessageHash::Compute,
             None,
             SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty(),
         )
         .unwrap();
 
@@ -364,7 +366,10 @@ pub(crate) mod tests {
             durable_nonce_fee: Some(DurableNonceFee::from(
                 &NonceFull::from_partial(
                     &rollback_partial,
-                    &SanitizedMessage::Legacy(LegacyMessage::new(message)),
+                    &SanitizedMessage::Legacy(LegacyMessage::new(
+                        message,
+                        &ReservedAccountKeys::empty(),
+                    )),
                     &[(pubkey, nonce_account)],
                     &rent_debits,
                 )

--- a/runtime-transaction/src/runtime_transaction.rs
+++ b/runtime-transaction/src/runtime_transaction.rs
@@ -17,10 +17,12 @@ use {
     solana_sdk::{
         hash::Hash,
         message::{AddressLoader, SanitizedMessage, SanitizedVersionedMessage},
+        pubkey::Pubkey,
         signature::Signature,
         simple_vote_transaction_checker::is_simple_vote_transaction,
         transaction::{Result, SanitizedVersionedTransaction},
     },
+    std::collections::HashSet,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -101,12 +103,14 @@ impl RuntimeTransaction<SanitizedMessage> {
     pub fn try_from(
         statically_loaded_runtime_tx: RuntimeTransaction<SanitizedVersionedMessage>,
         address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self> {
         let mut tx = Self {
             signatures: statically_loaded_runtime_tx.signatures,
             message: SanitizedMessage::try_new(
                 statically_loaded_runtime_tx.message,
                 address_loader,
+                reserved_account_keys,
             )?,
             meta: statically_loaded_runtime_tx.meta,
         };
@@ -132,6 +136,7 @@ mod tests {
             compute_budget::ComputeBudgetInstruction,
             instruction::Instruction,
             message::Message,
+            reserved_account_keys::ReservedAccountKeys,
             signer::{keypair::Keypair, Signer},
             transaction::{SimpleAddressLoader, Transaction, VersionedTransaction},
         },
@@ -256,6 +261,7 @@ mod tests {
         let dynamically_loaded_transaction = RuntimeTransaction::<SanitizedMessage>::try_from(
             statically_loaded_transaction,
             SimpleAddressLoader::Disabled,
+            &ReservedAccountKeys::empty(),
         );
         let dynamically_loaded_transaction =
             dynamically_loaded_transaction.expect("created from statically loaded tx");

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -36,7 +36,7 @@ fn build_sanitized_transaction(
         Some(signer_account),
     ));
 
-    SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap()
+    SanitizedTransaction::from_transaction_for_tests(transaction)
 }
 
 #[bench]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -4395,7 +4395,7 @@ fn test_bank_get_program_accounts() {
     assert!(
         genesis_accounts
             .iter()
-            .any(|(pubkey, _, _)| solana_sdk::sysvar::is_sysvar_id(pubkey)),
+            .any(|(_, account, _)| solana_sdk::sysvar::check_id(account.owner())),
         "no sysvars found"
     );
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -117,7 +117,7 @@ use {
     },
     std::{
         collections::{HashMap, HashSet},
-        convert::{TryFrom, TryInto},
+        convert::TryInto,
         fs::File,
         io::Read,
         str::FromStr,
@@ -196,7 +196,7 @@ fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
 }
 
 fn new_sanitized_message(message: Message) -> SanitizedMessage {
-    SanitizedMessage::try_from(message).unwrap()
+    SanitizedMessage::try_from_legacy_message(message).unwrap()
 }
 
 #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -195,6 +195,10 @@ fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
     solana_sdk::genesis_config::create_genesis_config(lamports)
 }
 
+fn new_sanitized_message(message: Message) -> SanitizedMessage {
+    SanitizedMessage::try_from(message).unwrap()
+}
+
 #[test]
 fn test_race_register_tick_freeze() {
     solana_logger::setup();
@@ -2666,7 +2670,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let expected_fee_paid = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         genesis_config
             .fee_rate_governor
             .create_fee_calculator()
@@ -2794,7 +2798,7 @@ fn test_bank_blockhash_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let cheap_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         cheap_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2810,7 +2814,7 @@ fn test_bank_blockhash_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let expensive_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         expensive_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2856,7 +2860,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let cheap_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         cheap_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2872,7 +2876,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let expensive_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         expensive_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2979,8 +2983,7 @@ fn test_filter_program_errors_and_collect_compute_unit_fee() {
                 .fee_rate_governor
                 .burn(
                     calculate_test_fee(
-                        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique())))
-                            .unwrap(),
+                        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
                         genesis_config
                             .fee_rate_governor
                             .create_fee_calculator()
@@ -5275,7 +5278,7 @@ fn test_nonce_transaction() {
     recent_message.recent_blockhash = bank.last_blockhash();
     let mut expected_balance = 4_650_000
         - bank
-            .get_fee_for_message(&recent_message.try_into().unwrap())
+            .get_fee_for_message(&new_sanitized_message(recent_message))
             .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_eq!(bank.get_balance(&nonce_pubkey), 250_000);
@@ -5334,7 +5337,7 @@ fn test_nonce_transaction() {
     let mut recent_message = nonce_tx.message.clone();
     recent_message.recent_blockhash = bank.last_blockhash();
     expected_balance -= bank
-        .get_fee_for_message(&SanitizedMessage::try_from(recent_message).unwrap())
+        .get_fee_for_message(&new_sanitized_message(recent_message))
         .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_ne!(
@@ -5402,7 +5405,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     recent_message.recent_blockhash = bank.last_blockhash();
     let mut expected_balance = 4_650_000
         - bank
-            .get_fee_for_message(&recent_message.try_into().unwrap())
+            .get_fee_for_message(&new_sanitized_message(recent_message))
             .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_eq!(bank.get_balance(&nonce_pubkey), 250_000);
@@ -5461,7 +5464,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     let mut recent_message = nonce_tx.message.clone();
     recent_message.recent_blockhash = bank.last_blockhash();
     expected_balance -= bank
-        .get_fee_for_message(&SanitizedMessage::try_from(recent_message).unwrap())
+        .get_fee_for_message(&new_sanitized_message(recent_message))
         .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_ne!(
@@ -5593,7 +5596,7 @@ fn test_nonce_payer() {
         bank.get_balance(&nonce_pubkey),
         nonce_starting_balance
             - bank
-                .get_fee_for_message(&recent_message.try_into().unwrap())
+                .get_fee_for_message(&new_sanitized_message(recent_message))
                 .unwrap()
     );
     assert_ne!(
@@ -5660,7 +5663,7 @@ fn test_nonce_payer_tx_wide_cap() {
         bank.get_balance(&nonce_pubkey),
         nonce_starting_balance
             - bank
-                .get_fee_for_message(&recent_message.try_into().unwrap())
+                .get_fee_for_message(&new_sanitized_message(recent_message))
                 .unwrap()
     );
     assert_ne!(
@@ -10034,8 +10037,7 @@ fn calculate_test_fee(
 #[test]
 fn test_calculate_fee() {
     // Default: no fee.
-    let message =
-        SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(
             &message,
@@ -10066,7 +10068,7 @@ fn test_calculate_fee() {
     let key1 = Pubkey::new_unique();
     let ix0 = system_instruction::transfer(&key0, &key1, 1);
     let ix1 = system_instruction::transfer(&key1, &key0, 1);
-    let message = SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&key0))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&key0)));
     assert_eq!(
         calculate_test_fee(
             &message,
@@ -10091,8 +10093,7 @@ fn test_calculate_fee_compute_units() {
 
     // One signature, no unit request
 
-    let message =
-        SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + lamports_per_signature
@@ -10102,8 +10103,7 @@ fn test_calculate_fee_compute_units() {
 
     let ix0 = system_instruction::transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1);
     let ix1 = system_instruction::transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1);
-    let message =
-        SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + 3 * lamports_per_signature
@@ -10129,15 +10129,14 @@ fn test_calculate_fee_compute_units() {
             PrioritizationFeeType::ComputeUnitPrice(PRIORITIZATION_FEE_RATE),
             requested_compute_units as u64,
         );
-        let message = SanitizedMessage::try_from(Message::new(
+        let message = new_sanitized_message(Message::new(
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(requested_compute_units),
                 ComputeBudgetInstruction::set_compute_unit_price(PRIORITIZATION_FEE_RATE),
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
             ],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        ));
         let fee = calculate_test_fee(&message, 1, &fee_structure);
         assert_eq!(
             fee,
@@ -10161,14 +10160,13 @@ fn test_calculate_prioritization_fee() {
     );
     let prioritization_fee = prioritization_fee_details.get_fee();
 
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             ComputeBudgetInstruction::set_compute_unit_limit(request_units),
             ComputeBudgetInstruction::set_compute_unit_price(request_unit_price),
         ],
         Some(&Pubkey::new_unique()),
-    ))
-    .unwrap();
+    ));
 
     let fee = calculate_test_fee(
         &message,
@@ -10202,24 +10200,22 @@ fn test_calculate_fee_secp256k1() {
         data: vec![1],
     };
 
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             ix0.clone(),
             secp_instruction1.clone(),
             secp_instruction2.clone(),
         ],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
     assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 2);
 
     secp_instruction1.data = vec![0];
     secp_instruction2.data = vec![10];
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[ix0, secp_instruction1, secp_instruction2],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
     assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 11);
 }
 
@@ -10745,7 +10741,7 @@ fn test_invalid_rent_state_changes_fee_payer() {
     .unwrap();
 
     // Dummy message to determine fee amount
-    let dummy_message = SanitizedMessage::try_from(Message::new_with_blockhash(
+    let dummy_message = new_sanitized_message(Message::new_with_blockhash(
         &[system_instruction::transfer(
             &rent_exempt_fee_payer.pubkey(),
             &recipient,
@@ -10753,8 +10749,7 @@ fn test_invalid_rent_state_changes_fee_payer() {
         )],
         Some(&rent_exempt_fee_payer.pubkey()),
         &recent_blockhash,
-    ))
-    .unwrap();
+    ));
     let fee = bank.get_fee_for_message(&dummy_message).unwrap();
 
     // RentPaying fee-payer can remain RentPaying
@@ -11814,7 +11809,7 @@ fn test_calculate_fee_with_congestion_multiplier() {
     let key1 = Pubkey::new_unique();
     let ix0 = system_instruction::transfer(&key0, &key1, 1);
     let ix1 = system_instruction::transfer(&key1, &key0, 1);
-    let message = SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&key0))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&key0)));
 
     // assert when lamports_per_signature is less than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier has no effect on fee.
@@ -11843,7 +11838,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
         lamports_per_signature: signature_fee,
         ..FeeStructure::default()
     };
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             system_instruction::transfer(&key0, &key1, 1),
             ComputeBudgetInstruction::set_compute_unit_limit(request_cu as u32),
@@ -11851,8 +11846,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
             ComputeBudgetInstruction::set_compute_unit_price(lamports_per_cu * 1_000_000),
         ],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
 
     // assert when request_heap_frame is presented in tx, prioritization fee will be counted
     // into transaction fee

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -19,7 +19,6 @@ use {
         transport::{Result, TransportError},
     },
     std::{
-        convert::TryFrom,
         io,
         sync::{Arc, Mutex},
         thread::{sleep, Builder},
@@ -286,7 +285,7 @@ impl SyncClient for BankClient {
     }
 
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
-        SanitizedMessage::try_from(message.clone())
+        SanitizedMessage::try_from_legacy_message(message.clone())
             .ok()
             .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
             .ok_or_else(|| {

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -285,7 +285,7 @@ impl SyncClient for BankClient {
     }
 
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
-        SanitizedMessage::try_from_legacy_message(message.clone())
+        SanitizedMessage::try_from_legacy_message(message.clone(), &self.bank.reserved_account_keys)
             .ok()
             .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
             .ok_or_else(|| {

--- a/runtime/src/compute_budget_details.rs
+++ b/runtime/src/compute_budget_details.rs
@@ -95,8 +95,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {
@@ -133,8 +132,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {
@@ -171,8 +169,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -459,7 +459,7 @@ mod tests {
             Some(signer_account),
         ));
 
-        SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap()
+        SanitizedTransaction::from_transaction_for_tests(transaction)
     }
 
     // update fee cache is asynchronous, this test helper blocks until update is completed.

--- a/runtime/src/snapshot_minimizer.rs
+++ b/runtime/src/snapshot_minimizer.rs
@@ -21,7 +21,7 @@ use {
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::Slot,
         pubkey::Pubkey,
-        sdk_ids,
+        reserved_account_keys::ReservedAccountKeys,
     },
     std::{
         collections::HashSet,
@@ -127,9 +127,11 @@ impl<'a> SnapshotMinimizer<'a> {
 
     /// Used to get sdk accounts in `minimize`
     fn get_sdk_accounts(&self) {
-        sdk_ids::SDK_IDS.iter().for_each(|pubkey| {
-            self.minimized_account_set.insert(*pubkey);
-        });
+        ReservedAccountKeys::active_and_inactive()
+            .iter()
+            .for_each(|pubkey| {
+                self.minimized_account_set.insert(*pubkey);
+            })
     }
 
     /// Used to get rent collection accounts in `minimize`

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -9,7 +9,6 @@ use {
         pubkey::{self, Pubkey},
         sysvar::instructions::{self, construct_instructions_data},
     },
-    std::convert::TryFrom,
     test::Bencher,
 };
 
@@ -30,9 +29,11 @@ fn bench_bincode_instruction_serialize(b: &mut Bencher) {
 #[bench]
 fn bench_construct_instructions_data(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     b.iter(|| {
         let instructions = message.decompile_instructions();
         test::black_box(construct_instructions_data(&instructions));
@@ -51,9 +52,11 @@ fn bench_bincode_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {
         for i in 0..instructions.len() {
@@ -66,9 +69,11 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {
         #[allow(deprecated)]

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -7,6 +7,7 @@ use {
         instruction::{AccountMeta, Instruction},
         message::{Message, SanitizedMessage},
         pubkey::{self, Pubkey},
+        reserved_account_keys::ReservedAccountKeys,
         sysvar::instructions::{self, construct_instructions_data},
     },
     test::Bencher,
@@ -29,10 +30,10 @@ fn bench_bincode_instruction_serialize(b: &mut Bencher) {
 #[bench]
 fn bench_construct_instructions_data(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message = SanitizedMessage::try_from_legacy_message(Message::new(
-        &instructions,
-        Some(&Pubkey::new_unique()),
-    ))
+    let message = SanitizedMessage::try_from_legacy_message(
+        Message::new(&instructions, Some(&Pubkey::new_unique())),
+        &ReservedAccountKeys::empty(),
+    )
     .unwrap();
     b.iter(|| {
         let instructions = message.decompile_instructions();
@@ -52,10 +53,10 @@ fn bench_bincode_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message = SanitizedMessage::try_from_legacy_message(Message::new(
-        &instructions,
-        Some(&Pubkey::new_unique()),
-    ))
+    let message = SanitizedMessage::try_from_legacy_message(
+        Message::new(&instructions, Some(&Pubkey::new_unique())),
+        &ReservedAccountKeys::empty(),
+    )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {
@@ -69,10 +70,10 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message = SanitizedMessage::try_from_legacy_message(Message::new(
-        &instructions,
-        Some(&Pubkey::new_unique()),
-    ))
+    let message = SanitizedMessage::try_from_legacy_message(
+        Message::new(&instructions, Some(&Pubkey::new_unique())),
+        &ReservedAccountKeys::empty(),
+    )
     .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -535,6 +535,7 @@ pub mod system_program;
 pub mod sysvar;
 pub mod vote;
 pub mod wasm;
+pub mod zk_token_proof_program;
 
 #[deprecated(
     since = "1.17.0",

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -58,6 +58,11 @@ lazy_static! {
     };
 }
 
+#[deprecated(
+    since = "1.18.0",
+    note = "please use solana_sdk::reserved_account_keys::ReservedAccountKeys instead"
+)]
+#[allow(deprecated)]
 pub fn is_builtin_key_or_sysvar(key: &Pubkey) -> bool {
     if MAYBE_BUILTIN_KEY_OR_SYSVAR[key.0[0] as usize] {
         return sysvar::is_sysvar_id(key) || BUILTIN_PROGRAMS_KEYS.contains(key);
@@ -568,6 +573,7 @@ impl Message {
     /// instructions in this message. Since the dynamic set of reserved accounts
     /// isn't used here to demote write locks, this shouldn't be used in the
     /// runtime.
+    #[allow(deprecated)]
     pub fn is_maybe_writable(&self, i: usize) -> bool {
         (self.is_writable_index(i))
             && !is_builtin_key_or_sysvar(&self.account_keys[i])

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -548,12 +548,28 @@ impl Message {
         self.is_key_called_as_program(i) && !self.is_upgradeable_loader_present()
     }
 
-    pub fn is_writable(&self, i: usize) -> bool {
-        (i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
+    /// Returns true if the account at the specified index was requested to be
+    /// writable. This method should not be used directly.
+    fn is_writable_index(&self, i: usize) -> bool {
+        i < (self.header.num_required_signatures - self.header.num_readonly_signed_accounts)
             as usize
             || (i >= self.header.num_required_signatures as usize
                 && i < self.account_keys.len()
-                    - self.header.num_readonly_unsigned_accounts as usize))
+                    - self.header.num_readonly_unsigned_accounts as usize)
+    }
+
+    pub fn is_writable(&self, i: usize) -> bool {
+        (self.is_writable_index(i))
+            && !is_builtin_key_or_sysvar(&self.account_keys[i])
+            && !self.demote_program_id(i)
+    }
+
+    /// Returns true if the account at the specified index is writable by the
+    /// instructions in this message. Since the dynamic set of reserved accounts
+    /// isn't used here to demote write locks, this shouldn't be used in the
+    /// runtime.
+    pub fn is_maybe_writable(&self, i: usize) -> bool {
+        (self.is_writable_index(i))
             && !is_builtin_key_or_sysvar(&self.account_keys[i])
             && !self.demote_program_id(i)
     }

--- a/sdk/program/src/message/sanitized.rs
+++ b/sdk/program/src/message/sanitized.rs
@@ -17,7 +17,7 @@ use {
         solana_program::{system_instruction::SystemInstruction, system_program},
         sysvar::instructions::{BorrowedAccountMeta, BorrowedInstruction},
     },
-    std::{borrow::Cow, convert::TryFrom},
+    std::{borrow::Cow, collections::HashSet, convert::TryFrom},
     thiserror::Error,
 };
 
@@ -31,12 +31,12 @@ pub struct LegacyMessage<'a> {
 }
 
 impl<'a> LegacyMessage<'a> {
-    pub fn new(message: legacy::Message) -> Self {
+    pub fn new(message: legacy::Message, reserved_account_keys: &HashSet<Pubkey>) -> Self {
         let is_writable_account_cache = message
             .account_keys
             .iter()
             .enumerate()
-            .map(|(i, _key)| message.is_writable(i))
+            .map(|(i, _key)| message.is_writable(i, reserved_account_keys))
             .collect::<Vec<_>>();
         Self {
             message: Cow::Owned(message),
@@ -105,23 +105,34 @@ impl SanitizedMessage {
     pub fn try_new(
         sanitized_msg: SanitizedVersionedMessage,
         address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self, SanitizeMessageError> {
         Ok(match sanitized_msg.message {
             VersionedMessage::Legacy(message) => {
-                SanitizedMessage::Legacy(LegacyMessage::new(message))
+                SanitizedMessage::Legacy(LegacyMessage::new(message, reserved_account_keys))
             }
             VersionedMessage::V0(message) => {
                 let loaded_addresses =
                     address_loader.load_addresses(&message.address_table_lookups)?;
-                SanitizedMessage::V0(v0::LoadedMessage::new(message, loaded_addresses))
+                SanitizedMessage::V0(v0::LoadedMessage::new(
+                    message,
+                    loaded_addresses,
+                    reserved_account_keys,
+                ))
             }
         })
     }
 
     /// Create a sanitized legacy message
-    pub fn try_from_legacy_message(message: legacy::Message) -> Result<Self, SanitizeMessageError> {
+    pub fn try_from_legacy_message(
+        message: legacy::Message,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> Result<Self, SanitizeMessageError> {
         message.sanitize()?;
-        Ok(Self::Legacy(LegacyMessage::new(message)))
+        Ok(Self::Legacy(LegacyMessage::new(
+            message,
+            reserved_account_keys,
+        )))
     }
 
     /// Return true if this message contains duplicate account keys
@@ -379,7 +390,11 @@ mod tests {
         };
 
         assert_eq!(
-            SanitizedMessage::try_from_legacy_message(legacy_message_with_no_signers).err(),
+            SanitizedMessage::try_from_legacy_message(
+                legacy_message_with_no_signers,
+                &HashSet::default(),
+            )
+            .err(),
             Some(SanitizeMessageError::IndexOutOfBounds),
         );
     }
@@ -403,6 +418,7 @@ mod tests {
                 Hash::default(),
                 instructions,
             ),
+            &HashSet::default(),
         )
         .unwrap();
 
@@ -420,15 +436,18 @@ mod tests {
         let key4 = Pubkey::new_unique();
         let key5 = Pubkey::new_unique();
 
-        let legacy_message = SanitizedMessage::try_from_legacy_message(legacy::Message {
-            header: MessageHeader {
-                num_required_signatures: 2,
-                num_readonly_signed_accounts: 1,
-                num_readonly_unsigned_accounts: 1,
+        let legacy_message = SanitizedMessage::try_from_legacy_message(
+            legacy::Message {
+                header: MessageHeader {
+                    num_required_signatures: 2,
+                    num_readonly_signed_accounts: 1,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                account_keys: vec![key0, key1, key2, key3],
+                ..legacy::Message::default()
             },
-            account_keys: vec![key0, key1, key2, key3],
-            ..legacy::Message::default()
-        })
+            &HashSet::default(),
+        )
         .unwrap();
 
         assert_eq!(legacy_message.num_readonly_accounts(), 2);
@@ -447,6 +466,7 @@ mod tests {
                 writable: vec![key4],
                 readonly: vec![key5],
             },
+            &HashSet::default(),
         ));
 
         assert_eq!(v0_message.num_readonly_accounts(), 3);
@@ -473,6 +493,7 @@ mod tests {
                 Hash::default(),
                 instructions,
             ),
+            &HashSet::default(),
         )
         .unwrap();
 
@@ -504,15 +525,18 @@ mod tests {
         let key4 = Pubkey::new_unique();
         let key5 = Pubkey::new_unique();
 
-        let legacy_message = SanitizedMessage::try_from_legacy_message(legacy::Message {
-            header: MessageHeader {
-                num_required_signatures: 2,
-                num_readonly_signed_accounts: 1,
-                num_readonly_unsigned_accounts: 1,
+        let legacy_message = SanitizedMessage::try_from_legacy_message(
+            legacy::Message {
+                header: MessageHeader {
+                    num_required_signatures: 2,
+                    num_readonly_signed_accounts: 1,
+                    num_readonly_unsigned_accounts: 1,
+                },
+                account_keys: vec![key0, key1, key2, key3],
+                ..legacy::Message::default()
             },
-            account_keys: vec![key0, key1, key2, key3],
-            ..legacy::Message::default()
-        })
+            &HashSet::default(),
+        )
         .unwrap();
         match legacy_message {
             SanitizedMessage::Legacy(message) => {
@@ -544,6 +568,7 @@ mod tests {
                 writable: vec![key4],
                 readonly: vec![key5],
             },
+            &HashSet::default(),
         ));
         match v0_message {
             SanitizedMessage::V0(message) => {

--- a/sdk/program/src/message/versions/mod.rs
+++ b/sdk/program/src/message/versions/mod.rs
@@ -79,7 +79,7 @@ impl VersionedMessage {
     /// used in the runtime.
     pub fn is_maybe_writable(&self, index: usize) -> bool {
         match self {
-            Self::Legacy(message) => message.is_writable(index),
+            Self::Legacy(message) => message.is_maybe_writable(index),
             Self::V0(message) => message.is_maybe_writable(index),
         }
     }

--- a/sdk/program/src/message/versions/v0/loaded.rs
+++ b/sdk/program/src/message/versions/v0/loaded.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         bpf_loader_upgradeable,
-        message::{legacy::is_builtin_key_or_sysvar, v0, AccountKeys},
+        message::{v0, AccountKeys},
         pubkey::Pubkey,
     },
     std::{borrow::Cow, collections::HashSet},
@@ -55,32 +55,40 @@ impl LoadedAddresses {
 }
 
 impl<'a> LoadedMessage<'a> {
-    pub fn new(message: v0::Message, loaded_addresses: LoadedAddresses) -> Self {
+    pub fn new(
+        message: v0::Message,
+        loaded_addresses: LoadedAddresses,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> Self {
         let mut loaded_message = Self {
             message: Cow::Owned(message),
             loaded_addresses: Cow::Owned(loaded_addresses),
             is_writable_account_cache: Vec::default(),
         };
-        loaded_message.set_is_writable_account_cache();
+        loaded_message.set_is_writable_account_cache(reserved_account_keys);
         loaded_message
     }
 
-    pub fn new_borrowed(message: &'a v0::Message, loaded_addresses: &'a LoadedAddresses) -> Self {
+    pub fn new_borrowed(
+        message: &'a v0::Message,
+        loaded_addresses: &'a LoadedAddresses,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> Self {
         let mut loaded_message = Self {
             message: Cow::Borrowed(message),
             loaded_addresses: Cow::Borrowed(loaded_addresses),
             is_writable_account_cache: Vec::default(),
         };
-        loaded_message.set_is_writable_account_cache();
+        loaded_message.set_is_writable_account_cache(reserved_account_keys);
         loaded_message
     }
 
-    fn set_is_writable_account_cache(&mut self) {
+    fn set_is_writable_account_cache(&mut self, reserved_account_keys: &HashSet<Pubkey>) {
         let is_writable_account_cache = self
             .account_keys()
             .iter()
             .enumerate()
-            .map(|(i, _key)| self.is_writable_internal(i))
+            .map(|(i, _key)| self.is_writable_internal(i, reserved_account_keys))
             .collect::<Vec<_>>();
         let _ = std::mem::replace(
             &mut self.is_writable_account_cache,
@@ -127,10 +135,14 @@ impl<'a> LoadedMessage<'a> {
     }
 
     /// Returns true if the account at the specified index was loaded as writable
-    fn is_writable_internal(&self, key_index: usize) -> bool {
+    fn is_writable_internal(
+        &self,
+        key_index: usize,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> bool {
         if self.is_writable_index(key_index) {
             if let Some(key) = self.account_keys().get(key_index) {
-                return !(is_builtin_key_or_sysvar(key) || self.demote_program_id(key_index));
+                return !(reserved_account_keys.contains(key) || self.demote_program_id(key_index));
             }
         }
         false
@@ -201,6 +213,7 @@ mod tests {
                 writable: vec![key4],
                 readonly: vec![key5],
             },
+            &HashSet::default(),
         );
 
         (message, [key0, key1, key2, key3, key4, key5])
@@ -225,6 +238,7 @@ mod tests {
                     writable: keys.split_off(2),
                     readonly: keys,
                 },
+                &HashSet::default(),
             )
         };
 
@@ -257,6 +271,8 @@ mod tests {
     #[test]
     fn test_is_writable() {
         solana_logger::setup();
+
+        let reserved_account_keys = HashSet::from_iter([sysvar::clock::id(), system_program::id()]);
         let create_message_with_keys = |keys: Vec<Pubkey>| {
             LoadedMessage::new(
                 v0::Message {
@@ -272,6 +288,7 @@ mod tests {
                     writable: keys[2..=2].to_vec(),
                     readonly: keys[3..].to_vec(),
                 },
+                &reserved_account_keys,
             )
         };
 
@@ -321,6 +338,7 @@ mod tests {
                 writable: vec![key1, key2],
                 readonly: vec![],
             },
+            &HashSet::default(),
         );
 
         assert!(message.is_writable_index(2));

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -334,9 +334,10 @@ impl Message {
             .any(|&key| key == bpf_loader_upgradeable::id())
     }
 
-    /// Returns true if the account at the specified index was requested as writable.
-    /// Before loading addresses, we can't demote write locks for dynamically loaded
-    /// addresses so this should not be used by the runtime.
+    /// Returns true if the account at the specified index was requested as
+    /// writable. Before loading addresses and without the reserved account keys
+    /// set, we can't demote write locks properly so this should not be used by
+    /// the runtime.
     pub fn is_maybe_writable(&self, key_index: usize) -> bool {
         self.is_writable_index(key_index)
             && !{

--- a/sdk/program/src/message/versions/v0/mod.rs
+++ b/sdk/program/src/message/versions/v0/mod.rs
@@ -9,6 +9,8 @@
 //! [`v0`]: crate::message::v0
 //! [future message format]: https://docs.solanalabs.com/proposals/versioned-transactions
 
+#[allow(deprecated)]
+use crate::message::legacy::is_builtin_key_or_sysvar;
 use crate::{
     address_lookup_table_account::AddressLookupTableAccount,
     bpf_loader_upgradeable,
@@ -16,7 +18,6 @@ use crate::{
     instruction::{CompiledInstruction, Instruction},
     message::{
         compiled_keys::{CompileError, CompiledKeys},
-        legacy::is_builtin_key_or_sysvar,
         AccountKeys, MessageHeader, MESSAGE_VERSION_PREFIX,
     },
     pubkey::Pubkey,
@@ -338,6 +339,7 @@ impl Message {
     /// writable. Before loading addresses and without the reserved account keys
     /// set, we can't demote write locks properly so this should not be used by
     /// the runtime.
+    #[allow(deprecated)]
     pub fn is_maybe_writable(&self, key_index: usize) -> bool {
         self.is_writable_index(key_index)
             && !{

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -302,10 +302,11 @@ mod tests {
             message::{Message as LegacyMessage, SanitizedMessage},
             pubkey::Pubkey,
         },
+        std::collections::HashSet,
     };
 
     fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message, &HashSet::default()).unwrap()
     }
 
     #[test]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -302,11 +302,10 @@ mod tests {
             message::{Message as LegacyMessage, SanitizedMessage},
             pubkey::Pubkey,
         },
-        std::convert::TryFrom,
     };
 
     fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
-        SanitizedMessage::try_from(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message).unwrap()
     }
 
     #[test]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -305,6 +305,10 @@ mod tests {
         std::convert::TryFrom,
     };
 
+    fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
+        SanitizedMessage::try_from(message).unwrap()
+    }
+
     #[test]
     fn test_load_store_instruction() {
         let mut data = [4u8; 10];
@@ -327,11 +331,11 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
+        let message = LegacyMessage::new(
             &[instruction0.clone(), instruction1.clone()],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        );
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -381,11 +385,9 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
-            &[instruction0, instruction1],
-            Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        let message =
+            LegacyMessage::new(&[instruction0, instruction1], Some(&Pubkey::new_unique()));
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -435,15 +437,15 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
+        let message = LegacyMessage::new(
             &[
                 instruction0.clone(),
                 instruction1.clone(),
                 instruction2.clone(),
             ],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        );
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -538,7 +540,7 @@ mod tests {
         ];
 
         let message = LegacyMessage::new(&instructions, Some(&id1));
-        let sanitized_message = SanitizedMessage::try_from(message).unwrap();
+        let sanitized_message = new_sanitized_message(message);
         let serialized = serialize_instructions(&sanitized_message.decompile_instructions());
 
         // assert that deserialize_instruction is compatible with SanitizedMessage::serialize_instructions
@@ -560,9 +562,9 @@ mod tests {
             Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id1, true)]),
         ];
 
-        let message =
-            SanitizedMessage::try_from(LegacyMessage::new(&instructions, Some(&id1))).unwrap();
-        let serialized = serialize_instructions(&message.decompile_instructions());
+        let message = LegacyMessage::new(&instructions, Some(&id1));
+        let sanitized_message = new_sanitized_message(message);
+        let serialized = serialize_instructions(&sanitized_message.decompile_instructions());
         assert_eq!(
             deserialize_instruction(instructions.len(), &serialized).unwrap_err(),
             SanitizeError::IndexOutOfBounds,

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -118,6 +118,10 @@ lazy_static! {
 }
 
 /// Returns `true` of the given `Pubkey` is a sysvar account.
+#[deprecated(
+    since = "1.18.0",
+    note = "please check the account's owner or use solana_sdk::reserved_account_keys::ReservedAccountKeys instead"
+)]
 pub fn is_sysvar_id(id: &Pubkey) -> bool {
     ALL_IDS.iter().any(|key| key == id)
 }

--- a/sdk/program/src/zk_token_proof_program.rs
+++ b/sdk/program/src/zk_token_proof_program.rs
@@ -1,0 +1,9 @@
+//! The [ZK Token Proof Program][np].
+//!
+//! [np]: https://docs.solanalabs.com/runtime/zk-token-proof
+//!
+//! Documentation can be found in [`solana-zk-token-sdk`].
+//!
+//! [`solana-zk-token-sdk`]: https://docs.rs/solana-zk-token-sdk/latest/solana_zk_token_sdk
+
+crate::declare_id!("ZkTokenProof1111111111111111111111111111111");

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -744,6 +744,10 @@ pub mod allow_commission_decrease_at_any_time {
     solana_sdk::declare_id!("decoMktMcnmiq6t3u7g5BfgcQu91nKZr6RvMYf9z1Jb");
 }
 
+pub mod add_new_reserved_account_keys {
+    solana_sdk::declare_id!("8U4skmMVnF6k2kMvrWbQuRUT3qQSiTYpSjqmhmgfthZu");
+}
+
 pub mod consume_blockstore_duplicate_proofs {
     solana_sdk::declare_id!("6YsBCejwK96GZCkJ6mkZ4b68oP63z2PLoQmWjC7ggTqZ");
 }
@@ -965,6 +969,7 @@ lazy_static! {
         (drop_legacy_shreds::id(), "drops legacy shreds #34328"),
         (allow_commission_decrease_at_any_time::id(), "Allow commission decrease at any time in epoch #33843"),
         (consume_blockstore_duplicate_proofs::id(), "consume duplicate proofs from blockstore in consensus #34372"),
+        (add_new_reserved_account_keys::id(), "add new unwritable reserved accounts #???"),
         (index_erasure_conflict_duplicate_proofs::id(), "generate duplicate proofs for index and erasure conflicts #34360"),
         (merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for merkle root conflicts #34270"),
         (disable_bpf_loader_instructions::id(), "disable bpf loader management instructions #34194"),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -969,7 +969,7 @@ lazy_static! {
         (drop_legacy_shreds::id(), "drops legacy shreds #34328"),
         (allow_commission_decrease_at_any_time::id(), "Allow commission decrease at any time in epoch #33843"),
         (consume_blockstore_duplicate_proofs::id(), "consume duplicate proofs from blockstore in consensus #34372"),
-        (add_new_reserved_account_keys::id(), "add new unwritable reserved accounts #???"),
+        (add_new_reserved_account_keys::id(), "add new unwritable reserved accounts #34899"),
         (index_erasure_conflict_duplicate_proofs::id(), "generate duplicate proofs for index and erasure conflicts #34360"),
         (merkle_conflict_duplicate_proofs::id(), "generate duplicate proofs for merkle root conflicts #34270"),
         (disable_bpf_loader_instructions::id(), "disable bpf loader management instructions #34194"),

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -95,6 +95,7 @@ pub mod quic;
 pub mod recent_blockhashes_account;
 pub mod rent_collector;
 pub mod rent_debits;
+pub mod reserved_account_keys;
 pub mod reward_info;
 pub mod reward_type;
 pub mod rpc_port;

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -55,7 +55,7 @@ pub use solana_program::{
     program_pack, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serde_varint,
     serialize_utils, short_vec, slot_hashes, slot_history, stable_layout, stake, stake_history,
     syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const, vote,
-    wasm_bindgen,
+    wasm_bindgen, zk_token_proof_program,
 };
 
 pub mod account;

--- a/sdk/src/nonce_info.rs
+++ b/sdk/src/nonce_info.rs
@@ -133,7 +133,7 @@ mod tests {
         instructions: &[Instruction],
         payer: Option<&Pubkey>,
     ) -> SanitizedMessage {
-        Message::new(instructions, payer).try_into().unwrap()
+        SanitizedMessage::try_from_legacy_message(Message::new(instructions, payer)).unwrap()
     }
 
     #[test]

--- a/sdk/src/nonce_info.rs
+++ b/sdk/src/nonce_info.rs
@@ -124,6 +124,7 @@ mod tests {
             instruction::Instruction,
             message::Message,
             nonce::{self, state::DurableNonce},
+            reserved_account_keys::ReservedAccountKeys,
             signature::{keypair_from_seed, Signer},
             system_instruction, system_program,
         },
@@ -133,7 +134,11 @@ mod tests {
         instructions: &[Instruction],
         payer: Option<&Pubkey>,
     ) -> SanitizedMessage {
-        SanitizedMessage::try_from_legacy_message(Message::new(instructions, payer)).unwrap()
+        SanitizedMessage::try_from_legacy_message(
+            Message::new(instructions, payer),
+            &ReservedAccountKeys::empty(),
+        )
+        .unwrap()
     }
 
     #[test]

--- a/sdk/src/reserved_account_keys.rs
+++ b/sdk/src/reserved_account_keys.rs
@@ -1,0 +1,187 @@
+//! Collection of reserved account keys that cannot be write-locked by transactions.
+//! New reserved account keys may be added as long as they specify a feature
+//! gate that transitions the key into read-only at an epoch boundary.
+
+#![cfg(feature = "full")]
+
+use {
+    crate::{
+        address_lookup_table, bpf_loader, bpf_loader_deprecated, bpf_loader_upgradeable,
+        compute_budget, config, ed25519_program, feature,
+        feature_set::{self, FeatureSet},
+        loader_v4, native_loader,
+        pubkey::Pubkey,
+        secp256k1_program, stake, system_program, sysvar, vote, zk_token_proof_program,
+    },
+    lazy_static::lazy_static,
+    std::collections::HashSet,
+};
+
+pub struct ReservedAccountKeys;
+impl ReservedAccountKeys {
+    /// Compute a set of all reserved keys, regardless of if they are active or not
+    pub fn active_and_inactive() -> HashSet<Pubkey> {
+        RESERVED_ACCOUNT_KEYS
+            .iter()
+            .map(|reserved_key| reserved_key.key)
+            .collect()
+    }
+
+    /// Compute the active set of reserved keys based on activated features
+    pub fn active(feature_set: &FeatureSet) -> HashSet<Pubkey> {
+        Self::compute_active(&RESERVED_ACCOUNT_KEYS, feature_set)
+    }
+
+    // Method only exists for unit testing
+    fn compute_active(
+        account_keys: &[ReservedAccountKey],
+        feature_set: &FeatureSet,
+    ) -> HashSet<Pubkey> {
+        account_keys
+            .iter()
+            .filter(|reserved_key| reserved_key.is_active(feature_set))
+            .map(|reserved_key| reserved_key.key)
+            .collect()
+    }
+
+    /// Return an empty list of reserved keys for visibility when using in
+    /// places where the dynamic reserved key set is not available
+    pub fn empty() -> HashSet<Pubkey> {
+        HashSet::default()
+    }
+}
+
+/// `ReservedAccountKey` represents a reserved account key that will not be
+/// write-lockable by transactions. If a feature id is set, the account key will
+/// become read-only only after the feature has been activated.
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ReservedAccountKey {
+    key: Pubkey,
+    feature_id: Option<Pubkey>,
+}
+
+impl ReservedAccountKey {
+    fn new(key: Pubkey, feature_id: Option<Pubkey>) -> Self {
+        Self { key, feature_id }
+    }
+
+    /// Returns true if no feature id is set or if the feature id is activated
+    /// in the feature set.
+    fn is_active(&self, feature_set: &FeatureSet) -> bool {
+        self.feature_id
+            .map_or(true, |feature_id| feature_set.is_active(&feature_id))
+    }
+}
+
+// New reserved account keys should be added in alphabetical order and must
+// specify a feature id for activation.
+lazy_static! {
+    static ref RESERVED_ACCOUNT_KEYS: Vec<ReservedAccountKey> = [
+        // builtin programs
+        ReservedAccountKey::new(address_lookup_table::program::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        ReservedAccountKey::new(bpf_loader::id(), None),
+        ReservedAccountKey::new(bpf_loader_deprecated::id(), None),
+        ReservedAccountKey::new(bpf_loader_upgradeable::id(), None),
+        ReservedAccountKey::new(compute_budget::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        ReservedAccountKey::new(config::program::id(), None),
+        ReservedAccountKey::new(ed25519_program::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        ReservedAccountKey::new(feature::id(), None),
+        ReservedAccountKey::new(loader_v4::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        ReservedAccountKey::new(secp256k1_program::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        #[allow(deprecated)]
+        ReservedAccountKey::new(stake::config::id(), None),
+        ReservedAccountKey::new(stake::program::id(), None),
+        ReservedAccountKey::new(system_program::id(), None),
+        ReservedAccountKey::new(vote::program::id(), None),
+        ReservedAccountKey::new(zk_token_proof_program::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+
+        // sysvars
+        ReservedAccountKey::new(sysvar::clock::id(), None),
+        ReservedAccountKey::new(sysvar::epoch_rewards::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        ReservedAccountKey::new(sysvar::epoch_schedule::id(), None),
+        #[allow(deprecated)]
+        ReservedAccountKey::new(sysvar::fees::id(), None),
+        ReservedAccountKey::new(sysvar::instructions::id(), None),
+        ReservedAccountKey::new(sysvar::last_restart_slot::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+        #[allow(deprecated)]
+        ReservedAccountKey::new(sysvar::recent_blockhashes::id(), None),
+        ReservedAccountKey::new(sysvar::rent::id(), None),
+        ReservedAccountKey::new(sysvar::rewards::id(), None),
+        ReservedAccountKey::new(sysvar::slot_hashes::id(), None),
+        ReservedAccountKey::new(sysvar::slot_history::id(), None),
+        ReservedAccountKey::new(sysvar::stake_history::id(), None),
+
+        // other
+        ReservedAccountKey::new(native_loader::id(), None),
+        ReservedAccountKey::new(sysvar::id(), Some(feature_set::add_new_reserved_account_keys::id())),
+    ].to_vec();
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_program::{message::legacy::BUILTIN_PROGRAMS_KEYS, sysvar::ALL_IDS},
+    };
+
+    #[test]
+    fn test_reserved_account_key_is_active() {
+        let feature_id = Pubkey::new_unique();
+        let old_reserved_account_key = ReservedAccountKey::new(Pubkey::new_unique(), None);
+        let new_reserved_account_key =
+            ReservedAccountKey::new(Pubkey::new_unique(), Some(feature_id));
+
+        let mut feature_set = FeatureSet::default();
+        assert!(
+            old_reserved_account_key.is_active(&feature_set),
+            "if not feature id is set, the key should be active"
+        );
+        assert!(
+            !new_reserved_account_key.is_active(&feature_set),
+            "if feature id is set but not in the feature set, the key should not be active"
+        );
+
+        feature_set.active.insert(feature_id, 0);
+        assert!(
+            new_reserved_account_key.is_active(&feature_set),
+            "if feature id is set and is in the feature set, the key should be active"
+        );
+    }
+
+    #[test]
+    fn test_reserved_account_keys_compute_active() {
+        let feature_id = Pubkey::new_unique();
+        let key0 = Pubkey::new_unique();
+        let key1 = Pubkey::new_unique();
+        let test_account_keys = vec![
+            ReservedAccountKey::new(key0, None),
+            ReservedAccountKey::new(key1, Some(feature_id)),
+            ReservedAccountKey::new(Pubkey::new_unique(), Some(Pubkey::new_unique())),
+        ];
+
+        let mut feature_set = FeatureSet::default();
+        assert_eq!(
+            HashSet::from_iter([key0].into_iter()),
+            ReservedAccountKeys::compute_active(&test_account_keys, &feature_set),
+            "should only contain keys without feature ids"
+        );
+
+        feature_set.active.insert(feature_id, 0);
+        assert_eq!(
+            HashSet::from_iter([key0, key1].into_iter()),
+            ReservedAccountKeys::compute_active(&test_account_keys, &feature_set),
+            "should only contain keys without feature ids or with active feature ids"
+        );
+    }
+
+    #[test]
+    fn test_static_list_compat() {
+        let mut static_set = HashSet::new();
+        static_set.extend(ALL_IDS.iter().cloned());
+        static_set.extend(BUILTIN_PROGRAMS_KEYS.iter().cloned());
+
+        let initial_dynamic_set = ReservedAccountKeys::active(&FeatureSet::default());
+
+        assert_eq!(initial_dynamic_set, static_set);
+    }
+}

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -1074,7 +1074,7 @@ impl Transaction {
     }
 }
 
-pub fn uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
+pub fn maybe_uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
     let message = tx.message();
     message
         .instructions
@@ -1093,7 +1093,7 @@ pub fn uses_durable_nonce(tx: &Transaction) -> Option<&CompiledInstruction> {
             // Nonce account is writable
             && matches!(
                 instruction.accounts.first(),
-                Some(index) if message.is_writable(*index as usize)
+                Some(index) if message.is_maybe_writable(*index as usize)
             )
         })
 }
@@ -1553,19 +1553,19 @@ mod tests {
     #[test]
     fn tx_uses_nonce_ok() {
         let (_, _, tx) = nonced_transfer_tx();
-        assert!(uses_durable_nonce(&tx).is_some());
+        assert!(maybe_uses_durable_nonce(&tx).is_some());
     }
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        assert!(uses_durable_nonce(&Transaction::default()).is_none());
+        assert!(maybe_uses_durable_nonce(&Transaction::default()).is_none());
     }
 
     #[test]
     fn tx_uses_nonce_bad_prog_id_idx_fail() {
         let (_, _, mut tx) = nonced_transfer_tx();
         tx.message.instructions.get_mut(0).unwrap().program_id_index = 255u8;
-        assert!(uses_durable_nonce(&tx).is_none());
+        assert!(maybe_uses_durable_nonce(&tx).is_none());
     }
 
     #[test]
@@ -1580,7 +1580,7 @@ mod tests {
         ];
         let message = Message::new(&instructions, Some(&from_pubkey));
         let tx = Transaction::new(&[&from_keypair, &nonce_keypair], message, Hash::default());
-        assert!(uses_durable_nonce(&tx).is_none());
+        assert!(maybe_uses_durable_nonce(&tx).is_none());
     }
 
     #[test]
@@ -1606,7 +1606,7 @@ mod tests {
             &[&from_keypair, &nonce_keypair],
             Hash::default(),
         );
-        assert!(uses_durable_nonce(&tx).is_none());
+        assert!(maybe_uses_durable_nonce(&tx).is_none());
     }
 
     #[test]
@@ -1626,13 +1626,13 @@ mod tests {
         ];
         let message = Message::new(&instructions, Some(&nonce_pubkey));
         let tx = Transaction::new(&[&from_keypair, &nonce_keypair], message, Hash::default());
-        assert!(uses_durable_nonce(&tx).is_none());
+        assert!(maybe_uses_durable_nonce(&tx).is_none());
     }
 
     #[test]
     fn get_nonce_pub_from_ix_ok() {
         let (_, nonce_pubkey, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
+        let nonce_ix = maybe_uses_durable_nonce(&tx).unwrap();
         assert_eq!(
             get_nonce_pubkey_from_instruction(nonce_ix, &tx),
             Some(&nonce_pubkey),
@@ -1642,7 +1642,7 @@ mod tests {
     #[test]
     fn get_nonce_pub_from_ix_no_accounts_fail() {
         let (_, _, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
+        let nonce_ix = maybe_uses_durable_nonce(&tx).unwrap();
         let mut nonce_ix = nonce_ix.clone();
         nonce_ix.accounts.clear();
         assert_eq!(get_nonce_pubkey_from_instruction(&nonce_ix, &tx), None,);
@@ -1651,7 +1651,7 @@ mod tests {
     #[test]
     fn get_nonce_pub_from_ix_bad_acc_idx_fail() {
         let (_, _, tx) = nonced_transfer_tx();
-        let nonce_ix = uses_durable_nonce(&tx).unwrap();
+        let nonce_ix = maybe_uses_durable_nonce(&tx).unwrap();
         let mut nonce_ix = nonce_ix.clone();
         nonce_ix.accounts[0] = 255u8;
         assert_eq!(get_nonce_pubkey_from_instruction(&nonce_ix, &tx), None,);

--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -12,6 +12,7 @@ use {
         },
         precompiles::verify_if_precompile,
         pubkey::Pubkey,
+        reserved_account_keys::ReservedAccountKeys,
         sanitize::Sanitize,
         signature::Signature,
         simple_vote_transaction_checker::is_simple_vote_transaction,
@@ -19,6 +20,7 @@ use {
         transaction::{Result, Transaction, TransactionError, VersionedTransaction},
     },
     solana_program::message::SanitizedVersionedMessage,
+    std::collections::HashSet,
 };
 
 /// Maximum number of accounts that a transaction may lock.
@@ -66,17 +68,22 @@ impl SanitizedTransaction {
         message_hash: Hash,
         is_simple_vote_tx: bool,
         address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self> {
         let signatures = tx.signatures;
         let SanitizedVersionedMessage { message } = tx.message;
         let message = match message {
             VersionedMessage::Legacy(message) => {
-                SanitizedMessage::Legacy(LegacyMessage::new(message))
+                SanitizedMessage::Legacy(LegacyMessage::new(message, reserved_account_keys))
             }
             VersionedMessage::V0(message) => {
                 let loaded_addresses =
                     address_loader.load_addresses(&message.address_table_lookups)?;
-                SanitizedMessage::V0(v0::LoadedMessage::new(message, loaded_addresses))
+                SanitizedMessage::V0(v0::LoadedMessage::new(
+                    message,
+                    loaded_addresses,
+                    reserved_account_keys,
+                ))
             }
         };
 
@@ -96,6 +103,7 @@ impl SanitizedTransaction {
         message_hash: impl Into<MessageHash>,
         is_simple_vote_tx: Option<bool>,
         address_loader: impl AddressLoader,
+        reserved_account_keys: &HashSet<Pubkey>,
     ) -> Result<Self> {
         let sanitized_versioned_tx = SanitizedVersionedTransaction::try_from(tx)?;
         let is_simple_vote_tx = is_simple_vote_tx
@@ -109,15 +117,23 @@ impl SanitizedTransaction {
             message_hash,
             is_simple_vote_tx,
             address_loader,
+            reserved_account_keys,
         )
     }
 
-    pub fn try_from_legacy_transaction(tx: Transaction) -> Result<Self> {
+    /// Create a sanitized transaction from a legacy transaction
+    pub fn try_from_legacy_transaction(
+        tx: Transaction,
+        reserved_account_keys: &HashSet<Pubkey>,
+    ) -> Result<Self> {
         tx.sanitize()?;
 
         Ok(Self {
             message_hash: tx.message.hash(),
-            message: SanitizedMessage::Legacy(LegacyMessage::new(tx.message)),
+            message: SanitizedMessage::Legacy(LegacyMessage::new(
+                tx.message,
+                reserved_account_keys,
+            )),
             is_simple_vote_tx: false,
             signatures: tx.signatures,
         })
@@ -125,7 +141,7 @@ impl SanitizedTransaction {
 
     /// Create a sanitized transaction from a legacy transaction. Used for tests only.
     pub fn from_transaction_for_tests(tx: Transaction) -> Self {
-        Self::try_from_legacy_transaction(tx).unwrap()
+        Self::try_from_legacy_transaction(tx, &ReservedAccountKeys::empty()).unwrap()
     }
 
     /// Return the first signature for this transaction.
@@ -278,7 +294,10 @@ impl SanitizedTransaction {
 mod tests {
     use {
         super::*,
-        crate::signer::{keypair::Keypair, Signer},
+        crate::{
+            reserved_account_keys::ReservedAccountKeys,
+            signer::{keypair::Keypair, Signer},
+        },
         solana_program::vote::{self, state::Vote},
     };
 
@@ -303,6 +322,7 @@ mod tests {
                 MessageHash::Compute,
                 None,
                 SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty(),
             )
             .unwrap();
             assert!(vote_transaction.is_simple_vote_transaction());
@@ -315,6 +335,7 @@ mod tests {
                 MessageHash::Compute,
                 Some(false),
                 SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty(),
             )
             .unwrap();
             assert!(!vote_transaction.is_simple_vote_transaction());
@@ -329,6 +350,7 @@ mod tests {
                 MessageHash::Compute,
                 None,
                 SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty(),
             )
             .unwrap();
             assert!(!vote_transaction.is_simple_vote_transaction());
@@ -341,6 +363,7 @@ mod tests {
                 MessageHash::Compute,
                 Some(true),
                 SimpleAddressLoader::Disabled,
+                &ReservedAccountKeys::empty(),
             )
             .unwrap();
             assert!(vote_transaction.is_simple_vote_transaction());

--- a/sdk/src/transaction/versioned/mod.rs
+++ b/sdk/src/transaction/versioned/mod.rs
@@ -189,7 +189,7 @@ impl VersionedTransaction {
     /// instruction. Since dynamically loaded addresses can't have write locks
     /// demoted without loading addresses, this shouldn't be used in the
     /// runtime.
-    pub fn uses_durable_nonce(&self) -> bool {
+    pub fn maybe_uses_durable_nonce(&self) -> bool {
         let message = &self.message;
         message
             .instructions()
@@ -291,12 +291,12 @@ mod tests {
     #[test]
     fn tx_uses_nonce_ok() {
         let (_, _, tx) = nonced_transfer_tx();
-        assert!(tx.uses_durable_nonce());
+        assert!(tx.maybe_uses_durable_nonce());
     }
 
     #[test]
     fn tx_uses_nonce_empty_ix_fail() {
-        assert!(!VersionedTransaction::default().uses_durable_nonce());
+        assert!(!VersionedTransaction::default().maybe_uses_durable_nonce());
     }
 
     #[test]
@@ -308,7 +308,7 @@ mod tests {
             }
             VersionedMessage::V0(_) => unreachable!(),
         };
-        assert!(!tx.uses_durable_nonce());
+        assert!(!tx.maybe_uses_durable_nonce());
     }
 
     #[test]
@@ -324,7 +324,7 @@ mod tests {
         let message = LegacyMessage::new(&instructions, Some(&from_pubkey));
         let tx = Transaction::new(&[&from_keypair, &nonce_keypair], message, Hash::default());
         let tx = VersionedTransaction::from(tx);
-        assert!(!tx.uses_durable_nonce());
+        assert!(!tx.maybe_uses_durable_nonce());
     }
 
     #[test]
@@ -351,7 +351,7 @@ mod tests {
             Hash::default(),
         );
         let tx = VersionedTransaction::from(tx);
-        assert!(!tx.uses_durable_nonce());
+        assert!(!tx.maybe_uses_durable_nonce());
     }
 
     #[test]
@@ -372,6 +372,6 @@ mod tests {
         let message = LegacyMessage::new(&instructions, Some(&nonce_pubkey));
         let tx = Transaction::new(&[&from_keypair, &nonce_keypair], message, Hash::default());
         let tx = VersionedTransaction::from(tx);
-        assert!(!tx.uses_durable_nonce());
+        assert!(!tx.maybe_uses_durable_nonce());
     }
 }

--- a/storage-bigtable/src/lib.rs
+++ b/storage-bigtable/src/lib.rs
@@ -10,8 +10,8 @@ use {
         deserialize_utils::default_on_eof,
         message::v0::LoadedAddresses,
         pubkey::Pubkey,
+        reserved_account_keys::ReservedAccountKeys,
         signature::Signature,
-        sysvar::is_sysvar_id,
         timing::AtomicInterval,
         transaction::{TransactionError, VersionedTransaction},
     },
@@ -938,6 +938,7 @@ impl LedgerStorage {
             entries,
         } = confirmed_block;
 
+        let reserved_account_keys = ReservedAccountKeys::active_and_inactive();
         let mut tx_cells = Vec::with_capacity(confirmed_block.transactions.len());
         for (index, transaction_with_meta) in confirmed_block.transactions.iter().enumerate() {
             let VersionedTransactionWithStatusMeta { meta, transaction } = transaction_with_meta;
@@ -947,7 +948,7 @@ impl LedgerStorage {
             let memo = extract_and_fmt_memos(transaction_with_meta);
 
             for address in transaction_with_meta.account_keys().iter() {
-                if !is_sysvar_id(address) {
+                if !reserved_account_keys.contains(address) {
                     by_addr
                         .entry(address)
                         .or_default()
@@ -1083,9 +1084,9 @@ impl LedgerStorage {
                     let err = None;
 
                     for address in transaction.message.account_keys.iter() {
-                        if !is_sysvar_id(address) {
-                            addresses.insert(address);
-                        }
+                        // Some of these addresses might be reserved keys but it's
+                        // ok if we attempt to delete a row that doesn't exist
+                        addresses.insert(address);
                     }
 
                     expected_tx_infos.insert(
@@ -1100,9 +1101,9 @@ impl LedgerStorage {
                     let err = meta.status.clone().err();
 
                     for address in tx_with_meta.account_keys().iter() {
-                        if !is_sysvar_id(address) {
-                            addresses.insert(address);
-                        }
+                        // Some of these addresses might be reserved keys but it's
+                        // ok if we attempt to delete a row that doesn't exist
+                        addresses.insert(address);
                     }
 
                     expected_tx_infos.insert(

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -481,6 +481,7 @@ mod tests {
             nonce,
             rent::Rent,
             rent_collector::RentCollector,
+            reserved_account_keys::ReservedAccountKeys,
             signature::{Keypair, Signer},
             system_program, sysvar,
             transaction::{Result, Transaction, TransactionError},
@@ -678,7 +679,11 @@ mod tests {
             instructions,
         );
 
-        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(
+            tx.message().clone(),
+            &ReservedAccountKeys::empty(),
+        )
+        .unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,
@@ -1207,7 +1212,11 @@ mod tests {
             Hash::default(),
         );
 
-        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(
+            tx.message().clone(),
+            &ReservedAccountKeys::empty(),
+        )
+        .unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -678,7 +678,7 @@ mod tests {
             instructions,
         );
 
-        let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,
@@ -1207,7 +1207,7 @@ mod tests {
             Hash::default(),
         );
 
-        let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,

--- a/svm/tests/rent_state.rs
+++ b/svm/tests/rent_state.rs
@@ -55,7 +55,7 @@ fn test_rent_state_list_len() {
         last_block_hash,
     );
     let num_accounts = tx.message().account_keys.len();
-    let sanitized_tx = SanitizedTransaction::try_from_legacy_transaction(tx).unwrap();
+    let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(tx);
     let mut error_counters = TransactionErrorMetrics::default();
     let loaded_txs = load_accounts(
         &bank,

--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -19,6 +19,7 @@ use {
             AccountKeys, Message, MessageHeader, VersionedMessage,
         },
         pubkey::Pubkey,
+        reserved_account_keys::ReservedAccountKeys,
         signature::Signature,
         transaction::{
             Result as TransactionResult, Transaction, TransactionError, TransactionVersion,
@@ -980,12 +981,16 @@ impl VersionedTransactionWithStatusMeta {
         show_rewards: bool,
     ) -> Result<EncodedTransactionWithStatusMeta, EncodeError> {
         let version = self.validate_version(max_supported_transaction_version)?;
+        let reserved_account_keys = ReservedAccountKeys::active_and_inactive();
 
         let account_keys = match &self.transaction.message {
             VersionedMessage::Legacy(message) => parse_legacy_message_accounts(message),
             VersionedMessage::V0(message) => {
-                let loaded_message =
-                    LoadedMessage::new_borrowed(message, &self.meta.loaded_addresses);
+                let loaded_message = LoadedMessage::new_borrowed(
+                    message,
+                    &self.meta.loaded_addresses,
+                    &reserved_account_keys,
+                );
                 parse_v0_message_accounts(&loaded_message)
             }
         };
@@ -1228,8 +1233,10 @@ impl EncodableWithMeta for v0::Message {
         meta: &TransactionStatusMeta,
     ) -> Self::Encoded {
         if encoding == UiTransactionEncoding::JsonParsed {
+            let reserved_account_keys = ReservedAccountKeys::active_and_inactive();
             let account_keys = AccountKeys::new(&self.account_keys, Some(&meta.loaded_addresses));
-            let loaded_message = LoadedMessage::new_borrowed(self, &meta.loaded_addresses);
+            let loaded_message =
+                LoadedMessage::new_borrowed(self, &meta.loaded_addresses, &reserved_account_keys);
             UiMessage::Parsed(UiParsedMessage {
                 account_keys: parse_v0_message_accounts(&loaded_message),
                 recent_blockhash: self.recent_blockhash.to_string(),

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -21,7 +21,7 @@ pub fn parse_legacy_message_accounts(message: &Message) -> Vec<ParsedAccount> {
     for (i, account_key) in message.account_keys.iter().enumerate() {
         accounts.push(ParsedAccount {
             pubkey: account_key.to_string(),
-            writable: message.is_writable(i),
+            writable: message.is_maybe_writable(i),
             signer: message.is_signer(i),
             source: Some(ParsedAccountSource::Transaction),
         });

--- a/transaction-status/src/parse_accounts.rs
+++ b/transaction-status/src/parse_accounts.rs
@@ -54,6 +54,7 @@ mod test {
         solana_sdk::{
             message::{v0, v0::LoadedAddresses, MessageHeader},
             pubkey::Pubkey,
+            reserved_account_keys::ReservedAccountKeys,
         },
     };
 
@@ -126,6 +127,7 @@ mod test {
                 writable: vec![pubkey4],
                 readonly: vec![pubkey5],
             },
+            &ReservedAccountKeys::empty(),
         );
 
         assert_eq!(


### PR DESCRIPTION
#### Problem
There's no way to add new builtin programs and sysvars to the list of read-only reserved accounts.

#### Summary of Changes
Bank now tracks a dynamic set of reserved account keys which gets updated on epoch boundaries with feature activations. The set of reserved account keys needs to get passed to all the transaction and message constructors and then we take advantage of the is_writable cache to avoid passing the reserved account set to `is_writable` everywhere. It's inevitable that a change like this will result in breaking changes unfortunately. There is an option of moving towards using more internal sdk crates (like `solana-runtime-transactions`) for core types rather than thrashing the external sdk whenever internal needs change, but that's a pretty big effort.

#### Detailed changes
https://github.com/solana-labs/solana/pull/34901/commits/1fa7b7d6a85ea4681c126691f1edc28ad712c39a: refactors tests to minimize diff size when plumbing reserved accounts
https://github.com/solana-labs/solana/pull/34901/commits/c8cb15f4ff94c406655c91fb87c6ad01b5d3e735: adds the zk token module to the sdk so that reserved accounts can reference the program id
https://github.com/solana-labs/solana/pull/34901/commits/9ea7043dd177a242239ab6c2f8c02a868f3c120e: removes the `TryFrom<Message>` impl for `SanitizedMessage` and replaces it with `SanitizedMessage::try_from_legacy_message` which will allow plumbing the reserved accounts through
https://github.com/solana-labs/solana/pull/34901/commits/edbdf6f78940c27ba43751d7860ec10dd6356594: adds `Message::is_maybe_writable` for times when the reserved accounts set is not available but we want a rough guess still (cli output, durable nonce checking in rpc, etc)
https://github.com/solana-labs/solana/pull/34901/commits/8fb6616957f4c747480b60d96918e5b7e6f6b81f: is the meat of the change, it introduces the reserved accounts module, adds it to bank, and plumbs the reserved accounts set everywhere
https://github.com/solana-labs/solana/pull/34901/commits/701119bbb46939b28ba39af81076b76917390901: deprecates uses of static lists of sysvars and builtins. Unfortunately the lists themselves can't be deprecated due to use of `lazy_static`
- Deprecated `solana_program::message::is_builtin_key_or_sysvar` function
- Deprecated `solana_program::sysvar::is_sysvar_id` function
- Bigtable uploader used to skip indexing sysvars, now it skips all reserved keys
- Replaced some usages of `is_sysvar_id` which a check for owner equal to sysvar
- Snapshot minimizer logic now adds all active and inactive reserved account keys to the minimized snapshot

#### Breaking changes:
- Renamed `solana_rpc_client::rpc_client::SerializableTransaction::uses_durable_nonce` to `maybe_uses_durable_nonce` to prevent misuse
- Renamed `solana_sdk::transaction::uses_durable_nonce` to `maybe_uses_durable_nonce` to prevent misuse
- Renamed `solana_sdk::transaction::VersionedTransaction::uses_durable_nonce` to `maybe_uses_durable_nonce` to prevent misuse
- `solana_sdk::transaction::SanitizedTransaction::try_from_legacy_transaction` has a new `reserved_account_keys` argument
- `solana_sdk::transaction::SanitizedTransaction::try_create` has a new `reserved_account_keys` argument
- `solana_sdk::transaction::SanitizedTransaction::try_new` has a new `reserved_account_keys` argument
- `solana_program::message::Message::is_writable` has a new `reserved_account_keys` argument
- `solana_program::message::Message::get_account_keys_by_lock_type` has a new `reserved_account_keys` argument
- `solana_program::message::LegacyMessage::new` has a new `reserved_account_keys` argument
- `solana_program::message::SanitizedMessage::try_new` has a new `reserved_account_keys` argument
- `solana_program::message::LoadedMessage::new` has a new `reserved_account_keys` argument
- `solana_program::message::LoadedMessage::new_borrowed` has a new `reserved_account_keys` argument
- `solana_program::message::SanitizedMessage` no longer implements `TryFrom<Message>` (I added a `try_from_legacy_message` method instead in order to pass the `reserved_account_keys` argument)

Feature Gate Issue: https://github.com/solana-labs/solana/issues/34899
<!-- Don't forget to add the "feature-gate" label -->
