### PR TITLE
Use a single endpoint for all quic client connnections in a connection cache

### DIFF
--- a/quic-client/src/lib.rs
+++ b/quic-client/src/lib.rs
@@ -223,6 +223,7 @@ impl BaseClientConnection for Quic {
 
 pub struct QuicConnectionManager {
     connection_config: QuicConfig,
+    endpoint: Arc<QuicLazyInitializedEndpoint>,
 }
 
 impl ConnectionManager for QuicConnectionManager {
@@ -234,7 +235,7 @@ impl ConnectionManager for QuicConnectionManager {
     fn new_connection_pool(&self) -> Self::ConnectionPool {
         QuicPool {
             connections: Vec::default(),
-            endpoint: Arc::new(self.connection_config.create_endpoint()),
+            endpoint: self.endpoint.clone(),
         }
     }
 
@@ -250,7 +251,8 @@ impl ConnectionManager for QuicConnectionManager {
 
 impl QuicConnectionManager {
     pub fn new_with_connection_config(connection_config: QuicConfig) -> Self {
-        Self { connection_config }
+        let endpoint = Arc::new(connection_config.create_endpoint());
+        Self { connection_config, endpoint }
     }
 }
 


### PR DESCRIPTION
#### Problem
We currently create a new endpoint for every connection pool in a connection cache. This can lead to using up a lot of ports, which is not desirable. If this does not result in a perf regression, it would be preferable to use a single endpoint for the connection cache instead.

#### Summary of Changes
Tests using a single endpoint for a connection cache

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
