### PR TITLE
Removes unused parameters from AccountsHashVerifier::new()

### DIFF
--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -10,7 +10,6 @@ use {
         },
         sorted_storages::SortedStorages,
     },
-    solana_gossip::cluster_info::ClusterInfo,
     solana_measure::measure_us,
     solana_runtime::{
         serde_snapshot::BankIncrementalSnapshotPersistence,
@@ -46,8 +45,6 @@ impl AccountsHashVerifier {
         accounts_package_receiver: Receiver<AccountsPackage>,
         snapshot_package_sender: Option<Sender<SnapshotPackage>>,
         exit: Arc<AtomicBool>,
-        _cluster_info: Arc<ClusterInfo>,
-        _accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
         snapshot_config: SnapshotConfig,
     ) -> Self {
         // If there are no accounts packages to process, limit how often we re-check

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -778,8 +778,6 @@ impl Validator {
             accounts_package_receiver,
             snapshot_package_sender,
             exit.clone(),
-            cluster_info.clone(),
-            config.accounts_hash_fault_injector,
             config.snapshot_config.clone(),
         );
 

--- a/core/tests/epoch_accounts_hash.rs
+++ b/core/tests/epoch_accounts_hash.rs
@@ -197,8 +197,6 @@ impl BackgroundServices {
             accounts_package_receiver,
             Some(snapshot_package_sender),
             exit.clone(),
-            cluster_info,
-            None,
             snapshot_config.clone(),
         );
 

--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -1044,8 +1044,6 @@ fn test_snapshots_with_background_services(
         accounts_package_receiver,
         Some(snapshot_package_sender),
         exit.clone(),
-        cluster_info,
-        None,
         snapshot_test_config.snapshot_config.clone(),
     );
 

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -12,7 +12,6 @@ use {
     solana_geyser_plugin_manager::geyser_plugin_service::{
         GeyserPluginService, GeyserPluginServiceError,
     },
-    solana_gossip::{cluster_info::ClusterInfo, contact_info::ContactInfo},
     solana_ledger::{
         bank_forks_utils::{self, BankForksUtilsError},
         blockstore::{Blockstore, BlockstoreError},
@@ -41,10 +40,9 @@ use {
         },
     },
     solana_sdk::{
-        clock::Slot, genesis_config::GenesisConfig, pubkey::Pubkey, signature::Signer,
-        signer::keypair::Keypair, timing::timestamp, transaction::VersionedTransaction,
+        clock::Slot, genesis_config::GenesisConfig, pubkey::Pubkey,
+        transaction::VersionedTransaction,
     },
-    solana_streamer::socket::SocketAddrSpace,
     solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{
         path::{Path, PathBuf},
@@ -315,20 +313,12 @@ pub fn load_and_process_ledger(
         }
     }
 
-    let node_id = Arc::new(Keypair::new());
-    let cluster_info = Arc::new(ClusterInfo::new(
-        ContactInfo::new_localhost(&node_id.pubkey(), timestamp()),
-        Arc::clone(&node_id),
-        SocketAddrSpace::Unspecified,
-    ));
     let (accounts_package_sender, accounts_package_receiver) = crossbeam_channel::unbounded();
     let accounts_hash_verifier = AccountsHashVerifier::new(
         accounts_package_sender.clone(),
         accounts_package_receiver,
         None,
         exit.clone(),
-        cluster_info,
-        None,
         SnapshotConfig::new_load_only(),
     );
     let (snapshot_request_sender, snapshot_request_receiver) = crossbeam_channel::unbounded();


### PR DESCRIPTION
#### Problem

Follow up from https://github.com/solana-labs/solana/pull/34971, `AccountsHashVerifier::new()` has unused parameters that can be removed.


#### Summary of Changes

Remove 'em.