### PR TITLE
Remove unused get_append_vec_id function

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9786,12 +9786,6 @@ pub mod tests {
     }
 
     impl AccountsDb {
-        pub fn get_append_vec_id(&self, pubkey: &Pubkey, slot: Slot) -> Option<AppendVecId> {
-            let ancestors = vec![(slot, 1)].into_iter().collect();
-            let result = self.accounts_index.get(pubkey, Some(&ancestors), None);
-            result.map(|(list, index)| list.slot_list()[index].1.store_id())
-        }
-
         fn scan_snapshot_stores(
             &self,
             storage: &SortedStorages,


### PR DESCRIPTION
#### Problem

While looking at https://github.com/solana-labs/solana/pull/34918 and auditing where we clone the Arc from account index, I find that get_append_vec_id does clone the Arc. However, it is not used anywhere.

https://github.com/solana-labs/solana/pull/34918#issuecomment-1908755604

Looks like it is left-over from previous code.




#### Summary of Changes

- remove unused get_append_vec_id fn


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
