### PR TITLE
V1.18 revert #34865

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6660,17 +6660,6 @@ impl Bank {
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* debugging_features */
             ));
-
-        // genesis_config loaded by accounts_db::open_genesis_config() from ledger
-        // has it's lamports_per_signature set to zero; bank sets its value correctly
-        // after the first block with a transaction in it. This is a hack to mimic
-        // the process.
-        let derived_fee_rate_governor =
-            FeeRateGovernor::new_derived(&genesis_config.fee_rate_governor, 0);
-        // new bank's fee_structure.lamports_per_signature should be inline with
-        // what's configured in GenesisConfig
-        self.fee_structure.lamports_per_signature =
-            derived_fee_rate_governor.lamports_per_signature;
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3335,6 +3335,7 @@ fn test_bank_parent_account_spend() {
     let key2 = Keypair::new();
     let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
+    println!("==== amount {}", amount);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());


### PR DESCRIPTION
#34865 introduced a hash mismatch. Reverting for now so testnet can adopt v1.18.1

