### PR TITLE
Replaces fs-err in clean_orphaned_account_snapshot_dirs()

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -601,15 +601,15 @@ impl Validator {
             &config.snapshot_config.bank_snapshots_dir,
         );
 
-        info!("Cleaning orphaned account snapshot directories..");
+        info!("Cleaning orphaned account snapshot directories...");
         let mut timer = Measure::start("clean_orphaned_account_snapshot_dirs");
         clean_orphaned_account_snapshot_dirs(
             &config.snapshot_config.bank_snapshots_dir,
             &config.account_snapshot_paths,
         )
-        .map_err(|err| format!("Failed to clean orphaned account snapshot directories: {err:?}"))?;
+        .map_err(|err| format!("failed to clean orphaned account snapshot directories: {err}"))?;
         timer.stop();
-        info!("Cleaning orphaned account snapshot directories done. {timer}");
+        info!("Cleaning orphaned account snapshot directories... Done, and{timer}");
 
         // The accounts hash cache dir was renamed, so cleanup any old dirs that exist.
         let accounts_hash_cache_path = config

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -601,7 +601,7 @@ impl Validator {
             &config.snapshot_config.bank_snapshots_dir,
         );
 
-        info!("Cleaning orphaned account snapshot directories...");
+        info!("Cleaning orphaned account snapshot directories..");
         let mut timer = Measure::start("clean_orphaned_account_snapshot_dirs");
         clean_orphaned_account_snapshot_dirs(
             &config.snapshot_config.bank_snapshots_dir,
@@ -609,7 +609,7 @@ impl Validator {
         )
         .map_err(|err| format!("failed to clean orphaned account snapshot directories: {err}"))?;
         timer.stop();
-        info!("Cleaning orphaned account snapshot directories... Done, and{timer}");
+        info!("Cleaning orphaned account snapshot directories done. {timer}");
 
         // The accounts hash cache dir was renamed, so cleanup any old dirs that exist.
         let accounts_hash_cache_path = config

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -38,7 +38,6 @@ use {
         snapshot_hash::StartingSnapshotHashes,
         snapshot_utils::{
             self, clean_orphaned_account_snapshot_dirs, move_and_async_delete_path_contents,
-            SnapshotError,
         },
     },
     solana_sdk::{
@@ -67,7 +66,7 @@ const PROCESS_SLOTS_HELP_STRING: &str =
 #[derive(Error, Debug)]
 pub(crate) enum LoadAndProcessLedgerError {
     #[error("failed to clean orphaned account snapshot directories: {0}")]
-    CleanOrphanedAccountSnapshotDirectories(#[source] SnapshotError),
+    CleanOrphanedAccountSnapshotDirectories(#[source] std::io::Error),
 
     #[error("failed to create all run and snapshot directories: {0}")]
     CreateAllAccountsRunAndSnapshotDirectories(#[source] std::io::Error),

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -32,7 +32,7 @@ use {
         cmp::Ordering,
         collections::{HashMap, HashSet},
         fmt, fs,
-        io::{BufReader, BufWriter, Error as IoError, Read, Seek, Write},
+        io::{BufReader, BufWriter, Error as IoError, Read, Result as IoResult, Seek, Write},
         num::NonZeroUsize,
         path::{Path, PathBuf},
         process::ExitStatus,
@@ -610,7 +610,7 @@ pub fn move_and_async_delete_path(path: impl AsRef<Path>) {
 pub fn clean_orphaned_account_snapshot_dirs(
     bank_snapshots_dir: impl AsRef<Path>,
     account_snapshot_paths: &[PathBuf],
-) -> Result<()> {
+) -> IoResult<()> {
     // Create the HashSet of the account snapshot hardlink directories referenced by the snapshot dirs.
     // This is used to clean up any hardlinks that are no longer referenced by the snapshot dirs.
     let mut account_snapshot_dirs_referenced = HashSet::new();
@@ -618,20 +618,37 @@ pub fn clean_orphaned_account_snapshot_dirs(
     for snapshot in snapshots {
         let account_hardlinks_dir = snapshot.snapshot_dir.join(SNAPSHOT_ACCOUNTS_HARDLINKS);
         // loop through entries in the snapshot_hardlink_dir, read the symlinks, add the target to the HashSet
-        for entry in fs_err::read_dir(&account_hardlinks_dir)? {
+        let read_dir = fs::read_dir(&account_hardlinks_dir).map_err(|err| {
+            IoError::other(format!(
+                "failed to read account hardlinks dir '{}': {err}",
+                account_hardlinks_dir.display(),
+            ))
+        })?;
+        for entry in read_dir {
             let path = entry?.path();
-            let target = fs_err::read_link(&path)?;
+            let target = fs::read_link(&path).map_err(|err| {
+                IoError::other(format!(
+                    "failed to read symlink '{}': {err}",
+                    path.display(),
+                ))
+            })?;
             account_snapshot_dirs_referenced.insert(target);
         }
     }
 
     // loop through the account snapshot hardlink directories, if the directory is not in the account_snapshot_dirs_referenced set, delete it
     for account_snapshot_path in account_snapshot_paths {
-        for entry in fs_err::read_dir(account_snapshot_path)? {
+        let read_dir = fs::read_dir(account_snapshot_path).map_err(|err| {
+            IoError::other(format!(
+                "failed to read account snapshot dir '{}': {err}",
+                account_snapshot_path.display(),
+            ))
+        })?;
+        for entry in read_dir {
             let path = entry?.path();
             if !account_snapshot_dirs_referenced.contains(&path) {
                 info!(
-                    "Removing orphaned account snapshot hardlink directory: {}",
+                    "Removing orphaned account snapshot hardlink directory '{}'...",
                     path.display()
                 );
                 move_and_async_delete_path(&path);


### PR DESCRIPTION
#### Problem

We're trying to remove the `fs-err` crate. For more information, please refer to https://github.com/solana-labs/solana/pull/34838.

`snapshot_utils::clean_orphaned_account_snapshot_dirs()` still uses fs-err, but doesn't need to.


#### Summary of Changes

Replace fs-err with std::fs