### PR TITLE
Avoid account index entry Arc clone in shrinking

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4000,9 +4000,8 @@ impl AccountsDb {
                 |_pubkey, _slot_refs, entry| {
                     // pubkeys in `unrefed_pubkeys` were unref'd in `shrink_collect` above under the assumption that we would shrink everything.
                     // Since shrink is not occurring, we need to addref the pubkeys to get the system back to the prior state since the account still exists at this slot.
-                    if let Some(entry) = entry {
-                        entry.addref();
-                    }
+                    // We also expect that the account index entry must be present in the index.
+                    entry.expect("account index entry must exist").addref();
                     AccountsIndexScanResult::OnlyKeepInMemoryIfDirty
                 },
                 None,

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -4003,14 +4003,10 @@ impl AccountsDb {
                     if let Some(entry) = entry {
                         entry.addref();
                     } else {
-                        // We also expect that the account index entry must be
-                        // present in the index. Log a warning for now. In
-                        // future, we will panic when this happens.
-                        warn!(
-                            "pubkey {} in slot {} is NOT found in account index. \
-                        Likely a bug in account index",
-                            pubkey, slot
-                        );
+                        // We also expect that the accounts index must contain an
+                        // entry for `pubkey`. Log a warning for now. In future,
+                        // we will panic when this happens.
+                        warn!("pubkey {pubkey} in slot {slot} was NOT found in accounts index during shrink");
                         datapoint_warn!(
                             "accounts_db-shink_pubkey_missing_from_index",
                             ("store_slot", slot, i64),


### PR DESCRIPTION
#### Problem

In shrinking, we use `get()` to find the index entry and update refcount. However, getting account index entry will result in an Arc clone.

Similar to https://github.com/solana-labs/solana/pull/34918


#### Summary of Changes

- use `scan` to avoid account's index entry Arc clone in `do_shrink_slot_store`. 



Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
