### PR TITLE
fix fee resulted bank hash mismatch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6720,17 +6720,6 @@ impl Bank {
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* debugging_features */
             ));
-
-        // genesis_config loaded by accounts_db::open_genesis_config() from ledger
-        // has it's lamports_per_signature set to zero; bank sets its value correctly
-        // after the first block with a transaction in it. This is a hack to mimic
-        // the process.
-        let derived_fee_rate_governor =
-            FeeRateGovernor::new_derived(&genesis_config.fee_rate_governor, 0);
-        // new bank's fee_structure.lamports_per_signature should be inline with
-        // what's configured in GenesisConfig
-        self.fee_structure.lamports_per_signature =
-            derived_fee_rate_governor.lamports_per_signature;
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -92,10 +92,14 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        _unused: u64,
+        for_test_only: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
+        if for_test_only == 0 {
+            return 0;
+        }
+
         self.calculate_fee_details(
             message,
             budget_limits,

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -92,11 +92,11 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        for_test_only: u64,
+        test_fee_rate: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
-        if for_test_only == 0 {
+        if test_fee_rate == 0 {
             return 0;
         }
 


### PR DESCRIPTION
#### Problem
New `bank` not created from parent has its `fee_structure.lamports_per_signature` initialized by genesis_config.fee_rate_governor, which should not be the case if bank is created from snapshot where fee_rate_governor is deserialized.

#### Summary of Changes
For a backport-able fix:
- undo the link between fee_structure and fee_rate_governor for now
- clarify the calculate_fee() parameter that is used for testing only (that doesn't support fee)

Fixes #35008 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
