### PR TITLE
solana-program: only decode prior_voters if needed

### DIFF
--- a/sdk/program/src/serialize_utils/cursor.rs
+++ b/sdk/program/src/serialize_utils/cursor.rs
@@ -61,6 +61,15 @@ pub(crate) fn read_pubkey<T: AsRef<[u8]>>(
     Ok(Pubkey::from(buf))
 }
 
+pub(crate) fn read_bool<T: AsRef<[u8]>>(cursor: &mut Cursor<T>) -> Result<bool, InstructionError> {
+    let byte = read_u8(cursor)?;
+    match byte {
+        0 => Ok(false),
+        1 => Ok(true),
+        _ => Err(InstructionError::InvalidAccountData),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use {super::*, rand::Rng, std::fmt::Debug};
@@ -113,6 +122,12 @@ mod test {
             let test_value = Pubkey::from(buf);
             test_read(read_pubkey, test_value);
         }
+    }
+
+    #[test]
+    fn test_read_bool() {
+        test_read(read_bool, false);
+        test_read(read_bool, true);
     }
 
     fn test_read<T: Debug + PartialEq + serde::Serialize + borsh0_10::BorshSerialize>(

--- a/sdk/program/src/vote/state/vote_state_deserialize.rs
+++ b/sdk/program/src/vote/state/vote_state_deserialize.rs
@@ -5,6 +5,7 @@ use {
         serialize_utils::cursor::*,
         vote::state::{BlockTimestamp, LandedVote, Lockout, VoteState, MAX_ITEMS},
     },
+    bincode::serialized_size,
     std::io::Cursor,
 };
 
@@ -66,33 +67,45 @@ fn read_prior_voters_into<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
     vote_state: &mut VoteState,
 ) -> Result<(), InstructionError> {
-    let mut encountered_null_voter = false;
-    for i in 0..MAX_ITEMS {
-        let prior_voter = read_pubkey(cursor)?;
-        let from_epoch = read_u64(cursor)?;
-        let until_epoch = read_u64(cursor)?;
-        let item = (prior_voter, from_epoch, until_epoch);
+    // record our position at the start of the struct
+    let prior_voters_position = cursor.position();
 
-        if item == (Pubkey::default(), 0, 0) {
-            encountered_null_voter = true;
-        } else if encountered_null_voter {
-            // `prior_voters` should never be sparse
-            return Err(InstructionError::InvalidAccountData);
-        } else {
-            vote_state.prior_voters.buf[i] = item;
+    // `serialized_size()` must be used over `mem::size_of()` because of alignment
+    let is_empty_position = serialized_size(&vote_state.prior_voters)
+        .ok()
+        .and_then(|v| v.checked_add(prior_voters_position))
+        .and_then(|v| v.checked_sub(1))
+        .ok_or(InstructionError::InvalidAccountData)?;
+
+    // move to the end, to check if we need to parse the data
+    cursor.set_position(is_empty_position);
+
+    // if empty, we already read past the end of this struct and need to do no further work
+    // otherwise we go back to the start and proceed to decode the data
+    let is_empty = read_bool(cursor)?;
+    if !is_empty {
+        cursor.set_position(prior_voters_position);
+
+        let mut encountered_null_voter = false;
+        for i in 0..MAX_ITEMS {
+            let prior_voter = read_pubkey(cursor)?;
+            let from_epoch = read_u64(cursor)?;
+            let until_epoch = read_u64(cursor)?;
+            let item = (prior_voter, from_epoch, until_epoch);
+
+            if item == (Pubkey::default(), 0, 0) {
+                encountered_null_voter = true;
+            } else if encountered_null_voter {
+                // `prior_voters` should never be sparse
+                return Err(InstructionError::InvalidAccountData);
+            } else {
+                vote_state.prior_voters.buf[i] = item;
+            }
         }
+
+        vote_state.prior_voters.idx = read_u64(cursor)? as usize;
+        vote_state.prior_voters.is_empty = read_bool(cursor)?;
     }
-
-    let idx = read_u64(cursor)? as usize;
-    vote_state.prior_voters.idx = idx;
-
-    let is_empty_byte = read_u8(cursor)?;
-    let is_empty = match is_empty_byte {
-        0 => false,
-        1 => true,
-        _ => return Err(InstructionError::InvalidAccountData),
-    };
-    vote_state.prior_voters.is_empty = is_empty;
 
     Ok(())
 }


### PR DESCRIPTION
#### Problem
originally i wrote the `VoteState` parse to check `is_empty` and skip parsing `prior_voters` if it was empty. later i got rid of this as unnecessary complexity. however it turns out `prior_voters` may be fully half the CU cost of a typical vote account, 7-8k vs 15-16k total

#### Summary of Changes
add this logic back in for a 50% efficiency gain if `prior_voters` is empty, which is more likely than not. i wrote this to only operate with the cursor, rather than the raw input bytes, per jons suggestion

also i added bounds checking to the cursor before and after; while writing this, i discovered `Cursor` successfully returns 0 rather than erroring if it runs out of bounds. also i fixed a mistake with the tests where insufficient data was generated, making coverage of the full struct basically nil