### PR TITLE
ledger-tool: Refactor accounts subcommand output code

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -30,6 +30,7 @@ use {
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
     },
+    solana_cli_output::OutputFormat,
     solana_core::{
         system_monitor_service::{SystemMonitorService, SystemMonitorStatsReportConfig},
         validator::BlockVerificationMethod,
@@ -2176,10 +2177,13 @@ fn main() {
                     let include_sysvars = arg_matches.is_present("include_sysvars");
                     let include_account_contents = !arg_matches.is_present("no_account_contents");
                     let include_account_data = !arg_matches.is_present("no_account_data");
+                    let output_format =
+                        OutputFormat::from_matches(arg_matches, "output_format", false);
                     let data_encoding = parse_encoding_format(arg_matches);
 
                     let accounts_streamer = AccountsOutputStreamer::new(
                         bank,
+                        output_format,
                         include_sysvars,
                         include_account_contents,
                         include_account_data,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2189,7 +2189,12 @@ fn main() {
 
                     let accounts_streamer =
                         AccountsOutputStreamer::new(bank, output_format, config);
-                    let (_, scan_time) = measure!(accounts_streamer.output(), "accounts scan");
+                    let (_, scan_time) = measure!(
+                        accounts_streamer
+                            .output()
+                            .map_err(|err| error!("Error while outputting accounts: {err}")),
+                        "accounts scan"
+                    );
                     info!("{scan_time}");
                 }
                 ("capitalization", Some(arg_matches)) => {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    crate::{args::*, bigtable::*, blockstore::*, ledger_path::*, ledger_utils::*, program::*},
+    crate::{
+        args::*, bigtable::*, blockstore::*, ledger_path::*, ledger_utils::*,
+        output::output_account, program::*,
+    },
     clap::{
         crate_description, crate_name, value_t, value_t_or_exit, values_t_or_exit, App,
         AppSettings, Arg, ArgMatches, SubCommand,
@@ -11,7 +14,7 @@ use {
         ser::{SerializeSeq, Serializer},
         Serialize,
     },
-    solana_account_decoder::{UiAccount, UiAccountData, UiAccountEncoding},
+    solana_account_decoder::UiAccountEncoding,
     solana_accounts_db::{
         accounts::Accounts, accounts_db::CalcAccountsHashDataSource, accounts_index::ScanConfig,
         hardened_unpack::MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -99,44 +102,6 @@ fn parse_encoding_format(matches: &ArgMatches<'_>) -> UiAccountEncoding {
         Some("base64") => UiAccountEncoding::Base64,
         Some("base64+zstd") => UiAccountEncoding::Base64Zstd,
         _ => UiAccountEncoding::Base64,
-    }
-}
-
-fn output_account(
-    pubkey: &Pubkey,
-    account: &AccountSharedData,
-    modified_slot: Option<Slot>,
-    print_account_data: bool,
-    encoding: UiAccountEncoding,
-) {
-    println!("{pubkey}:");
-    println!("  balance: {} SOL", lamports_to_sol(account.lamports()));
-    println!("  owner: '{}'", account.owner());
-    println!("  executable: {}", account.executable());
-    if let Some(slot) = modified_slot {
-        println!("  slot: {slot}");
-    }
-    println!("  rent_epoch: {}", account.rent_epoch());
-    println!("  data_len: {}", account.data().len());
-    if print_account_data {
-        let account_data = UiAccount::encode(pubkey, account, encoding, None, None).data;
-        match account_data {
-            UiAccountData::Binary(data, data_encoding) => {
-                println!("  data: '{data}'");
-                println!(
-                    "  encoding: {}",
-                    serde_json::to_string(&data_encoding).unwrap()
-                );
-            }
-            UiAccountData::Json(account_data) => {
-                println!(
-                    "  data: '{}'",
-                    serde_json::to_string(&account_data).unwrap()
-                );
-                println!("  encoding: \"jsonParsed\"");
-            }
-            UiAccountData::LegacyBinary(_) => {}
-        };
     }
 }
 

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2189,10 +2189,8 @@ fn main() {
                         include_account_data,
                         data_encoding,
                     );
-                    let mut measure = Measure::start("scanning accounts");
-                    accounts_streamer.output();
-                    measure.stop();
-                    info!("{}", measure);
+                    let (_, scan_time) = measure!(accounts_streamer.output(), "accounts scan");
+                    info!("{scan_time}");
                 }
                 ("capitalization", Some(arg_matches)) => {
                     let process_options = parse_process_options(&ledger_path, arg_matches);

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -6,7 +6,7 @@ use {
         blockstore::*,
         ledger_path::*,
         ledger_utils::*,
-        output::{output_account, AccountsOutputStreamer},
+        output::{output_account, AccountsOutputConfig, AccountsOutputStreamer},
         program::*,
     },
     clap::{
@@ -2177,18 +2177,18 @@ fn main() {
                     let include_sysvars = arg_matches.is_present("include_sysvars");
                     let include_account_contents = !arg_matches.is_present("no_account_contents");
                     let include_account_data = !arg_matches.is_present("no_account_data");
-                    let output_format =
-                        OutputFormat::from_matches(arg_matches, "output_format", false);
-                    let data_encoding = parse_encoding_format(arg_matches);
-
-                    let accounts_streamer = AccountsOutputStreamer::new(
-                        bank,
-                        output_format,
+                    let account_data_encoding = parse_encoding_format(arg_matches);
+                    let config = AccountsOutputConfig {
                         include_sysvars,
                         include_account_contents,
                         include_account_data,
-                        data_encoding,
-                    );
+                        account_data_encoding,
+                    };
+                    let output_format =
+                        OutputFormat::from_matches(arg_matches, "output_format", false);
+
+                    let accounts_streamer =
+                        AccountsOutputStreamer::new(bank, output_format, config);
                     let (_, scan_time) = measure!(accounts_streamer.output(), "accounts scan");
                     info!("{scan_time}");
                 }

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -621,7 +621,7 @@ impl AccountsOutputStreamer {
     }
 }
 
-pub struct AccountsScanner {
+struct AccountsScanner {
     bank: Arc<Bank>,
     total_accounts_stats: Rc<RefCell<TotalAccountsStats>>,
     include_sysvars: bool,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -636,9 +636,7 @@ impl AccountsScanner {
         solana_accounts_db::accounts::Accounts::is_loadable(account.lamports())
             && (self.config.include_sysvars || !solana_sdk::sysvar::is_sysvar_id(pubkey))
     }
-}
 
-impl AccountsScanner {
     pub fn output<S>(&self, seq_serializer: &mut Option<S>)
     where
         S: SerializeSeq,

--- a/ledger-tool/src/output.rs
+++ b/ledger-tool/src/output.rs
@@ -28,9 +28,9 @@ use {
         collections::HashMap,
         fmt::{self, Display, Formatter},
         io::{stdout, Write},
+        rc::Rc,
         result::Result,
         sync::Arc,
-        rc::Rc,
     },
 };
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -71,6 +71,7 @@ use {
         slice::ParallelSlice,
         ThreadPool, ThreadPoolBuilder,
     },
+    serde::Serialize,
     solana_accounts_db::{
         account_overrides::AccountOverrides,
         accounts::{
@@ -8444,7 +8445,7 @@ impl CollectRentInPartitionInfo {
 }
 
 /// Struct to collect stats when scanning all accounts in `get_total_accounts_stats()`
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, Serialize)]
 pub struct TotalAccountsStats {
     /// Total number of accounts
     pub num_accounts: usize,


### PR DESCRIPTION
#### Problem
The implementation of the `accounts` subcommand currently streams account information as each account is handled. This prevents memory pressure from collecting all of the information in a `Vec`, and is more efficient by doing the I/O as we go instead of waiting until the end. But, this implementation is a bit cluttered.

#### Summary of Changes
This PR does the following:
- Shift the logic for outputting accounts over to `output.rs`
- Add an object `AccountScanner` to handle
- Allows running with `--output json` to output the summary information as well while still being a valid json object
    - This is accomplished by putting the list of accounts in an array for `accounts` field, and then adding a `summary` field

This change lays the groundwork for cleanly adding modes where the output is limited to individual accounts or accounts owned by a specific program