### PR TITLE
Fix epoch rewards partition-data program owner

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3611,7 +3611,7 @@ impl Bank {
         let new_account = AccountSharedData::new_data(
             account_balance,
             &epoch_rewards_partition_data,
-            &solana_sdk::stake::program::id(),
+            &solana_sdk::sysvar::id(),
         )
         .unwrap();
         self.store_account_and_update_capitalization(&address, &new_account);


### PR DESCRIPTION
#### Problem
#34862 attempted to change the program-owner of the epoch rewards partition-data PDAs. However, the runtime constructs the account manually, so the owner needs to be updated there too.

#### Summary of Changes
Fix owner assignment

Sorry, dumb bug
