### PR TITLE
reduces frequency of the outgoing gossip pull requests

### DIFF
--- a/gossip/..rej
+++ b/gossip/..rej
@@ -1,0 +1,31 @@
+--- cluster_info.rs
++++ cluster_info.rs
+@@ -1795,9 +1795,8 @@ impl ClusterInfo {
+             let value = CrdsValue::new_signed(value, &self.keypair());
+             self.push_message(value);
+         }
+-        let mut generate_pull_requests = true;
+         let run_gossip = move || {
+-            loop {
++            for round in 0u64.. {
+                 let start = timestamp();
+                 if self.contact_debug_interval != 0
+                     && start - last_contact_info_trace > self.contact_debug_interval
+@@ -1834,7 +1833,8 @@ impl ClusterInfo {
+                     &recycler,
+                     &stakes,
+                     &sender,
+-                    generate_pull_requests,
++                    // Generate pull requests once every 10 gossip rounds.
++                    (round % 10) == 0,
+                 );
+                 if exit.load(Ordering::Relaxed) {
+                     return;
+@@ -1858,7 +1858,6 @@ impl ClusterInfo {
+                     let time_left = GOSSIP_SLEEP_MILLIS - elapsed;
+                     sleep(Duration::from_millis(time_left));
+                 }
+-                generate_pull_requests = !generate_pull_requests;
+             }
+         };
+         Builder::new()

--- a/gossip/src/cluster_info.rs
+++ b/gossip/src/cluster_info.rs
@@ -1795,9 +1795,8 @@ impl ClusterInfo {
             let value = CrdsValue::new_signed(value, &self.keypair());
             self.push_message(value);
         }
-        let mut generate_pull_requests = true;
         let run_gossip = move || {
-            loop {
+            for round in 0u64.. {
                 let start = timestamp();
                 if self.contact_debug_interval != 0
                     && start - last_contact_info_trace > self.contact_debug_interval
@@ -1834,7 +1833,8 @@ impl ClusterInfo {
                     &recycler,
                     &stakes,
                     &sender,
-                    generate_pull_requests,
+                    // Generate pull requests once every 10 gossip rounds.
+                    (round % 10) == 0,
                 );
                 if exit.load(Ordering::Relaxed) {
                     return;
@@ -1858,7 +1858,6 @@ impl ClusterInfo {
                     let time_left = GOSSIP_SLEEP_MILLIS - elapsed;
                     sleep(Duration::from_millis(time_left));
                 }
-                generate_pull_requests = !generate_pull_requests;
             }
         };
         Builder::new()

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3343,7 +3343,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     );
 
     let mut votes_on_c_fork = std::collections::BTreeSet::new(); // S4 and S5
-    for _ in 0..100 {
+    for _ in 0..500 {
         sleep(Duration::from_millis(100));
 
         if let Some((last_vote, _)) = last_vote_in_tower(&val_c_ledger_path, &validator_c_pubkey) {
@@ -3371,7 +3371,7 @@ fn do_test_optimistic_confirmation_violation_with_or_without_tower(with_tower: b
     // monitor for actual votes from validator A
     let mut bad_vote_detected = false;
     let mut a_votes = vec![];
-    for _ in 0..100 {
+    for _ in 0..500 {
         sleep(Duration::from_millis(100));
 
         if let Some((last_vote, _)) = last_vote_in_tower(&val_a_ledger_path, &validator_a_pubkey) {


### PR DESCRIPTION
#### Problem
Gossip pull requests are inefficient and expensive.
Recent releases are much better in propagating messages through the push path and do not rely on pull request/responses as much.

#### Summary of Changes
The commit reduces frequency of the outgoing gossip pull requests to once every 10 gossip rounds.

```diff
- The 1st commit is only style change and has no functional change.
- Only the 2nd commit has functional change.
```