### PR TITLE
Cli: Return final transaction signature in solana program deploy

### DIFF
--- a/cli-output/src/cli_output.rs
+++ b/cli-output/src/cli_output.rs
@@ -2075,6 +2075,7 @@ impl fmt::Display for CliTokenAccount {
 #[serde(rename_all = "camelCase")]
 pub struct CliProgramId {
     pub program_id: String,
+    pub signature: Option<String>,
 }
 
 impl QuietDisplay for CliProgramId {}
@@ -2082,7 +2083,12 @@ impl VerboseDisplay for CliProgramId {}
 
 impl fmt::Display for CliProgramId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln_name_value(f, "Program Id:", &self.program_id)
+        writeln_name_value(f, "Program Id:", &self.program_id)?;
+        if let Some(ref signature) = self.signature {
+            writeln!(f)?;
+            writeln_name_value(f, "Signature:", signature)?;
+        }
+        Ok(())
     }
 }
 

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -636,6 +636,7 @@ pub fn process_deploy_program(
 
     let program_id = CliProgramId {
         program_id: program_address.to_string(),
+        signature: None,
     };
     Ok(config.output_format.formatted_string(&program_id))
 }
@@ -690,6 +691,7 @@ fn process_undeploy_program(
 
     let program_id = CliProgramId {
         program_id: program_address.to_string(),
+        signature: None,
     };
     Ok(config.output_format.formatted_string(&program_id))
 }
@@ -716,6 +718,7 @@ fn process_finalize_program(
 
     let program_id = CliProgramId {
         program_id: program_address.to_string(),
+        signature: None,
     };
     Ok(config.output_format.formatted_string(&program_id))
 }


### PR DESCRIPTION
#### Problem
As outlined in #34830, `solana program deploy` operations do not return a relevant transaction signature, although it might appear temporarily on stderr. It is quite convenient to keep track of the exact transaction in which a program was upgraded in order to better document its evolution and write tools which are compatible with its entire transaction history, even through breaking changes.

#### Summary of Changes

- Adds a new optional `transaction` field to the `cli_output::CliProgramId` return struct.
- Patches `program::send_deploy_messages` to return this final transaction signature.

Fixes #34830

