### PR TITLE
Update changelog in preparation for creating new  v1.18 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 and follows a [Backwards Compatibility Policy](https://docs.solanalabs.com/backwards-compatibility)
 
 Release channels have their own copy of this changelog:
-* [edge - v1.18](#edge-channel)
-* [beta - v1.17](https://github.com/solana-labs/solana/blob/v1.17/CHANGELOG.md)
-* [stable - v1.16](https://github.com/solana-labs/solana/blob/v1.16/CHANGELOG.md)
+* [edge - v2.0](#edge-channel)
+* [beta - v1.18](https://github.com/solana-labs/solana/blob/v1.18/CHANGELOG.md)
+* [stable - v1.17](https://github.com/solana-labs/solana/blob/v1.17/CHANGELOG.md)
 
 <a name="edge-channel"></a>
-## [1.18.0] - Unreleased
+## [2.0.0] - Unreleased
+
+## [1.18.0]
 * Changes
   * Added a github check to support `changelog` label
   * The default for `--use-snapshot-archives-at-startup` is now `when-newest` (#33883)


### PR DESCRIPTION
It's time to branch v1.18 off of master and advance the master version number to 2.0. This resets the changelog in preparation.

