### PR TITLE
sdk: Do not derive AbiEnum on InstructionError for Solana builds

### DIFF
--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -28,9 +28,8 @@ use {
 /// an error be consistent across software versions.  For example, it is
 /// dangerous to include error strings from 3rd party crates because they could
 /// change at any time and changes to them are difficult to detect.
-#[derive(
-    Serialize, Deserialize, Debug, Error, PartialEq, Eq, Clone, AbiExample, AbiEnumVisitor,
-)]
+#[cfg_attr(not(target_os = "solana"), derive(AbiExample, AbiEnumVisitor))]
+#[derive(Serialize, Deserialize, Debug, Error, PartialEq, Eq, Clone)]
 pub enum InstructionError {
     /// Deprecated! Use CustomError instead!
     /// The program instruction returned an error


### PR DESCRIPTION
#### Problem

The `AbiEnumVisitor` derivation on `InstructionError` blows out the stack space for Solana builds, giving the error:

```
Error: Function _ZN112_$LT$solana_program..instruction..InstructionError$u20$as$u20$solana_frozen_abi..abi_example..AbiEnumVisitor$GT$13visit_for_abi17ha3a75fe06f2a2af4E Stack offset of 4584 exceeded max offset of 4096 by 488 bytes, please minimize large stack variables
```

#### Summary of Changes

Since these tests aren't useful for on-chain program builds, and only run with the nightly compiler anyway, don't derive the trait for on-chain programs.

Fixes #35003
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
