### PR TITLE
Add vote instruction count metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7638,6 +7638,7 @@ version = "1.18.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "lazy_static",
  "log",
  "num-derive 0.4.1",
  "num-traits",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6602,6 +6602,7 @@ name = "solana-vote-program"
 version = "1.18.0"
 dependencies = [
  "bincode",
+ "lazy_static",
  "log",
  "num-derive 0.4.1",
  "num-traits",

--- a/programs/vote/Cargo.toml
+++ b/programs/vote/Cargo.toml
@@ -11,6 +11,7 @@ edition = { workspace = true }
 
 [dependencies]
 bincode = { workspace = true }
+lazy_static = { workspace = true }
 log = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }

--- a/programs/vote/src/lib.rs
+++ b/programs/vote/src/lib.rs
@@ -10,6 +10,9 @@ extern crate solana_metrics;
 #[macro_use]
 extern crate solana_frozen_abi_macro;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub use solana_sdk::vote::{
     authorized_voters, error as vote_error, instruction as vote_instruction,
     program::{check_id, id},


### PR DESCRIPTION
#### Problem

In https://github.com/solana-labs/solana/pull/24696, we removed the processed vote instruction counters because of spamming. 

However, it is useful to know how many vote instructions per second are processed by the validator. 

#### Summary of Changes

Add vote instruction counter metrics.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
