### PR TITLE
Support json parsing of epoch-rewards partition data sysvar accounts

### DIFF
--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -9,6 +9,7 @@ use {
     bv::BitVec,
     solana_sdk::{
         clock::{Clock, Epoch, Slot, UnixTimestamp},
+        epoch_rewards_partition_data::EpochRewardsPartitionDataVersion,
         epoch_schedule::EpochSchedule,
         pubkey::Pubkey,
         rent::Rent,
@@ -96,7 +97,24 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                 .ok()
                 .map(SysvarAccountType::EpochRewards)
         } else {
-            None
+            // EpochRewards PartitionData accounts are owned by the sysvar
+            // program, but have dynamically generated addresses. Test on
+            // whether account content deserializes properly.
+            if let Ok(epoch_rewards_partition_data) =
+                deserialize::<EpochRewardsPartitionDataVersion>(data)
+            {
+                let EpochRewardsPartitionDataVersion::V0(partition_data) =
+                    epoch_rewards_partition_data;
+                Some(SysvarAccountType::EpochRewardsPartitionData(
+                    UiEpochRewardsPartitionData {
+                        version: 0,
+                        num_partitions: partition_data.num_partitions as u64,
+                        parent_blockhash: partition_data.parent_blockhash.to_string(),
+                    },
+                ))
+            } else {
+                None
+            }
         }
     };
     parsed_account.ok_or(ParseAccountError::AccountNotParsable(
@@ -120,6 +138,7 @@ pub enum SysvarAccountType {
     StakeHistory(Vec<UiStakeHistoryEntry>),
     LastRestartSlot(UiLastRestartSlot),
     EpochRewards(EpochRewards),
+    EpochRewardsPartitionData(UiEpochRewardsPartitionData),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -237,6 +256,14 @@ pub struct UiStakeHistoryEntry {
 #[serde(rename_all = "camelCase")]
 pub struct UiLastRestartSlot {
     pub last_restart_slot: Slot,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UiEpochRewardsPartitionData {
+    pub version: u32,
+    pub num_partitions: u64,
+    pub parent_blockhash: String,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem
New epoch rewards partition-data sysvars aren't parsed, even though all the other accounts owned by `Sysvar1111111111111111111111111111111111111` are.

#### Summary of Changes
Implement parsing

```
$ curl  -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0", "id":1, "method":"getAccountInfo", "params":["FdAGcHUFksSVgNj5ihPaddMet3cuuFwJsxkG6ZXVA4Ly", {"encoding":"jsonParsed","commitment":"confirmed"}]}' 127.0.0.1:8899 | jq
{
  "jsonrpc": "2.0",
  "result": {
    "context": {
      "apiVersion": "1.18.0",
      "slot": 831
    },
    "value": {
      "data": {
        "parsed": {
          "info": {
            "numPartitions": 18,
            "parentBlockhash": "8m6GQ3auZGBMKsqcShxSqzUhuUpATJmXbbn3FqKYFdQp",
            "version": 0
          },
          "type": "epochRewardsPartitionData"
        },
        "program": "sysvar",
        "space": 44
      },
      "executable": false,
      "lamports": 1197120,
      "owner": "Sysvar1111111111111111111111111111111111111",
      "rentEpoch": 0,
      "space": 44
    }
  },
  "id": 1
}
```


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
