### PR TITLE
Remove SVM dependency on Bank::should_collect_rent()

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -5370,7 +5370,6 @@ impl Bank {
             self.get_reward_interval(),
             &program_accounts_map,
             &programs_loaded_for_tx_batch.borrow(),
-            self.should_collect_rent(),
         );
         load_time.stop();
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10998,7 +10998,6 @@ fn test_rent_state_list_len() {
         RewardInterval::OutsideInterval,
         &HashMap::new(),
         &LoadedProgramsForTxBatch::default(),
-        true,
     );
 
     let compute_budget = bank.runtime_config.compute_budget.unwrap_or_else(|| {


### PR DESCRIPTION
#### Problem
SVM specific code's dependency on `Bank::should_collect_rent()` can be resolved by looking up `feature_set`. The current dependency is causing unnecessary bindings between bank and SVM.

#### Summary of Changes
Update the code to use `feature_set`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
