### PR TITLE
banking stage: remove spammy packet conversion metric

### DIFF
--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -749,7 +749,6 @@ impl ThreadLocalUnprocessedPackets {
                 })
                 .unzip();
 
-        inc_new_counter_info!("banking_stage-packet_conversion", 1);
         let filtered_count = packets_to_process.len().saturating_sub(transactions.len());
         saturating_add_assign!(*total_dropped_packets, filtered_count);
 


### PR DESCRIPTION
#### Problem
Not sure why I added this metric, it doesn't convey any useful information considering we have `packet_conversion_elapsed`.

#### Summary of Changes
Remove it

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
