### PR TITLE
SDK: refactor `Signer` and `Signers` traits

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1796,7 +1796,11 @@ mod tests {
         let keypair0_pubkey = keypair0.pubkey();
         let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
         let keypair0_clone_pubkey = keypair0.pubkey();
-        let signers = vec![None, Some(keypair0.into()), Some(keypair0_clone.into())];
+        let signers: Vec<Option<Box<dyn Signer>>> = vec![
+            None,
+            Some(Box::new(keypair0)),
+            Some(Box::new(keypair0_clone)),
+        ];
         let signer_info = default_signer
             .generate_unique_signers(signers, &matches, &mut None)
             .unwrap();
@@ -1808,7 +1812,8 @@ mod tests {
         let keypair0 = keypair_from_seed(&[1u8; 32]).unwrap();
         let keypair0_pubkey = keypair0.pubkey();
         let keypair0_clone = keypair_from_seed(&[1u8; 32]).unwrap();
-        let signers = vec![Some(keypair0.into()), Some(keypair0_clone.into())];
+        let signers: Vec<Option<Box<dyn Signer>>> =
+            vec![Some(Box::new(keypair0)), Some(Box::new(keypair0_clone))];
         let signer_info = default_signer
             .generate_unique_signers(signers, &matches, &mut None)
             .unwrap();
@@ -1825,11 +1830,11 @@ mod tests {
         let presigner0_pubkey = presigner0.pubkey();
         let presigner1 = Presigner::new(&keypair1.pubkey(), &keypair1.sign_message(&message));
         let presigner1_pubkey = presigner1.pubkey();
-        let signers = vec![
-            Some(keypair0.into()),
-            Some(presigner0.into()),
-            Some(presigner1.into()),
-            Some(keypair1.into()),
+        let signers: Vec<Option<Box<dyn Signer>>> = vec![
+            Some(Box::new(keypair0)),
+            Some(Box::new(presigner0)),
+            Some(Box::new(presigner1)),
+            Some(Box::new(keypair1)),
         ];
         let signer_info = default_signer
             .generate_unique_signers(signers, &matches, &mut None)
@@ -1913,7 +1918,7 @@ mod tests {
                     pubkey: None,
                     use_lamports_unit: true,
                 },
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -1978,7 +1983,7 @@ mod tests {
                     seed: "seed".to_string(),
                     program_id: stake::program::id(),
                 },
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -2020,7 +2025,7 @@ mod tests {
                 command: CliCommand::SignOffchainMessage {
                     message: message.clone()
                 },
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -2040,7 +2045,7 @@ mod tests {
                     signature,
                     message
                 },
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
     }
@@ -2460,7 +2465,7 @@ mod tests {
                     derived_address_program_id: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2488,7 +2493,7 @@ mod tests {
                     derived_address_program_id: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2521,7 +2526,7 @@ mod tests {
                     derived_address_program_id: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2557,7 +2562,7 @@ mod tests {
                     derived_address_program_id: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2601,7 +2606,7 @@ mod tests {
                     derived_address_program_id: None,
                     compute_unit_price: None,
                 },
-                signers: vec![Presigner::new(&from_pubkey, &from_sig).into()],
+                signers: vec![Box::new(Presigner::new(&from_pubkey, &from_sig))],
             }
         );
 
@@ -2647,8 +2652,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&nonce_authority_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&nonce_authority_file).unwrap())
                 ],
             }
         );
@@ -2686,7 +2691,7 @@ mod tests {
                     derived_address_program_id: Some(stake::program::id()),
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap()),],
             }
         );
     }

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -2399,7 +2399,7 @@ mod tests {
                     print_timestamp: true,
                     compute_unit_price: None,
                 },
-                signers: vec![default_keypair.into()],
+                signers: vec![Box::new(default_keypair)],
             }
         );
     }

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -728,7 +728,7 @@ mod tests {
                     new_authority: Pubkey::default(),
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -752,8 +752,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -777,8 +777,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap())
                 ],
             }
         );
@@ -804,8 +804,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap())
                 ],
             }
         );
@@ -839,7 +839,7 @@ mod tests {
                     memo: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -862,8 +862,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -909,7 +909,7 @@ mod tests {
                     lamports: 42_000_000_000,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -940,8 +940,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -986,8 +986,8 @@ mod tests {
                     compute_unit_price: Some(99),
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );

--- a/cli/src/program.rs
+++ b/cli/src/program.rs
@@ -2789,7 +2789,7 @@ mod tests {
                     allow_excessive_balance: false,
                     skip_fee_check: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -2817,7 +2817,7 @@ mod tests {
                     allow_excessive_balance: false,
                     skip_fee_check: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -2848,8 +2848,8 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&buffer_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&buffer_keypair_file).unwrap()),
                 ],
             }
         );
@@ -2879,7 +2879,7 @@ mod tests {
                     allow_excessive_balance: false,
                     skip_fee_check: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -2911,8 +2911,8 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&program_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&program_keypair_file).unwrap()),
                 ],
             }
         );
@@ -2945,8 +2945,8 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -2974,7 +2974,7 @@ mod tests {
                     skip_fee_check: false,
                     allow_excessive_balance: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
     }
@@ -3008,7 +3008,7 @@ mod tests {
                     max_len: None,
                     skip_fee_check: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3033,7 +3033,7 @@ mod tests {
                     max_len: Some(42),
                     skip_fee_check: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3062,8 +3062,8 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&buffer_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&buffer_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3093,8 +3093,8 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3129,9 +3129,9 @@ mod tests {
                     skip_fee_check: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&buffer_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&buffer_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3175,7 +3175,7 @@ mod tests {
                     dump_transaction_message: true,
                     blockhash_query: BlockhashQuery::new(Some(blockhash), true, None),
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3203,7 +3203,7 @@ mod tests {
                     dump_transaction_message: false,
                     blockhash_query: BlockhashQuery::default(),
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3236,10 +3236,8 @@ mod tests {
                     blockhash_query: BlockhashQuery::new(Some(blockhash), true, None),
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&new_authority_pubkey_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&new_authority_pubkey_file).unwrap()),
                 ],
             }
         );
@@ -3266,7 +3264,7 @@ mod tests {
                     dump_transaction_message: false,
                     blockhash_query: BlockhashQuery::default(),
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3295,8 +3293,8 @@ mod tests {
                     blockhash_query: BlockhashQuery::default(),
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3330,7 +3328,7 @@ mod tests {
                     buffer_authority_index: Some(0),
                     new_buffer_authority: new_authority_pubkey,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3354,7 +3352,7 @@ mod tests {
                     buffer_authority_index: Some(0),
                     new_buffer_authority: new_authority_keypair.pubkey(),
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
     }
@@ -3521,7 +3519,7 @@ mod tests {
                     use_lamports_unit: false,
                     bypass_warning: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3544,7 +3542,7 @@ mod tests {
                     use_lamports_unit: false,
                     bypass_warning: true,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
 
@@ -3569,8 +3567,8 @@ mod tests {
                     bypass_warning: false,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3594,7 +3592,7 @@ mod tests {
                     use_lamports_unit: false,
                     bypass_warning: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap()),],
             }
         );
 
@@ -3616,7 +3614,7 @@ mod tests {
                     use_lamports_unit: true,
                     bypass_warning: false,
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap()),],
             }
         );
     }
@@ -3648,7 +3646,7 @@ mod tests {
                     program_pubkey,
                     additional_bytes
                 }),
-                signers: vec![read_keypair_file(&keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&keypair_file).unwrap())],
             }
         );
     }

--- a/cli/src/program_v4.rs
+++ b/cli/src/program_v4.rs
@@ -1666,9 +1666,9 @@ mod tests {
                     authority_signer_index: 2,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&program_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&program_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -1712,8 +1712,8 @@ mod tests {
                     buffer_signer_index: None,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -1744,9 +1744,9 @@ mod tests {
                     authority_signer_index: 2,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&buffer_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&buffer_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -1787,8 +1787,8 @@ mod tests {
                     authority_signer_index: 1,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -1829,8 +1829,8 @@ mod tests {
                     authority_signer_index: 1,
                 }),
                 signers: vec![
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap())
                 ],
             }
         );

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -2874,7 +2874,7 @@ mod tests {
                     no_wait: false,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap()),],
             },
         );
         let (withdraw_authority_keypair_file, mut tmp_file) = make_tmp_file();
@@ -2924,13 +2924,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -2977,10 +2973,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3013,7 +3007,7 @@ mod tests {
                     no_wait: false,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap()),],
             },
         );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
@@ -3048,10 +3042,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3088,10 +3080,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3124,7 +3114,7 @@ mod tests {
                     no_wait: false,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap()),],
             },
         );
         let test_stake_authorize = test_commands.clone().get_matches_from(vec![
@@ -3159,10 +3149,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3198,7 +3186,7 @@ mod tests {
                     no_wait: true,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -3246,8 +3234,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3298,14 +3286,10 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3352,11 +3336,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3390,8 +3372,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3427,11 +3409,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3468,11 +3448,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3506,8 +3484,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3543,11 +3521,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             },
         );
@@ -3584,8 +3560,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authority_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authority_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3625,7 +3601,7 @@ mod tests {
                     no_wait: false,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
         // Test Authorize Subcommand w/ offline feepayer
@@ -3672,8 +3648,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&pubkey, &sig).into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&pubkey, &sig))
                 ],
             }
         );
@@ -3728,9 +3704,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&pubkey, &sig).into(),
-                    Presigner::new(&pubkey2, &sig2).into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&pubkey, &sig)),
+                    Box::new(Presigner::new(&pubkey2, &sig2)),
                 ],
             }
         );
@@ -3769,7 +3745,7 @@ mod tests {
                     no_wait: false,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
         // Test Authorize Subcommand w/ nonce
@@ -3817,8 +3793,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    nonce_authority_keypair.into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(nonce_authority_keypair)
                 ],
             }
         );
@@ -3860,8 +3836,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&fee_payer_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&fee_payer_keypair_file).unwrap()),
                 ],
             }
         );
@@ -3907,8 +3883,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&fee_payer_pubkey, &sig).into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&fee_payer_pubkey, &sig))
                 ],
             }
         );
@@ -3958,8 +3934,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    stake_account_keypair.into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(stake_account_keypair)
                 ],
             }
         );
@@ -3999,8 +3975,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap())
                 ],
             }
         );
@@ -4039,9 +4015,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    stake_account_keypair.into(),
-                    withdrawer_keypair.into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(stake_account_keypair),
+                    Box::new(withdrawer_keypair),
                 ],
             }
         );
@@ -4112,8 +4088,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    Presigner::new(&offline_pubkey, &offline_sig).into(),
-                    read_keypair_file(&keypair_file).unwrap().into()
+                    Box::new(Presigner::new(&offline_pubkey, &offline_sig)),
+                    Box::new(read_keypair_file(&keypair_file).unwrap())
                 ],
             }
         );
@@ -4145,7 +4121,7 @@ mod tests {
                     redelegation_stake_account: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4179,10 +4155,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -4213,7 +4187,7 @@ mod tests {
                     redelegation_stake_account: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4249,7 +4223,7 @@ mod tests {
                     redelegation_stake_account: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4280,7 +4254,7 @@ mod tests {
                     redelegation_stake_account: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4322,8 +4296,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&key1, &sig1).into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&key1, &sig1))
                 ],
             }
         );
@@ -4372,9 +4346,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&key1, &sig1).into(),
-                    Presigner::new(&key2, &sig2).into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&key1, &sig1)),
+                    Box::new(Presigner::new(&key2, &sig2)),
                 ],
             }
         );
@@ -4410,8 +4384,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&fee_payer_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&fee_payer_keypair_file).unwrap())
                 ],
             }
         );
@@ -4453,10 +4427,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&redelegation_stake_account_keypair_file)
-                        .unwrap()
-                        .into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&redelegation_stake_account_keypair_file).unwrap())
                 ],
             }
         );
@@ -4489,7 +4461,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4523,7 +4495,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: Some(99),
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4558,10 +4530,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -4597,8 +4567,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&custodian_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&custodian_keypair_file).unwrap())
                 ],
             }
         );
@@ -4647,10 +4617,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into(),
-                    Presigner::new(&offline_pubkey, &offline_sig).into()
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&offline_pubkey, &offline_sig))
                 ],
             }
         );
@@ -4678,7 +4646,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4706,7 +4674,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4736,10 +4704,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&stake_authority_keypair_file)
-                        .unwrap()
-                        .into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&stake_authority_keypair_file).unwrap())
                 ],
             }
         );
@@ -4774,7 +4740,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4803,7 +4769,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -4843,8 +4809,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&key1, &sig1).into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&key1, &sig1))
                 ],
             }
         );
@@ -4891,9 +4857,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    Presigner::new(&key1, &sig1).into(),
-                    Presigner::new(&key2, &sig2).into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(Presigner::new(&key1, &sig1)),
+                    Box::new(Presigner::new(&key2, &sig2)),
                 ],
             }
         );
@@ -4924,8 +4890,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&fee_payer_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&fee_payer_keypair_file).unwrap())
                 ],
             }
         );
@@ -4965,10 +4931,8 @@ mod tests {
                     rent_exempt_reserve: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&split_stake_account_keypair_file).unwrap())
                 ],
             }
         );
@@ -5033,11 +4997,9 @@ mod tests {
                     rent_exempt_reserve: None,
                 },
                 signers: vec![
-                    Presigner::new(&stake_auth_pubkey, &stake_sig).into(),
-                    Presigner::new(&nonce_auth_pubkey, &nonce_sig).into(),
-                    read_keypair_file(&split_stake_account_keypair_file)
-                        .unwrap()
-                        .into(),
+                    Box::new(Presigner::new(&stake_auth_pubkey, &stake_sig)),
+                    Box::new(Presigner::new(&nonce_auth_pubkey, &nonce_sig)),
+                    Box::new(read_keypair_file(&split_stake_account_keypair_file).unwrap()),
                 ],
             }
         );
@@ -5070,7 +5032,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into(),],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap()),],
             }
         );
     }

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -1517,7 +1517,7 @@ mod tests {
                     new_authorized: None,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -1551,8 +1551,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authorized_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authorized_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1586,8 +1586,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authorized_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authorized_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1635,8 +1635,11 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    Presigner::new(&pubkey2, &sig2).into(),
-                    Presigner::new(&authorized_keypair.pubkey(), &authorized_sig).into(),
+                    Box::new(Presigner::new(&pubkey2, &sig2)),
+                    Box::new(Presigner::new(
+                        &authorized_keypair.pubkey(),
+                        &authorized_sig
+                    )),
                 ],
             }
         );
@@ -1672,8 +1675,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&voter_keypair_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&voter_keypair_file).unwrap())
                 ],
             }
         );
@@ -1704,9 +1707,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&authorized_keypair_file).unwrap().into(),
-                    read_keypair_file(&voter_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&authorized_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&voter_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1758,9 +1761,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1792,9 +1795,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1833,9 +1836,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1886,10 +1889,10 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    Presigner::new(&identity_keypair.pubkey(), &identity_sig).into(),
-                    Presigner::new(&pubkey2, &sig2).into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(Presigner::new(&identity_keypair.pubkey(), &identity_sig)),
+                    Box::new(Presigner::new(&pubkey2, &sig2)),
                 ],
             }
         );
@@ -1929,9 +1932,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
                     Box::new(keypair),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1968,9 +1971,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&keypair_file).unwrap().into(),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -1999,9 +2002,9 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
-                    read_keypair_file(&identity_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&identity_keypair_file).unwrap()),
                 ],
             }
         );
@@ -2030,7 +2033,7 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
                     Box::new(read_keypair_file(&keypair_file).unwrap()),
                 ],
             }
@@ -2061,7 +2064,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2090,7 +2093,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2125,8 +2128,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_file).unwrap())
                 ],
             }
         );
@@ -2163,7 +2166,9 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&withdraw_authority_file).unwrap().into()],
+                signers: vec![Box::new(
+                    read_keypair_file(&withdraw_authority_file).unwrap()
+                )],
             }
         );
 
@@ -2204,7 +2209,10 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![Presigner::new(&withdraw_authority.pubkey(), &authorized_sig).into(),],
+                signers: vec![Box::new(Presigner::new(
+                    &withdraw_authority.pubkey(),
+                    &authorized_sig
+                )),],
             }
         );
 
@@ -2226,7 +2234,7 @@ mod tests {
                     fee_payer: 0,
                     compute_unit_price: None,
                 },
-                signers: vec![read_keypair_file(&default_keypair_file).unwrap().into()],
+                signers: vec![Box::new(read_keypair_file(&default_keypair_file).unwrap())],
             }
         );
 
@@ -2254,8 +2262,8 @@ mod tests {
                     compute_unit_price: None,
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_file).unwrap())
                 ],
             }
         );
@@ -2286,8 +2294,8 @@ mod tests {
                     compute_unit_price: Some(99),
                 },
                 signers: vec![
-                    read_keypair_file(&default_keypair_file).unwrap().into(),
-                    read_keypair_file(&withdraw_authority_file).unwrap().into()
+                    Box::new(read_keypair_file(&default_keypair_file).unwrap()),
+                    Box::new(read_keypair_file(&withdraw_authority_file).unwrap())
                 ],
             }
         );

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -85,7 +85,7 @@ pub trait Signer {
     fn is_interactive(&self) -> bool;
 }
 
-/// This impl allows using Signer with types like Box/Rc/Arc.
+/// This implements `Signer` for all ptr types - `Box/Rc/Arc/&/&mut` etc
 impl<Container: Deref<Target = impl Signer + ?Sized>> Signer for Container {
     #[inline]
     fn pubkey(&self) -> Pubkey {

--- a/sdk/src/signer/mod.rs
+++ b/sdk/src/signer/mod.rs
@@ -85,17 +85,8 @@ pub trait Signer {
     fn is_interactive(&self) -> bool;
 }
 
-impl<T> From<T> for Box<dyn Signer>
-where
-    T: Signer + 'static,
-{
-    fn from(signer: T) -> Self {
-        Box::new(signer)
-    }
-}
-
 /// This impl allows using Signer with types like Box/Rc/Arc.
-impl<Container: Deref<Target = impl Signer>> Signer for Container {
+impl<Container: Deref<Target = impl Signer + ?Sized>> Signer for Container {
     #[inline]
     fn pubkey(&self) -> Pubkey {
         self.deref().pubkey()

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -14,14 +14,14 @@ pub trait Signers {
     fn is_interactive(&self) -> bool;
 }
 
-/// Any `T` where `&T` impls `IntoIterator` yielding
-/// references to `Signer`s implements `Signers`.
+/// Any `T` where `T` impls `IntoIterator` yielding
+/// `Signer`s implements `Signers`.
 ///
 /// This includes [&dyn Signer], [Box<dyn Signer>],
 /// [&dyn Signer; N], Vec<dyn Signer>, Vec<Keypair>, etc.
 ///
-/// When used as a generic function param, `&S`
-/// should be used instead of `S` where S: Signers, due to the `?Sized` bounds on T.
+/// When used as a generic function param, `&T`
+/// should be used instead of `T` where T: Signers, due to the `?Sized` bounds on T.
 /// E.g. [Signer] implements `Signers`, but `&[Signer]` does not
 impl<T: ?Sized, S: Signer + ?Sized> Signers for T
 where

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -17,8 +17,12 @@ pub trait Signers {
 /// Any `T` where `&T` impls `IntoIterator` yielding
 /// references to `Signer`s implements `Signers`.
 ///
-/// This includes [&dyn Signer], &[Box<dyn Signer>],
-/// [&dyn Signer; N], Vec<dyn Signer>, Vec<Keypair>, HashSet<Box<dyn Signer>> etc
+/// This includes [&dyn Signer], [Box<dyn Signer>],
+/// [&dyn Signer; N], Vec<dyn Signer>, Vec<Keypair>, etc.
+/// 
+/// When used as a generic function param, `&S`
+/// should be used instead of `S` where S: Signers, due to the `?Sized` bounds on T.
+/// E.g. [Signer] implements `Signers`, but `&[Signer]` does not
 impl<T: ?Sized, S: Signer + ?Sized> Signers for T
 where
     for<'a> &'a T: IntoIterator<Item = &'a S>,

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -19,7 +19,7 @@ pub trait Signers {
 ///
 /// This includes [&dyn Signer], [Box<dyn Signer>],
 /// [&dyn Signer; N], Vec<dyn Signer>, Vec<Keypair>, etc.
-/// 
+///
 /// When used as a generic function param, `&S`
 /// should be used instead of `S` where S: Signers, due to the `?Sized` bounds on T.
 /// E.g. [Signer] implements `Signers`, but `&[Signer]` does not
@@ -32,11 +32,9 @@ where
     }
 
     fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError> {
-        let mut pubkeys = Vec::new();
-        for keypair in self.into_iter() {
-            pubkeys.push(keypair.try_pubkey()?);
-        }
-        Ok(pubkeys)
+        self.into_iter()
+            .map(|keypair| keypair.try_pubkey())
+            .collect()
     }
 
     fn sign_message(&self, message: &[u8]) -> Vec<Signature> {
@@ -46,11 +44,9 @@ where
     }
 
     fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError> {
-        let mut signatures = Vec::new();
-        for keypair in self.into_iter() {
-            signatures.push(keypair.try_sign_message(message)?);
-        }
-        Ok(signatures)
+        self.into_iter()
+            .map(|keypair| keypair.try_sign_message(message))
+            .collect()
     }
 
     fn is_interactive(&self) -> bool {

--- a/sdk/src/signer/signers.rs
+++ b/sdk/src/signer/signers.rs
@@ -1,11 +1,8 @@
 #![cfg(feature = "full")]
 
-use {
-    crate::{
-        pubkey::Pubkey,
-        signature::{Signature, Signer, SignerError},
-    },
-    std::sync::Arc,
+use crate::{
+    pubkey::Pubkey,
+    signature::{Signature, Signer, SignerError},
 };
 
 /// Convenience trait for working with mixed collections of `Signer`s
@@ -17,130 +14,86 @@ pub trait Signers {
     fn is_interactive(&self) -> bool;
 }
 
-macro_rules! default_keypairs_impl {
-    () => {
-        fn pubkeys(&self) -> Vec<Pubkey> {
-            self.iter().map(|keypair| keypair.pubkey()).collect()
+/// Do not make any blanket impls for [impl Signer] or Deref<Target = [impl Signer]> for now because
+/// fixed size arrays [T; N] do not implement it yet, but std lib will still
+/// throw conflicting impl bec it might impl it in the future.
+/// This SignerSlice helper trait helps to unify across [T], [T; N], Vec<T> etc
+///
+/// TODO: replace this helper trait
+/// with blanket over [SlicePattern](https://doc.rust-lang.org/stable/core/slice/trait.SlicePattern.html)
+/// or [core::str::Pattern](https://doc.rust-lang.org/stable/core/str/pattern/trait.Pattern.html) once stabilized
+trait SignerSlice {
+    type Item: Signer;
+
+    fn as_signer_slice(&self) -> &[Self::Item];
+}
+
+impl<T: SignerSlice + ?Sized> Signers for T {
+    fn pubkeys(&self) -> Vec<Pubkey> {
+        self.as_signer_slice()
+            .iter()
+            .map(|keypair| keypair.pubkey())
+            .collect()
+    }
+
+    fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError> {
+        let mut pubkeys = Vec::new();
+        for keypair in self.as_signer_slice().iter() {
+            pubkeys.push(keypair.try_pubkey()?);
         }
+        Ok(pubkeys)
+    }
 
-        fn try_pubkeys(&self) -> Result<Vec<Pubkey>, SignerError> {
-            let mut pubkeys = Vec::new();
-            for keypair in self.iter() {
-                pubkeys.push(keypair.try_pubkey()?);
-            }
-            Ok(pubkeys)
+    fn sign_message(&self, message: &[u8]) -> Vec<Signature> {
+        self.as_signer_slice()
+            .iter()
+            .map(|keypair| keypair.sign_message(message))
+            .collect()
+    }
+
+    fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError> {
+        let mut signatures = Vec::new();
+        for keypair in self.as_signer_slice().iter() {
+            signatures.push(keypair.try_sign_message(message)?);
         }
+        Ok(signatures)
+    }
 
-        fn sign_message(&self, message: &[u8]) -> Vec<Signature> {
-            self.iter()
-                .map(|keypair| keypair.sign_message(message))
-                .collect()
-        }
-
-        fn try_sign_message(&self, message: &[u8]) -> Result<Vec<Signature>, SignerError> {
-            let mut signatures = Vec::new();
-            for keypair in self.iter() {
-                signatures.push(keypair.try_sign_message(message)?);
-            }
-            Ok(signatures)
-        }
-
-        fn is_interactive(&self) -> bool {
-            self.iter().any(|s| s.is_interactive())
-        }
-    };
+    fn is_interactive(&self) -> bool {
+        self.as_signer_slice().iter().any(|s| s.is_interactive())
+    }
 }
 
-impl<T: Signer> Signers for [&T] {
-    default_keypairs_impl!();
+impl<T: Signer> SignerSlice for [T] {
+    type Item = T;
+
+    fn as_signer_slice(&self) -> &[Self::Item] {
+        self
+    }
 }
 
-impl Signers for [Box<dyn Signer>] {
-    default_keypairs_impl!();
+impl<T: Signer, const N: usize> SignerSlice for [T; N] {
+    type Item = T;
+
+    fn as_signer_slice(&self) -> &[Self::Item] {
+        self
+    }
 }
 
-impl Signers for Vec<Box<dyn Signer>> {
-    default_keypairs_impl!();
+impl<T: Signer> SignerSlice for Vec<T> {
+    type Item = T;
+
+    fn as_signer_slice(&self) -> &[Self::Item] {
+        self
+    }
 }
 
-impl Signers for [Arc<dyn Signer>] {
-    default_keypairs_impl!();
-}
+impl<S: SignerSlice + ?Sized> SignerSlice for &S {
+    type Item = S::Item;
 
-impl Signers for [Arc<dyn Signer>; 0] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [Arc<dyn Signer>; 1] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [Arc<dyn Signer>; 2] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [Arc<dyn Signer>; 3] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [Arc<dyn Signer>; 4] {
-    default_keypairs_impl!();
-}
-
-impl Signers for Vec<Arc<dyn Signer>> {
-    default_keypairs_impl!();
-}
-
-impl Signers for Vec<&dyn Signer> {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer; 0] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer; 1] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer; 2] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer; 3] {
-    default_keypairs_impl!();
-}
-
-impl Signers for [&dyn Signer; 4] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for [&T; 0] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for [&T; 1] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for [&T; 2] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for [&T; 3] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for [&T; 4] {
-    default_keypairs_impl!();
-}
-
-impl<T: Signer> Signers for Vec<&T> {
-    default_keypairs_impl!();
+    fn as_signer_slice(&self) -> &[Self::Item] {
+        (**self).as_signer_slice()
+    }
 }
 
 #[cfg(test)]

--- a/tokens/src/commands.rs
+++ b/tokens/src/commands.rs
@@ -1850,8 +1850,8 @@ mod tests {
             lockup_date: None,
         }];
         let args = DistributeTokensArgs {
-            sender_keypair: read_keypair_file(sender_keypair_file).unwrap().into(),
-            fee_payer: read_keypair_file(fee_payer).unwrap().into(),
+            sender_keypair: Box::new(read_keypair_file(sender_keypair_file).unwrap()),
+            fee_payer: Box::new(read_keypair_file(fee_payer).unwrap()),
             dry_run: false,
             input_csv: "".to_string(),
             transaction_db: "".to_string(),
@@ -1893,12 +1893,8 @@ mod tests {
         let unfunded_payer = Keypair::new();
         let unfunded_payer_keypair_file = tmp_file_path("keypair_file", &unfunded_payer.pubkey());
         write_keypair_file(&unfunded_payer, &unfunded_payer_keypair_file).unwrap();
-        args.sender_keypair = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
@@ -1933,12 +1929,9 @@ mod tests {
             .send_and_confirm_transaction_with_spinner(&transaction)
             .unwrap();
 
-        args.sender_keypair = read_keypair_file(&partially_funded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&partially_funded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair =
+            Box::new(read_keypair_file(&partially_funded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&partially_funded_payer_keypair_file).unwrap());
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
                 .unwrap_err();
@@ -1999,10 +1992,8 @@ mod tests {
         let unfunded_payer = Keypair::new();
         let unfunded_payer_keypair_file = tmp_file_path("keypair_file", &unfunded_payer.pubkey());
         write_keypair_file(&unfunded_payer, &unfunded_payer_keypair_file).unwrap();
-        args.sender_keypair = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&sender_keypair_file).unwrap().into();
+        args.sender_keypair = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&sender_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
@@ -2015,10 +2006,8 @@ mod tests {
         }
 
         // Unfunded fee payer
-        args.sender_keypair = read_keypair_file(&sender_keypair_file).unwrap().into();
-        args.fee_payer = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair = Box::new(read_keypair_file(&sender_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
@@ -2145,12 +2134,8 @@ mod tests {
         let unfunded_payer = Keypair::new();
         let unfunded_payer_keypair_file = tmp_file_path("keypair_file", &unfunded_payer.pubkey());
         write_keypair_file(&unfunded_payer, &unfunded_payer_keypair_file).unwrap();
-        args.sender_keypair = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
@@ -2185,12 +2170,9 @@ mod tests {
             .send_and_confirm_transaction_with_spinner(&transaction)
             .unwrap();
 
-        args.sender_keypair = read_keypair_file(&partially_funded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&partially_funded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair =
+            Box::new(read_keypair_file(&partially_funded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&partially_funded_payer_keypair_file).unwrap());
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
                 .unwrap_err();
@@ -2258,10 +2240,8 @@ mod tests {
         let unfunded_payer = Keypair::new();
         let unfunded_payer_keypair_file = tmp_file_path("keypair_file", &unfunded_payer.pubkey());
         write_keypair_file(&unfunded_payer, &unfunded_payer_keypair_file).unwrap();
-        args.sender_keypair = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
-        args.fee_payer = read_keypair_file(&sender_keypair_file).unwrap().into();
+        args.sender_keypair = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&sender_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)
@@ -2274,10 +2254,8 @@ mod tests {
         }
 
         // Unfunded fee payer
-        args.sender_keypair = read_keypair_file(&sender_keypair_file).unwrap().into();
-        args.fee_payer = read_keypair_file(&unfunded_payer_keypair_file)
-            .unwrap()
-            .into();
+        args.sender_keypair = Box::new(read_keypair_file(&sender_keypair_file).unwrap());
+        args.fee_payer = Box::new(read_keypair_file(&unfunded_payer_keypair_file).unwrap());
 
         let err_result =
             check_payer_balances(&[one_signer_message(&client)], &allocations, &client, &args)


### PR DESCRIPTION
#### Problem

See #34983

#### Summary of Changes
- Remove `From` blanket impl for `Signer`
- add `?Sized` trait bound to blanket impl for `Signer` for `Box<dyn Signer>`
- retain `Deref` blanket impl for `Signer`
- refactor `Signers` to blanket impl for all types where their references impls `IntoIterator` yielding `Signer` refs

Fixes #34983
Fixes #13670