### PR TITLE
Refactor remove unnecessary rounding

### DIFF
--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -92,13 +92,12 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
+        _unused: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
         self.calculate_fee_details(
             message,
-            lamports_per_signature,
             budget_limits,
             include_loaded_account_data_size_in_fee,
         )
@@ -110,7 +109,6 @@ impl FeeStructure {
     pub fn calculate_fee_details(
         &self,
         message: &SanitizedMessage,
-        _lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> FeeDetails {

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -146,10 +146,9 @@ impl FeeStructure {
             });
 
         FeeDetails {
-            transaction_fee: (signature_fee
+            transaction_fee: signature_fee
                 .saturating_add(write_lock_fee)
-                .saturating_add(compute_fee) as f64)
-                .round() as u64,
+                .saturating_add(compute_fee),
             prioritization_fee: budget_limits.prioritization_fee,
         }
     }


### PR DESCRIPTION
#### Problem

A call to `round()` was left behind after removing congestion_multipler.

#### Summary of Changes
- remove it.
- rename an unused parameter

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
