### PR TITLE
Use correct fee in `Bank::get_lamports_per_signature`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4000,7 +4000,7 @@ impl Bank {
     }
 
     pub fn get_lamports_per_signature(&self) -> u64 {
-        self.fee_rate_governor.lamports_per_signature
+        self.fee_structure.lamports_per_signature
     }
 
     pub fn get_lamports_per_signature_for_blockhash(&self, hash: &Hash) -> Option<u64> {


### PR DESCRIPTION
#### Problem
`Bank::get_lamports_per_signature` uses the fee from the `FeeRateGovernor` rather than the `FeeStructure`. These two values diverge when blocks have more than 10k signatures.

#### Summary of Changes
Since `FeeRateGovernor` is no longer used for tx fee calculation, use `FeeStructure` instead to match how the runtime actually assesses fees. This primarily fixes the `Consumer::check_fee_payer_unlocked` call-site of `Bank::get_lamports_per_signature`. The only other call-sites are in banks-server/banks-client and tests.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
