### PR TITLE
[TS] Add get_account() and account_matches_owner() to TieredStorageReader

### DIFF
--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -326,7 +326,7 @@ impl HotStorageReader {
     }
 
     /// Returns the offset to the account given the specified index.
-    pub(crate) fn get_account_offset(
+    pub(super) fn get_account_offset(
         &self,
         index_offset: IndexOffset,
     ) -> TieredStorageResult<HotAccountOffset> {

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -326,7 +326,7 @@ impl HotStorageReader {
     }
 
     /// Returns the offset to the account given the specified index.
-    fn get_account_offset(
+    pub(crate) fn get_account_offset(
         &self,
         index_offset: IndexOffset,
     ) -> TieredStorageResult<HotAccountOffset> {


### PR DESCRIPTION
#### Problem
TieredStorageReader is a wrapper enum that works for
both Hot and Cold storage readers, but its get_account()
and account_matches_owner() API are missing.

#### Summary of Changes
Add get_account() and account_matches_owner() to
TieredStorageReader.

#### Test Plan
hot.rs offers similar coverage for HotStorageReader.
