### PR TITLE
Refactor load_accounts to take a reference to a slice instead of vec

### DIFF
--- a/accounts-db/src/nonce_info.rs
+++ b/accounts-db/src/nonce_info.rs
@@ -66,7 +66,7 @@ impl NonceFull {
         }
     }
     pub fn from_partial(
-        partial: NoncePartial,
+        partial: &NoncePartial,
         message: &SanitizedMessage,
         accounts: &[TransactionAccount],
         rent_debits: &RentDebits,
@@ -221,8 +221,8 @@ mod tests {
                 ),
             ];
 
-            let full = NonceFull::from_partial(partial.clone(), &message, &accounts, &rent_debits)
-                .unwrap();
+            let full =
+                NonceFull::from_partial(&partial, &message, &accounts, &rent_debits).unwrap();
             assert_eq!(*full.address(), nonce_address);
             assert_eq!(*full.account(), rent_collected_nonce_account);
             assert_eq!(full.lamports_per_signature(), Some(lamports_per_signature));
@@ -252,8 +252,8 @@ mod tests {
                 ),
             ];
 
-            let full = NonceFull::from_partial(partial.clone(), &message, &accounts, &rent_debits)
-                .unwrap();
+            let full =
+                NonceFull::from_partial(&partial, &message, &accounts, &rent_debits).unwrap();
             assert_eq!(*full.address(), nonce_address);
             assert_eq!(*full.account(), nonce_account);
             assert_eq!(full.lamports_per_signature(), Some(lamports_per_signature));
@@ -264,7 +264,7 @@ mod tests {
         {
             let message = new_sanitized_message(&instructions, Some(&nonce_address));
             assert_eq!(
-                NonceFull::from_partial(partial, &message, &[], &RentDebits::default())
+                NonceFull::from_partial(&partial, &message, &[], &RentDebits::default())
                     .unwrap_err(),
                 TransactionError::AccountNotFound,
             );

--- a/rpc/src/transaction_status_service.rs
+++ b/rpc/src/transaction_status_service.rs
@@ -365,7 +365,7 @@ pub(crate) mod tests {
             inner_instructions: None,
             durable_nonce_fee: Some(DurableNonceFee::from(
                 &NonceFull::from_partial(
-                    rollback_partial,
+                    &rollback_partial,
                     &SanitizedMessage::Legacy(LegacyMessage::new(message)),
                     &[(pubkey, nonce_account)],
                     &rent_debits,

--- a/runtime/src/accounts/mod.rs
+++ b/runtime/src/accounts/mod.rs
@@ -49,7 +49,7 @@ pub(super) fn load_accounts(
     accounts_db: &AccountsDb,
     ancestors: &Ancestors,
     txs: &[SanitizedTransaction],
-    lock_results: Vec<TransactionCheckResult>,
+    lock_results: &[TransactionCheckResult],
     hash_queue: &BlockhashQueue,
     error_counters: &mut TransactionErrorMetrics,
     rent_collector: &RentCollector,
@@ -123,7 +123,7 @@ pub(super) fn load_accounts(
 
                 (Ok(loaded_transaction), nonce)
             }
-            (_, (Err(e), _nonce)) => (Err(e), None),
+            (_, (Err(e), _nonce)) => (Err(e.clone()), None),
         })
         .collect()
 }
@@ -544,7 +544,7 @@ mod tests {
             &accounts.accounts_db,
             &ancestors,
             &[sanitized_tx],
-            vec![(Ok(()), None)],
+            &[(Ok(()), None)],
             &hash_queue,
             error_counters,
             rent_collector,
@@ -1022,7 +1022,7 @@ mod tests {
             &accounts.accounts_db,
             &ancestors,
             &[tx],
-            vec![(Ok(()), None)],
+            &[(Ok(()), None)],
             &hash_queue,
             &mut error_counters,
             &rent_collector,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5179,7 +5179,7 @@ impl Bank {
             &self.rc.accounts.accounts_db,
             &self.ancestors,
             sanitized_txs,
-            check_results,
+            &check_results,
             &self.blockhash_queue.read().unwrap(),
             &mut error_counters,
             &self.rent_collector,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10989,7 +10989,7 @@ fn test_rent_state_list_len() {
         &bank.accounts().accounts_db,
         &bank.ancestors,
         &[sanitized_tx.clone()],
-        vec![(Ok(()), None)],
+        &[(Ok(()), None)],
         &bank.blockhash_queue.read().unwrap(),
         &mut error_counters,
         &bank.rent_collector,


### PR DESCRIPTION
This is in preparation for further refactoring of
Bank::load_and_execute_transactions in a separate commit. #34893
