### PR TITLE
Replaces fs-err in snapshot_utils.rs

### DIFF
--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -13,7 +13,6 @@ use {
     bzip2::bufread::BzDecoder,
     crossbeam_channel::Sender,
     flate2::read::GzDecoder,
-    fs_err,
     lazy_static::lazy_static,
     log::*,
     regex::Regex,


### PR DESCRIPTION
#### Problem

We're trying to remove the `fs-err` crate. For more information, please refer to https://github.com/solana-labs/solana/pull/34838.

`snapshot_utils.rs` still uses fs-err, but doesn't need to.

#### Summary of Changes

Removes fs_err from `snapshot_utils.rs`

Each piece is its own commit:
- Replaces fs-err in streaming_snapshot_dir_files()
- Replaces fs-err in serialize_snapshot_data_file_capped()
- Replaces fs-err in create_snapshot_meta_files_for_unarchived_snapshot()
- Replaces fs-err in create_snapshot_data_file_stream()
- Removes fs-err import