### PR TITLE
ledger-tool: Minor cleanup on --ignore-ulimit-nofile-error flag

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -843,7 +843,7 @@ fn main() {
         .arg(
             Arg::with_name("ignore_ulimit_nofile_error")
                 .long("ignore-ulimit-nofile-error")
-                .value_name("FORMAT")
+                .takes_value(false)
                 .global(true)
                 .help(
                     "Allow opening the blockstore to succeed even if the desired open file \


### PR DESCRIPTION
#### Problem
This argument is a flag and doesn't take a value; however, it had the .value_name() modifier set with "FORMAT". This could be confusing so remove .value_name() and add .takes_value(false).

Here is the only place where this argument is read; note that it checks for presence and not value:
https://github.com/solana-labs/solana/blob/b04765f8b582a3156bf009307708e3c9701cea8d/ledger-tool/src/ledger_utils.rs#L428

Before:
```
        --ignore-ulimit-nofile-error <FORMAT>
            Allow opening the blockstore to succeed even if the desired open file descriptor limit cannot be configured.
            Use with caution as some commands may run fine with a reduced file descriptor limit while others will not
```
After:
```
        --ignore-ulimit-nofile-error    Allow opening the blockstore to succeed even if the desired open file descriptor
                                        limit cannot be configured. Use with caution as some commands may run fine with
                                        a reduced file descriptor limit while others will not
```