### PR TITLE
Removes RwLock on AccountsDb::shrink_paths

### DIFF
--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -274,7 +274,6 @@ pub fn load_and_process_ledger(
             genesis_config,
             blockstore.as_ref(),
             account_paths,
-            None,
             snapshot_config.as_ref(),
             &process_options,
             None,

--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -80,7 +80,6 @@ pub fn load(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
-    shrink_paths: Option<Vec<PathBuf>>,
     snapshot_config: Option<&SnapshotConfig>,
     process_options: ProcessOptions,
     transaction_status_sender: Option<&TransactionStatusSender>,
@@ -93,7 +92,6 @@ pub fn load(
         genesis_config,
         blockstore,
         account_paths,
-        shrink_paths,
         snapshot_config,
         &process_options,
         cache_block_meta_sender,
@@ -121,7 +119,6 @@ pub fn load_bank_forks(
     genesis_config: &GenesisConfig,
     blockstore: &Blockstore,
     account_paths: Vec<PathBuf>,
-    shrink_paths: Option<Vec<PathBuf>>,
     snapshot_config: Option<&SnapshotConfig>,
     process_options: &ProcessOptions,
     cache_block_meta_sender: Option<&CacheBlockMetaSender>,
@@ -181,7 +178,6 @@ pub fn load_bank_forks(
                 incremental_snapshot_archive_info,
                 genesis_config,
                 account_paths,
-                shrink_paths,
                 snapshot_config,
                 process_options,
                 accounts_update_notifier,
@@ -231,7 +227,6 @@ fn bank_forks_from_snapshot(
     incremental_snapshot_archive_info: Option<IncrementalSnapshotArchiveInfo>,
     genesis_config: &GenesisConfig,
     account_paths: Vec<PathBuf>,
-    shrink_paths: Option<Vec<PathBuf>>,
     snapshot_config: &SnapshotConfig,
     process_options: &ProcessOptions,
     accounts_update_notifier: Option<AccountsUpdateNotifier>,
@@ -344,10 +339,6 @@ fn bank_forks_from_snapshot(
         })?;
         bank
     };
-
-    if let Some(shrink_paths) = shrink_paths {
-        bank.set_shrink_paths(shrink_paths);
-    }
 
     let full_snapshot_hash = FullSnapshotHash((
         full_snapshot_archive_info.slot(),

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -745,7 +745,6 @@ pub fn test_process_blockstore(
         blockstore,
         Vec::new(),
         None,
-        None,
         opts,
         None,
         None,

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -13,7 +13,6 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         voting_disabled: config.voting_disabled,
         account_paths: config.account_paths.clone(),
         account_snapshot_paths: config.account_snapshot_paths.clone(),
-        account_shrink_paths: config.account_shrink_paths.clone(),
         rpc_config: config.rpc_config.clone(),
         on_start_geyser_plugin_config_files: config.on_start_geyser_plugin_config_files.clone(),
         rpc_addrs: config.rpc_addrs,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -2211,7 +2211,6 @@ fn create_snapshot_to_hard_fork(
                 .unwrap()
                 .0,
         ],
-        None,
         Some(&snapshot_config),
         process_options,
         None,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4436,10 +4436,6 @@ impl Bank {
         self.rc.accounts.accounts_db.remove_unrooted_slots(slots)
     }
 
-    pub fn set_shrink_paths(&self, paths: Vec<PathBuf>) {
-        self.rc.accounts.accounts_db.set_shrink_paths(paths);
-    }
-
     fn check_age(
         &self,
         sanitized_txs: &[impl core::borrow::Borrow<SanitizedTransaction>],


### PR DESCRIPTION
#### Problem

The accounts db shrink paths unnecessarily are wrapped in an RwLock. The paths are either set or not *at startup* and then never change, so there's no need to support runtime mutation.

Additionally, we now get to remove one additional spot within AccountsDb where we implicitly create directories. This is backwards; the code that constructs AccountsDb should create the directories, and then simply pass the paths to AccountsDb.


#### Summary of Changes

Removes the RwLock (and Option) around AccountsDb::shrink_paths.