### PR TITLE
Replaces bare Arc::default() in CacheHashData::new()

### DIFF
--- a/accounts-db/src/cache_hash_data.rs
+++ b/accounts-db/src/cache_hash_data.rs
@@ -214,7 +214,7 @@ impl CacheHashData {
             cache_dir,
             pre_existing_cache_files: Arc::new(Mutex::new(HashSet::default())),
             deletion_policy,
-            stats: Arc::default(),
+            stats: Arc::new(CacheHashDataStats::default()),
         };
 
         result.get_cache_files();


### PR DESCRIPTION
#### Problem

I was grepping for all the places where `CacheHashDataStats` was created and couldn't find it. Turns out it's because a plain `Arc::default()` will call `Default::default()` on its inner `T`.


#### Summary of Changes

Instantiate the `CacheHashDataStats` explicitly 