### PR TITLE
Updates mergify backport actions for new minor version

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -95,51 +95,14 @@ pull_request_rules:
           - automerge
       comment:
         message: automerge label removed due to a CI failure
-  - name: v1.16 feature-gate backport
-    conditions:
-      - label=v1.16
-      - label=feature-gate
-    actions:
-      backport:
-        assignees: &BackportAssignee
-          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        labels:
-          - feature-gate
-        branches:
-          - v1.16
-  - name: v1.16 non-feature-gate backport
-    conditions:
-      - label=v1.16
-      - label!=feature-gate
-    actions:
-      backport:
-        assignees: *BackportAssignee
-        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
-        ignore_conflicts: true
-        branches:
-          - v1.16
-  - name: v1.16 backport warning comment
-    conditions:
-      - label=v1.16
-    actions:
-      comment:
-        message: >
-          Backports to the stable branch are to be avoided unless absolutely
-          necessary for fixing bugs, security issues, and perf regressions.
-          Changes intended for backport should be structured such that a
-          minimum effective diff can be committed separately from any
-          refactoring, plumbing, cleanup, etc that are not strictly
-          necessary to achieve the goal. Any of the latter should go only
-          into master and ride the normal stabilization schedule.
   - name: v1.17 feature-gate backport
     conditions:
       - label=v1.17
       - label=feature-gate
     actions:
       backport:
-        assignees: *BackportAssignee
+        assignees: &BackportAssignee
+          - "{{ merged_by|replace('mergify[bot]', label|select('equalto', 'community')|first|default(author)|replace('community', '@solana-labs/community-pr-subscribers')) }}"
         title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
         ignore_conflicts: true
         labels:
@@ -160,6 +123,43 @@ pull_request_rules:
   - name: v1.17 backport warning comment
     conditions:
       - label=v1.17
+    actions:
+      comment:
+        message: >
+          Backports to the stable branch are to be avoided unless absolutely
+          necessary for fixing bugs, security issues, and perf regressions.
+          Changes intended for backport should be structured such that a
+          minimum effective diff can be committed separately from any
+          refactoring, plumbing, cleanup, etc that are not strictly
+          necessary to achieve the goal. Any of the latter should go only
+          into master and ride the normal stabilization schedule.
+  - name: v1.18 feature-gate backport
+    conditions:
+      - label=v1.18
+      - label=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        labels:
+          - feature-gate
+        branches:
+          - v1.18
+  - name: v1.18 non-feature-gate backport
+    conditions:
+      - label=v1.18
+      - label!=feature-gate
+    actions:
+      backport:
+        assignees: *BackportAssignee
+        title: "{{ destination_branch }}: {{ title }} (backport of #{{ number }})"
+        ignore_conflicts: true
+        branches:
+          - v1.18
+  - name: v1.18 backport warning comment
+    conditions:
+      - label=v1.18
     actions:
       comment:
         message: >


### PR DESCRIPTION
#### Problem

There is a v1.18 branch, but no v1.18 backport label.


#### Summary of Changes

Add v1.18 backport actions. (Used https://github.com/solana-labs/solana/pull/33490/ as a template.)