### PR TITLE
solana-program: use VoteState::deserialize_into on non-bpf

### DIFF
--- a/account-decoder/src/parse_vote.rs
+++ b/account-decoder/src/parse_vote.rs
@@ -8,7 +8,8 @@ use {
 };
 
 pub fn parse_vote(data: &[u8]) -> Result<VoteAccountType, ParseAccountError> {
-    let mut vote_state = VoteState::deserialize(data).map_err(ParseAccountError::from)?;
+    let mut vote_state =
+        VoteState::deserialize_with_bincode(data).map_err(ParseAccountError::from)?;
     let epoch_credits = vote_state
         .epoch_credits()
         .iter()

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -133,7 +133,7 @@ impl From<VoteStateUpdate> for VoteTransaction {
 
 // utility function, used by Stakes, tests
 pub fn from<T: ReadableAccount>(account: &T) -> Option<VoteState> {
-    VoteState::deserialize(account.data()).ok()
+    VoteState::deserialize_with_bincode(account.data()).ok()
 }
 
 // utility function, used by Stakes, tests

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -2680,7 +2680,7 @@ impl Bank {
             // vote_accounts_cache_miss_count is shown to be always zero.
             let account = self.get_account_with_fixed_root(vote_pubkey)?;
             if account.owner() == &solana_vote_program
-                && VoteState::deserialize(account.data()).is_ok()
+                && VoteState::deserialize_with_bincode(account.data()).is_ok()
             {
                 vote_accounts_cache_miss_count.fetch_add(1, Relaxed);
             }

--- a/sdk/program/src/vote/state/mod.rs
+++ b/sdk/program/src/vote/state/mod.rs
@@ -399,12 +399,6 @@ impl VoteState {
         input: &[u8],
         vote_state: &mut VoteState,
     ) -> Result<(), InstructionError> {
-        let minimum_size =
-            serialized_size(vote_state).map_err(|_| InstructionError::InvalidAccountData)?;
-        if (input.len() as u64) < minimum_size {
-            return Err(InstructionError::InvalidAccountData);
-        }
-
         let mut cursor = Cursor::new(input);
 
         let variant = read_u32(&mut cursor)?;

--- a/vote/src/vote_account.rs
+++ b/vote/src/vote_account.rs
@@ -65,11 +65,13 @@ impl VoteAccount {
     }
 
     pub fn vote_state(&self) -> Result<&VoteState, &Error> {
-        // VoteState::deserialize deserializes a VoteStateVersions and then
+        // VoteState::deserialize_with_bincode deserializes a VoteStateVersions and then
         // calls VoteStateVersions::convert_to_current.
         self.0
             .vote_state
-            .get_or_init(|| VoteState::deserialize(self.0.account.data()).map_err(Error::from))
+            .get_or_init(|| {
+                VoteState::deserialize_with_bincode(self.0.account.data()).map_err(Error::from)
+            })
             .as_ref()
     }
 


### PR DESCRIPTION
#### Problem
the custom `VoteState` parser can be much faster. also it now makes sense to expose this to non-bpf contexts so validators can benefit from faster vote parsing. however we still want to preserve `V0_23_5` support for maximum safety

#### Summary of Changes

previously, the logic went something like "if on bpf, use the new parser, otherwise use bincode," and the new parser did not support `V0_23_5` for the sake of code simplicity, as they should in theory never be encountered. now the logic goes "always use the new parser. inside the new parser, if V0_23_5 and on bpf, error. if V0_23_5 and not on bpf, fall back to bincode"

also i made the parser appreciably faster. it is now 7x faster than bincode on average, can be up to 20x faster in the worst case, and is never slower

```
HANA custom vs bincode
* we win: 10000, they win: 0
* our max 22.422µs, their max 471.89µs
* our avg 5.76µs, their avg 35.956µs
* avg speedup 30.195µs
```

we also introduce a new function `VoteState::deserialize_with_bincode()` which is identical to the original `VoteState::deserialize()`. this is a temporary measure while we work on a (potentially feature gated) upgrade to use the new parser in the core runtime