### PR TITLE
replay: only vote on blocks with >= 32 data shreds in last fec set

### DIFF
--- a/core/src/repair/cluster_slot_state_verifier.rs
+++ b/core/src/repair/cluster_slot_state_verifier.rs
@@ -159,6 +159,10 @@ impl BankFrozenState {
             is_slot_duplicate,
         }
     }
+
+    pub fn mark_duplicate(&mut self) {
+        self.is_slot_duplicate = true;
+    }
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -2939,8 +2939,9 @@ impl ReplayStage {
                     (bank.slot(), bank.hash()),
                     Some((bank.parent_slot(), bank.parent_hash())),
                 );
+
                 bank_progress.fork_stats.bank_hash = Some(bank.hash());
-                let bank_frozen_state = BankFrozenState::new_from_state(
+                let mut bank_frozen_state = BankFrozenState::new_from_state(
                     bank.slot(),
                     bank.hash(),
                     duplicate_slots_tracker,
@@ -2948,6 +2949,25 @@ impl ReplayStage {
                     heaviest_subtree_fork_choice,
                     epoch_slots_frozen_slots,
                 );
+
+                if bank
+                    .feature_set
+                    .is_active(&solana_sdk::feature_set::vote_only_full_fec_sets::id())
+                    && bank
+                        .feature_set
+                        .is_active(&solana_sdk::feature_set::drop_legacy_shreds::id())
+                {
+                    // If the block does not have at least DATA_SHREDS_PER_FEC_BLOCK shreds in the last FEC set,
+                    // process it like a duplicate, which allows us to continue replaying the fork but not vote on it.
+                    let is_last_fec_set_full = blockstore.is_last_fec_set_full(bank.slot());
+                    if let Err(e) = is_last_fec_set_full {
+                        warn!("Unable to determine if last fec set is full for slot {} {}, marking as duplicate: {e:?}", bank.slot(), bank.hash());
+                        bank_frozen_state.mark_duplicate();
+                    } else if !is_last_fec_set_full.unwrap() {
+                        bank_frozen_state.mark_duplicate();
+                    }
+                }
+
                 check_slot_agrees_with_cluster(
                     bank.slot(),
                     bank_forks.read().unwrap().root(),

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -780,6 +780,10 @@ pub mod enable_chained_merkle_shreds {
     solana_sdk::declare_id!("7uZBkJXJ1HkuP6R3MJfZs7mLwymBcDbKdqbF51ZWLier");
 }
 
+pub mod vote_only_full_fec_sets {
+    solana_sdk::declare_id!("ffecLRhhakKSGhMuc6Fz2Lnfq4uT9q3iu9ZsNaPLxPc");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -970,6 +974,7 @@ lazy_static! {
         (cost_model_requested_write_lock_cost::id(), "cost model uses number of requested write locks #34819"),
         (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
+        (vote_only_full_fec_sets::id(), "vote only full fec sets #"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem
We want a wider retransmitter set

#### Summary of Changes
Disregard blocks with too small of a final FEC set from fork choice.

<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
