### PR TITLE
ledger-tool: Add additional modes for accounts subcommand

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -1346,6 +1346,15 @@ fn main() {
                             "Limit output to accounts corresponding to the specified pubkey(s), \
                             may be specified multiple times",
                         ),
+                )
+                .arg(
+                    Arg::with_name("program_accounts")
+                        .long("program-accounts")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_pubkey)
+                        .conflicts_with("account")
+                        .help("Limit output to accounts owned by the provided program pubkey"),
                 ),
         )
         .subcommand(
@@ -2192,9 +2201,14 @@ fn main() {
                     let include_account_contents = !arg_matches.is_present("no_account_contents");
                     let include_account_data = !arg_matches.is_present("no_account_data");
                     let account_data_encoding = parse_encoding_format(arg_matches);
-                    let mode = if let Some(accounts) = pubkeys_of(arg_matches, "account") {
-                        AccountsOutputMode::IndividualAccounts(accounts)
+                    let mode = if let Some(pubkeys) = pubkeys_of(arg_matches, "account") {
+                        info!("Scanning individual accounts: {pubkeys:?}");
+                        AccountsOutputMode::IndividualAccounts(pubkeys)
+                    } else if let Some(pubkey) = pubkey_of(arg_matches, "program_accounts") {
+                        info!("Scanning program accounts for {pubkey}");
+                        AccountsOutputMode::ProgramAccounts(pubkey)
                     } else {
+                        info!("Scanning all accounts");
                         AccountsOutputMode::AllAccounts
                     };
                     let config = AccountsOutputConfig {

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -6,7 +6,9 @@ use {
         blockstore::*,
         ledger_path::*,
         ledger_utils::*,
-        output::{output_account, AccountsOutputConfig, AccountsOutputStreamer},
+        output::{
+            output_account, AccountsOutputConfig, AccountsOutputMode, AccountsOutputStreamer,
+        },
         program::*,
     },
     clap::{
@@ -1311,6 +1313,7 @@ fn main() {
                 .arg(&geyser_plugin_args)
                 .arg(&accounts_data_encoding_arg)
                 .arg(&use_snapshot_archives_at_startup)
+                .arg(&max_genesis_archive_unpacked_size_arg)
                 .arg(
                     Arg::with_name("include_sysvars")
                         .long("include-sysvars")
@@ -1332,7 +1335,18 @@ fn main() {
                         .takes_value(false)
                         .help("Do not print account data when printing account contents."),
                 )
-                .arg(&max_genesis_archive_unpacked_size_arg),
+                .arg(
+                    Arg::with_name("account")
+                        .long("account")
+                        .takes_value(true)
+                        .value_name("PUBKEY")
+                        .validator(is_pubkey)
+                        .multiple(true)
+                        .help(
+                            "Limit output to accounts corresponding to the specified pubkey(s), \
+                            may be specified multiple times",
+                        ),
+                ),
         )
         .subcommand(
             SubCommand::with_name("capitalization")
@@ -2178,7 +2192,13 @@ fn main() {
                     let include_account_contents = !arg_matches.is_present("no_account_contents");
                     let include_account_data = !arg_matches.is_present("no_account_data");
                     let account_data_encoding = parse_encoding_format(arg_matches);
+                    let mode = if let Some(accounts) = pubkeys_of(arg_matches, "account") {
+                        AccountsOutputMode::IndividualAccounts(accounts)
+                    } else {
+                        AccountsOutputMode::AllAccounts
+                    };
                     let config = AccountsOutputConfig {
+                        mode,
                         include_sysvars,
                         include_account_contents,
                         include_account_data,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2203,13 +2203,13 @@ fn main() {
                     let account_data_encoding = parse_encoding_format(arg_matches);
                     let mode = if let Some(pubkeys) = pubkeys_of(arg_matches, "account") {
                         info!("Scanning individual accounts: {pubkeys:?}");
-                        AccountsOutputMode::IndividualAccounts(pubkeys)
+                        AccountsOutputMode::Individual(pubkeys)
                     } else if let Some(pubkey) = pubkey_of(arg_matches, "program_accounts") {
                         info!("Scanning program accounts for {pubkey}");
-                        AccountsOutputMode::ProgramAccounts(pubkey)
+                        AccountsOutputMode::Program(pubkey)
                     } else {
                         info!("Scanning all accounts");
-                        AccountsOutputMode::AllAccounts
+                        AccountsOutputMode::All
                     };
                     let config = AccountsOutputConfig {
                         mode,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6763,8 +6763,16 @@ impl Bank {
     // pro: safer assertion can be enabled inside AccountsDb
     // con: panics!() if called from off-chain processing
     pub fn get_account_with_fixed_root(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
-        self.load_slow_with_fixed_root(&self.ancestors, pubkey)
+        self.get_account_modified_slot_with_fixed_root(pubkey)
             .map(|(acc, _slot)| acc)
+    }
+
+    // See note above get_account_with_fixed_root() about when to prefer this function
+    pub fn get_account_modified_slot_with_fixed_root(
+        &self,
+        pubkey: &Pubkey,
+    ) -> Option<(AccountSharedData, Slot)> {
+        self.load_slow_with_fixed_root(&self.ancestors, pubkey)
     }
 
     pub fn get_account_modified_slot(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {


### PR DESCRIPTION
#### Problem
The `accounts` subcommand currently dumps every single account. This is very intensive and overkill for some situations, such as wanting to know the state of a single account.

#### Summary of Changes
This change adds two flags to limit the output of the command to either:
- A set of accounts specified by `--account <PUBKEY>`; multiple pubkeys can be passed
- A set of accounts owned by a program account specified by `--program-account <PUBKEY>`

Here is some sample output running with `--output json` (piped through `jq .` to pretty print):
<details>
<summary>--account 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on </summary>

```
{
  "accounts": [
    {
      "pubkey": "5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on",
      "account": {
        "lamports": 43871930671716,
        "data": [
          "",
          "base64"
        ],
        "owner": "11111111111111111111111111111111",
        "executable": false,
        "rentEpoch": 18446744073709552000,
        "space": 0
      }
    }
  ],
  "summary": {
    "num_accounts": 1,
    "data_len": 0,
    "num_executable_accounts": 0,
    "executable_data_len": 0,
    "num_rent_exempt_accounts": 1,
    "num_rent_paying_accounts": 0,
    "num_rent_paying_accounts_without_data": 0,
    "lamports_in_rent_paying_accounts": 0
  }
}
```

</details>

<details>
<summary>--account 5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on ... </summary>

```
{
  "accounts": [
    {
      "pubkey": "5D1fNXzvv5NjV1ysLjirC4WY92RNsVH18vjmcszZd8on",
      "account": {
        "lamports": 43871930671716,
        "data": [
          "",
          "base64"
        ],
        "owner": "11111111111111111111111111111111",
        "executable": false,
        "rentEpoch": 18446744073709552000,
        "space": 0
      }
    },
    {
      "pubkey": "J7v9ndmcoBuo9to2MnHegLnBkC9x3SAVbQBJo5MMJrN1",
      "account": {
        "lamports": 147636514192370,
        "data": [
          "",
          "base64"
        ],
        "owner": "11111111111111111111111111111111",
        "executable": false,
        "rentEpoch": 18446744073709552000,
        "space": 0
      }
    }
  ],
  "summary": {
    "num_accounts": 2,
    "data_len": 0,
    "num_executable_accounts": 0,
    "executable_data_len": 0,
    "num_rent_exempt_accounts": 2,
    "num_rent_paying_accounts": 0,
    "num_rent_paying_accounts_without_data": 0,
    "lamports_in_rent_paying_accounts": 0
  }
}
```

</details>

<details>
<summary>--program-account Vote111111111111111111111111111111111111111</summary>

```
{
  "accounts": [
      ...    
  ],
  "summary": {
    "num_accounts": 9698,
    "data_len": 36315112,
    "num_executable_accounts": 0,
    "executable_data_len": 0,
    "num_rent_exempt_accounts": 9698,
    "num_rent_paying_accounts": 0,
    "num_rent_paying_accounts_without_data": 0,
    "lamports_in_rent_paying_accounts": 0
  }
}
```

</details>