### PR TITLE
Use ThreadLocalMultiIterator for tests

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -343,6 +343,7 @@ impl ValidatorConfig {
         Self {
             enforce_ulimit_nofile: false,
             rpc_config: JsonRpcConfig::default_for_test(),
+            block_production_method: BlockProductionMethod::ThreadLocalMultiIterator,
             ..Self::default()
         }
     }

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2268,7 +2268,7 @@ fn test_hard_fork_with_gap_in_roots() {
 
     let validator_config = ValidatorConfig {
         snapshot_config: LocalCluster::create_dummy_load_only_snapshot_config(),
-        ..ValidatorConfig::default()
+        ..ValidatorConfig::default_for_test()
     };
     let mut config = ClusterConfig {
         cluster_lamports: 100_000,
@@ -5236,7 +5236,7 @@ fn test_duplicate_shreds_switch_failure() {
                 validator_keypair,
                 validator_config: ValidatorConfig {
                     voting_disabled,
-                    ..ValidatorConfig::default()
+                    ..ValidatorConfig::default_for_test()
                 },
                 in_genesis,
             }


### PR DESCRIPTION
#### Problem
- Some local-cluster tests rely on transaction forwarding by the leaders in order to run in a timely manner: https://discord.com/channels/428295358100013066/560503042458517505/1199965947285487636

#### Summary of Changes
- Use the MI method for block-production, which will do forwarding, while proper fixes in the client's used by tests are worked on.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
