### PR TITLE
v1.17: Pin spl-token-cli to 3.3.0

### DIFF
--- a/scripts/spl-token-cli-version.sh
+++ b/scripts/spl-token-cli-version.sh
@@ -1,5 +1,5 @@
 # populate this on the stable branch
-splTokenCliVersion=
+splTokenCliVersion=3.3.0
 
 maybeSplTokenCliVersionArg=
 if [[ -n "$splTokenCliVersion" ]]; then


### PR DESCRIPTION
#### Problem

v1.17 has become the stable branch, but it hasn't pinned a version of `spl-token-cli` to build.

#### Summary of Changes

Pin to the current latest version, which is 3.3.0.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
