### PR TITLE
SVM: Move `TransactionAccountStateInfo` to svm and decouple from `bank`

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11014,8 +11014,12 @@ fn test_rent_state_list_len() {
     );
 
     assert_eq!(
-        bank.get_transaction_account_state_info(&transaction_context, sanitized_tx.message())
-            .len(),
+        TransactionAccountStateInfo::new(
+            &bank.rent_collector.rent,
+            &transaction_context,
+            sanitized_tx.message()
+        )
+        .len(),
         num_accounts,
     );
 }

--- a/runtime/src/svm/mod.rs
+++ b/runtime/src/svm/mod.rs
@@ -1,2 +1,3 @@
 pub mod account_loader;
 pub mod account_rent_state;
+pub mod transaction_account_state_info;


### PR DESCRIPTION
#### Problem
`TransactionAccountStateInfo` is only used by transaction processing code in SVM. It can be moved to the `svm` folder and cleaned up to remove dependency on `Bank`.

#### Summary of Changes
Move to svm, and remove `Bank` deps.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
