### PR TITLE
Skip creating reward partition account for `--partitioned-epoch-rewards-force-enable-single-slot` 

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3634,7 +3634,7 @@ impl Bank {
         .unwrap();
 
         info!(
-            "create epoch_reward partition data account {} {address} {epoch_rewards_partition_data:#?}", self.slot
+            "create epoch rewards partition data account {} {address} {epoch_rewards_partition_data:?}", self.slot
         );
         self.store_account_and_update_capitalization(&address, &new_account);
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1637,7 +1637,8 @@ impl Bank {
         // (total_rewards, distributed_rewards, credit_end_exclusive), total capital will increase by (total_rewards - distributed_rewards)
         self.create_epoch_rewards_sysvar(total_rewards, distributed_rewards, credit_end_exclusive);
 
-        // Skip creating data account when we are testing partitioned rewards
+        // Skip creating data account when we are testing partitioned
+        // rewards but feature is not yet active
         let should_create = self.is_partitioned_rewards_code_enabled()
             || !self.force_partition_rewards_in_first_block_of_epoch();
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1533,11 +1533,7 @@ impl Bank {
         // After saving a snapshot of stakes, apply stake rewards and commission
         let (_, update_rewards_with_thread_pool_time) = measure!(
             {
-                if self.is_partitioned_rewards_feature_enabled()
-                    || self
-                        .partitioned_epoch_rewards_config()
-                        .test_enable_partitioned_rewards
-                {
+                if self.is_partitioned_rewards_code_enabled() {
                     self.begin_partitioned_rewards(
                         reward_calc_tracer,
                         &thread_pool,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1630,7 +1630,7 @@ impl Bank {
         // (total_rewards, distributed_rewards, credit_end_exclusive), total capital will increase by (total_rewards - distributed_rewards)
         self.create_epoch_rewards_sysvar(total_rewards, distributed_rewards, credit_end_exclusive);
 
-        // Skip creating reward partition account when we are testing partitioned reward against mainnet.
+        // Skip creating data account when we are testing partitioned rewards
         let skip_reward_partition_account = !self.is_partitioned_rewards_feature_enabled()
             && (self
                 .partitioned_epoch_rewards_config()


### PR DESCRIPTION
#### Problem

A follow up PR from https://github.com/solana-labs/solana/pull/34809

We can run the validator against mainnet with the new partitioned reward code by enabling `--partitioned-epoch-rewards-force-enable-single-slot` CLI argument. 

Recently, my test node running with the above CLI fails on account hash mismatch. It turns out that the mismatch is coming from the new partition reward account introduced at the epoch, i.e. https://github.com/solana-labs/solana/pull/34624.

In https://github.com/solana-labs/solana/pull/34809, we solve this problem by ignoring the PDA accounts for account hash, bank capital and bank hash. This works but it is too *hacky*. And it turns out that keeping the PDA accounts doesn't provide any other benefit to test the related `getInflactionReward` RPC method.

Therefore, we want a simpler fix.

#### Summary of Changes

- skip creating reward partition account when we are testing partitioned reward against mainnet with `--partitioned-epoch-rewards-force-enable-single-slot` 
- log when creating reward partition account


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
