### PR TITLE
Revert congestion multiplier PRs

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -6720,17 +6720,6 @@ impl Bank {
                 &self.runtime_config.compute_budget.unwrap_or_default(),
                 false, /* debugging_features */
             ));
-
-        // genesis_config loaded by accounts_db::open_genesis_config() from ledger
-        // has it's lamports_per_signature set to zero; bank sets its value correctly
-        // after the first block with a transaction in it. This is a hack to mimic
-        // the process.
-        let derived_fee_rate_governor =
-            FeeRateGovernor::new_derived(&genesis_config.fee_rate_governor, 0);
-        // new bank's fee_structure.lamports_per_signature should be inline with
-        // what's configured in GenesisConfig
-        self.fee_structure.lamports_per_signature =
-            derived_fee_rate_governor.lamports_per_signature;
     }
 
     pub fn set_inflation(&self, inflation: Inflation) {

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -31,19 +31,6 @@ pub struct FeeStructure {
     pub compute_fee_bins: Vec<FeeBin>,
 }
 
-/// Return type of calculate_fee(...)
-#[derive(Debug, Default, Clone, Eq, PartialEq)]
-pub struct FeeDetails {
-    transaction_fee: u64,
-    prioritization_fee: u64,
-}
-
-impl FeeDetails {
-    pub fn total_fee(&self) -> u64 {
-        self.transaction_fee.saturating_add(self.prioritization_fee)
-    }
-}
-
 pub const ACCOUNT_DATA_COST_PAGE_SIZE: u64 = 32_u64.saturating_mul(1024);
 
 impl FeeStructure {
@@ -88,32 +75,15 @@ impl FeeStructure {
             .saturating_mul(heap_cost)
     }
 
+    /// Calculate fee for `SanitizedMessage`
     #[cfg(not(target_os = "solana"))]
     pub fn calculate_fee(
-        &self,
-        message: &SanitizedMessage,
-        lamports_per_signature: u64,
-        budget_limits: &FeeBudgetLimits,
-        include_loaded_account_data_size_in_fee: bool,
-    ) -> u64 {
-        self.calculate_fee_details(
-            message,
-            lamports_per_signature,
-            budget_limits,
-            include_loaded_account_data_size_in_fee,
-        )
-        .total_fee()
-    }
-
-    /// Calculate fee details for `SanitizedMessage`
-    #[cfg(not(target_os = "solana"))]
-    pub fn calculate_fee_details(
         &self,
         message: &SanitizedMessage,
         _lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
-    ) -> FeeDetails {
+    ) -> u64 {
         let signature_fee = message
             .num_signatures()
             .saturating_mul(self.lamports_per_signature);
@@ -145,13 +115,12 @@ impl FeeStructure {
                     .unwrap_or_default()
             });
 
-        FeeDetails {
-            transaction_fee: (signature_fee
-                .saturating_add(write_lock_fee)
-                .saturating_add(compute_fee) as f64)
-                .round() as u64,
-            prioritization_fee: budget_limits.prioritization_fee,
-        }
+        (budget_limits
+            .prioritization_fee
+            .saturating_add(signature_fee)
+            .saturating_add(write_lock_fee)
+            .saturating_add(compute_fee) as f64)
+            .round() as u64
     }
 }
 

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -92,12 +92,13 @@ impl FeeStructure {
     pub fn calculate_fee(
         &self,
         message: &SanitizedMessage,
-        _unused: u64,
+        lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> u64 {
         self.calculate_fee_details(
             message,
+            lamports_per_signature,
             budget_limits,
             include_loaded_account_data_size_in_fee,
         )
@@ -109,6 +110,7 @@ impl FeeStructure {
     pub fn calculate_fee_details(
         &self,
         message: &SanitizedMessage,
+        _lamports_per_signature: u64,
         budget_limits: &FeeBudgetLimits,
         include_loaded_account_data_size_in_fee: bool,
     ) -> FeeDetails {


### PR DESCRIPTION
#### Problem

#34865 caused hash mismatch. 

#### Summary of Changes
- revert #34865, and two PRs built on top of it: #34757 and #34970

Fixes #35008 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
