### PR TITLE
Fix bank new_from_field for epoch reward status

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1853,7 +1853,7 @@ impl Bank {
                 fields.epoch,
             ))),
             check_program_modification_slot: false,
-            epoch_reward_status: EpochRewardStatus::default(),
+            epoch_reward_status: fields.epoch_reward_status,
         };
         bank.finish_init(
             genesis_config,

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -411,7 +411,7 @@ mod tests {
             );
 
             // assert epoch_reward_status is the same as the set epoch reward status
-            let epoch_reward_status = bank
+            let epoch_reward_status = dbank
                 .get_epoch_reward_status_to_serialize()
                 .unwrap_or(&EpochRewardStatus::Inactive);
             if let Some(rewards) = epoch_reward_status_active {
@@ -504,7 +504,7 @@ mod tests {
             );
 
             // assert epoch_reward_status is the same as the set epoch reward status
-            let epoch_reward_status = bank
+            let epoch_reward_status = dbank
                 .get_epoch_reward_status_to_serialize()
                 .unwrap_or(&EpochRewardStatus::Inactive);
             if let Some(rewards) = epoch_reward_status_active {
@@ -593,7 +593,7 @@ mod tests {
         assert_eq!(0, dbank.fee_rate_governor.lamports_per_signature);
 
         // epoch_reward status should default to `Inactive`
-        let epoch_reward_status = bank
+        let epoch_reward_status = dbank
             .get_epoch_reward_status_to_serialize()
             .unwrap_or(&EpochRewardStatus::Inactive);
         assert_matches!(epoch_reward_status, EpochRewardStatus::Inactive);


### PR DESCRIPTION
#### Problem

We have a bug when reconstruct the `reward_status` on the bank from deserialized field. 

Bank `new_from_field` is not using deserialized epoch reward status from field to reconstruct the bank.

This should have been caught by our tests. But unfortunately, there is a typo in the test, which didn't catch the bug. 


#### Summary of Changes

- fix bank new_from_field to reconstruct epoch reward status.
- fix bank serde test assert for epoch reward status


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
