### PR TITLE
[TieredStorage] Have HotStorageWriter::write_account() return Vec<StoredAccountInfo>

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -551,7 +551,8 @@ impl HotStorageWriter {
 
         // writing accounts blocks
         let len = accounts.accounts.len();
-        let mut stored_infos = Vec::with_capacity(len - skip);
+        let total_input_accounts = len - skip;
+        let mut stored_infos = Vec::with_capacity(total_input_accounts);
         for i in skip..len {
             let (account, address, account_hash, _write_version) = accounts.get(i);
             let index_entry = AccountIndexWriterEntry {
@@ -601,7 +602,7 @@ impl HotStorageWriter {
             });
             index.push(index_entry);
         }
-        footer.account_entry_count = (len - skip) as u32;
+        footer.account_entry_count = total_input_accounts as u32;
 
         // writing index block
         // expect the offset of each block aligned.
@@ -1311,7 +1312,7 @@ pub mod tests {
                     acc.owner(),
                     acc.data(),
                     acc.executable(),
-                    // only persist rent_epoch for those non-rent-exempt accounts
+                    // only persist rent_epoch for those rent-paying accounts
                     Some(*account_hash),
                 )
             })

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -593,12 +593,13 @@ impl HotStorageWriter {
                 // is to store AccountOffset instead, which can further save
                 // one jump from the index block to the accounts block.
                 offset: index.len(),
-                // The size here might be slightly bigger than the actual
-                // storage size of one account as one owner address could be
-                // shared by multiple accounts.
+                // Here we only include the stored size that the account directly
+                // contribute (i.e., account entry + index entry that include the
+                // account meta, data, optional fields, its address, and AccountOffset).
+                // Storage size from those shared blocks like footer and owners block
+                // is not included.
                 size: stored_size
-                    + footer.index_block_format.entry_size::<HotAccountOffset>()
-                    + std::mem::size_of::<Pubkey>(),
+                    + footer.index_block_format.entry_size::<HotAccountOffset>(),
             });
             index.push(index_entry);
         }

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -598,8 +598,7 @@ impl HotStorageWriter {
                 // account meta, data, optional fields, its address, and AccountOffset).
                 // Storage size from those shared blocks like footer and owners block
                 // is not included.
-                size: stored_size
-                    + footer.index_block_format.entry_size::<HotAccountOffset>(),
+                size: stored_size + footer.index_block_format.entry_size::<HotAccountOffset>(),
             });
             index.push(index_entry);
         }


### PR DESCRIPTION
#### Problem
To allow hot-storage to use HotStorageWriter::write_account() to
implement AccountsFile::append_accounts(), it is required to
provide a Vector of StoredAccountInfo to allow AccountsDB to
properly prepare the entry for each account.

#### Summary of Changes
This PR enables HotStorageWriter::write_account() to return
Vec<StoredAccountInfo>.

#### Test Plan
Extend existing tests for HotStorageWriter to verify the correctness
of the returned Vec<StoredAccountInfo>.


