### PR TITLE
rpc: disable BigTable with header

### DIFF
--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -218,6 +218,15 @@ pub struct JsonRpcRequestProcessor {
 impl Metadata for JsonRpcRequestProcessor {}
 
 impl JsonRpcRequestProcessor {
+    pub fn clone_without_bigtable(&self) -> JsonRpcRequestProcessor {
+        Self {
+            bigtable_ledger_storage: None, // Disable BigTable
+            ..self.clone()
+        }
+    }
+}
+
+impl JsonRpcRequestProcessor {
     fn get_bank_with_config(&self, config: RpcContextConfig) -> Result<Arc<Bank>> {
         let RpcContextConfig {
             commitment,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -523,7 +523,14 @@ impl JsonRpcService {
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,
-                    move |_req: &hyper::Request<hyper::Body>| request_processor.clone(),
+                    move |req: &hyper::Request<hyper::Body>| {
+                        let xbigtable = req.headers().get("x-bigtable");
+                        if xbigtable.map(|v| v == "disabled").unwrap_or(false) {
+                            request_processor.clone_without_bigtable()
+                        } else {
+                            request_processor.clone()
+                        }
+                    },
                 )
                 .event_loop_executor(runtime.handle().clone())
                 .threads(1)


### PR DESCRIPTION
#### Problem

By default, all RPC queries can reach BigTable if they need more data. In some cases, it can be good to control should we reach BigTable or not. For example, we can use cache layers after `solana-validator`, like `old-faithful` / S3-like storage / local disk. In https://triton.one/ we do this with `x-bigtable` header (our docs: https://docs.triton.one/chains/solana/old-faithful-historical-archive-1). Probably it would be good to add it to upstream so all providers can support this feature.

#### Summary of Changes

Add extra clone method for `x-bigtable` header.