### PR TITLE
refactor unused parameter

### DIFF
--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -92,13 +92,12 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        lamports_per_signature: u64,
+        _unused: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
         self.calculate_fee_details(
             message,
-            lamports_per_signature,
             budget_limits,
             include_loaded_account_data_size_in_fee,
         )
@@ -110,7 +109,6 @@ impl FeeStructure {
     pub fn calculate_fee_details(
         &self,
         message: &SanitizedMessage,
-        _lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> FeeDetails {


### PR DESCRIPTION
#### Problem

A unused parameter in newly added public api.

#### Summary of Changes
- remove it from new API, rename to "unused" for original api.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
