### PR TITLE
accounts-cluster-bench: Break early when a max-accounts limit is reached

### DIFF
--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -873,14 +873,14 @@ fn main() {
             Arg::with_name("num_instructions")
                 .long("num-instructions")
                 .takes_value(true)
-                .value_name("NUM")
+                .value_name("NUM_INSTRUCTIONS")
                 .help("Number of accounts to create on each transaction"),
         )
         .arg(
             Arg::with_name("iterations")
                 .long("iterations")
                 .takes_value(true)
-                .value_name("NUM")
+                .value_name("NUM_ITERATIONS")
                 .help("Number of iterations to make. 0 = unlimited iterations."),
         )
         .arg(
@@ -892,6 +892,7 @@ fn main() {
             Arg::with_name("mint")
                 .long("mint")
                 .takes_value(true)
+                .value_name("MINT_ADDRESS")
                 .help("Mint address to initialize account"),
         )
         .arg(
@@ -904,12 +905,14 @@ fn main() {
             Arg::with_name("num_rpc_bench_threads")
                 .long("num-rpc-bench-threads")
                 .takes_value(true)
+                .value_name("NUM_THREADS")
                 .help("Spawn this many RPC benching threads for each type passed by --rpc-bench"),
         )
         .arg(
             Arg::with_name("rpc_bench")
                 .long("rpc-bench")
                 .takes_value(true)
+                .value_name("RPC_BENCH_TYPE(S)")
                 .multiple(true)
                 .help("Spawn a thread which calls a specific RPC method in a loop to benchmark it"),
         )

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -699,9 +699,14 @@ fn run_accounts_bench(
             last_log = Instant::now();
         }
         if iterations != 0 && count >= iterations {
+            info!("{iterations} iterations reached");
             break;
         }
         if max_accounts_met {
+            info!(
+                "Max account limit of {:?} reached",
+                max_accounts.unwrap_or_default()
+            );
             break;
         }
         if executor.num_outstanding() >= batch_size {

--- a/accounts-cluster-bench/src/main.rs
+++ b/accounts-cluster-bench/src/main.rs
@@ -683,7 +683,15 @@ fn run_accounts_bench(
         }
 
         count += 1;
-        if last_log.elapsed().as_millis() > 3000 || (count >= iterations && iterations != 0) {
+        let max_accounts_met = if let Some(max_accounts) = max_accounts {
+            total_accounts_created >= max_accounts
+        } else {
+            false
+        };
+        if last_log.elapsed().as_millis() > 3000
+            || (count >= iterations && iterations != 0)
+            || max_accounts_met
+        {
             info!(
                 "total_accounts_created: {} total_accounts_closed: {} tx_sent_count: {} loop_count: {} balance(s): {:?}",
                 total_accounts_created, total_accounts_closed, tx_sent_count, count, balances
@@ -693,10 +701,8 @@ fn run_accounts_bench(
         if iterations != 0 && count >= iterations {
             break;
         }
-        if let Some(max_accounts) = max_accounts {
-            if total_accounts_created >= max_accounts {
-                break;
-            }
+        if max_accounts_met {
+            break;
         }
         if executor.num_outstanding() >= batch_size {
             sleep(Duration::from_millis(500));


### PR DESCRIPTION
#### Problem
While `solana-accounts-cluster-bench` can be halted early using the `--iterations` arg, if the actual goal is some number of accounts, this requires cumbersome mathing of iterations with the batch size and number of instructions per transaction. It would be nice to have a simple cli argument that halts the client when a limit is reached.

#### Summary of Changes
Add `--max-accounts` cli arg and break out of accounts-bench loop when reached. Because of the async nature of the TransactionExecutor, the exact number of accounts that were created may vary from the limit set. If more precision is needed, tune `--iterations` instead.
