### PR TITLE
Adds hit/miss stats for cache hash data

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7149,6 +7149,29 @@ impl AccountsDb {
             })
             .collect::<Vec<_>>();
 
+        // Calculate the hits and misses of the hash data files cache.
+        // This is outside of the parallel loop above so that we only need to
+        // update each atomic stat value once.
+        // There are approximately 173 items in the cache files list,
+        // so should be very fast to iterate and compute.
+        // (173 cache files == 432,000 slots / 2,5000 slots-per-cache-file)
+        let mut hits = 0;
+        let mut misses = 0;
+        for cache_file in &cache_files {
+            match cache_file {
+                ScanAccountStorageResult::CacheFileAlreadyExists(_) => hits += 1,
+                ScanAccountStorageResult::CacheFileNeedsToBeCreated(_) => misses += 1,
+            };
+        }
+        cache_hash_data
+            .stats
+            .hits
+            .fetch_add(hits, Ordering::Relaxed);
+        cache_hash_data
+            .stats
+            .misses
+            .fetch_add(misses, Ordering::Relaxed);
+
         // deletes the old files that will not be used before creating new ones
         cache_hash_data.delete_old_cache_files();
 

--- a/accounts-db/src/cache_hash_data_stats.rs
+++ b/accounts-db/src/cache_hash_data_stats.rs
@@ -15,6 +15,10 @@ pub struct CacheHashDataStats {
     pub load_us: AtomicU64,
     pub read_us: AtomicU64,
     pub unused_cache_files: AtomicUsize,
+    /// the number of hash data files that were found in the cache and reused
+    pub hits: AtomicUsize,
+    /// the number of hash data files that were not found in the cache
+    pub misses: AtomicUsize,
 }
 
 impl CacheHashDataStats {
@@ -69,6 +73,8 @@ impl CacheHashDataStats {
                 self.unused_cache_files.load(Ordering::Relaxed),
                 i64
             ),
+            ("hits", self.hits.load(Ordering::Relaxed), i64),
+            ("misses", self.misses.load(Ordering::Relaxed), i64),
         );
     }
 }


### PR DESCRIPTION
#### Problem

When create/using the account hash data cache, we don't know easily how many hits and misses there were.


#### Summary of Changes

Add metrics for the number of hits and misses.