### PR TITLE
ledger-tool: Change --snapshot-archive-path to --snapshots

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -819,12 +819,13 @@ fn main() {
                 ),
         )
         .arg(
-            Arg::with_name("snapshot_archive_path")
-                .long("snapshot-archive-path")
+            Arg::with_name("snapshots")
+                .long("snapshots")
+                .alias("snapshot-archive-path")
                 .value_name("DIR")
                 .takes_value(true)
                 .global(true)
-                .help("Use DIR for snapshot location"),
+                .help("Use DIR for snapshot location [default: --ledger value]"),
         )
         .arg(
             Arg::with_name("incremental_snapshot_archive_path")
@@ -1420,7 +1421,7 @@ fn main() {
     info!("{} {}", crate_name!(), solana_version::version!());
 
     let ledger_path = PathBuf::from(value_t_or_exit!(matches, "ledger_path", String));
-    let snapshot_archive_path = value_t!(matches, "snapshot_archive_path", String)
+    let snapshot_archive_path = value_t!(matches, "snapshots", String)
         .ok()
         .map(PathBuf::from);
     let incremental_snapshot_archive_path =

--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -71,7 +71,7 @@ fn load_accounts(path: &Path) -> Result<Input> {
 
 fn load_blockstore(ledger_path: &Path, arg_matches: &ArgMatches<'_>) -> Arc<Bank> {
     let process_options = parse_process_options(ledger_path, arg_matches);
-    let snapshot_archive_path = value_t!(arg_matches, "snapshot_archive_path", String)
+    let snapshot_archive_path = value_t!(arg_matches, "snapshots", String)
         .ok()
         .map(PathBuf::from);
     let incremental_snapshot_archive_path =


### PR DESCRIPTION
#### Summary of Changes
    This change makes solana-ledger-tool match solana-validator CLI; the old
    flag --snapshot-archive-path is retained as an argument alias and can
    still be used for the sake of backwards compatibility.

https://github.com/solana-labs/solana/blob/0dcac3fe7c4832fc6f358f010ddba8a116da70ab/validator/src/cli.rs#L296-L302

Possibly more work to be done to deduplicate the arguments between validator and ledger-tool, but I think that is for another day.