### PR TITLE
[TieredStorage] Correct the HotStorage API for account_matches_owners

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -361,7 +361,7 @@ impl HotStorageReader {
     pub fn account_matches_owners(
         &self,
         account_offset: HotAccountOffset,
-        owners: &[&Pubkey],
+        owners: &[Pubkey],
     ) -> Result<usize, MatchAccountOwnerError> {
         let account_meta = self
             .get_account_meta_from_offset(account_offset)
@@ -376,7 +376,7 @@ impl HotStorageReader {
 
             owners
                 .iter()
-                .position(|candidate| &account_owner == candidate)
+                .position(|candidate| account_owner == candidate)
                 .ok_or(MatchAccountOwnerError::NoMatch)
         }
     }
@@ -1065,7 +1065,7 @@ pub mod tests {
         let hot_storage = HotStorageReader::new_from_path(&path).unwrap();
 
         // First, verify whether we can find the expected owners.
-        let mut owner_candidates: Vec<_> = owner_addresses.iter().collect();
+        let mut owner_candidates = owner_addresses.clone();
         owner_candidates.shuffle(&mut rng);
 
         for (account_offset, account_meta) in account_offsets.iter().zip(hot_account_metas.iter()) {
@@ -1074,16 +1074,15 @@ pub mod tests {
                 .unwrap();
             assert_eq!(
                 owner_candidates[index],
-                &owner_addresses[account_meta.owner_offset().0 as usize]
+                owner_addresses[account_meta.owner_offset().0 as usize]
             );
         }
 
         // Second, verify the MatchAccountOwnerError::NoMatch case
         const NUM_UNMATCHED_OWNERS: usize = 20;
-        let unmatched_owners: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
+        let unmatched_candidates: Vec<_> = std::iter::repeat_with(Pubkey::new_unique)
             .take(NUM_UNMATCHED_OWNERS)
             .collect();
-        let unmatched_candidates: Vec<_> = unmatched_owners.iter().collect();
 
         for account_offset in account_offsets.iter() {
             assert_eq!(
@@ -1103,7 +1102,7 @@ pub mod tests {
                 .unwrap();
             assert_eq!(
                 owner_candidates[index],
-                &owner_addresses[account_meta.owner_offset().0 as usize]
+                owner_addresses[account_meta.owner_offset().0 as usize]
             );
         }
     }


### PR DESCRIPTION
#### Problem
In HotStorageReader, the account_matches_owners takes
&[&Pubkey] as the address candidates.  However, it should
be &[Pubkey] as defined in the accounts_file API.

#### Summary of Changes
Correct HotStorageReader::account_matches_owners() to
take &[Pubkey] instead.

#### Test Plan
Existing unit-tests