### PR TITLE
poc simd-0110

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5951,6 +5951,7 @@ version = "1.18.0"
 dependencies = [
  "lazy_static",
  "log",
+ "lru",
  "rustc_version 0.4.0",
  "solana-address-lookup-table-program",
  "solana-bpf-loader-program",

--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -17,7 +17,7 @@ use {
     },
 };
 
-pub type TransactionCheckResult = (transaction::Result<()>, Option<NoncePartial>, Option<u64>);
+pub type TransactionCheckResult = (transaction::Result<()>, Option<NoncePartial>, Option<u64>, Option<u64> /*SIMD-0110 write_lock_fee*/);
 
 pub struct TransactionResults {
     pub fee_collection_results: Vec<transaction::Result<()>>,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -418,7 +418,7 @@ impl Consumer {
             bank.check_transactions(txs, &pre_results, MAX_PROCESSING_AGE, &mut error_counters);
         let check_results = check_results
             .into_iter()
-            .map(|(result, _nonce, _lamports)| result);
+            .map(|(result, _nonce, _lamports, _write_lock_fee)| result);
         let mut output = self.process_and_record_transactions_with_pre_results(
             bank,
             txs,
@@ -842,7 +842,7 @@ impl Consumer {
         valid_txs
             .iter()
             .enumerate()
-            .filter_map(|(index, (x, _h, _lamports))| if x.is_ok() { Some(index) } else { None })
+            .filter_map(|(index, (x, _h, _lamports, _write_lock_fee))| if x.is_ok() { Some(index) } else { None })
             .collect_vec()
     }
 }
@@ -2543,24 +2543,24 @@ mod tests {
     fn test_bank_filter_valid_transaction_indexes() {
         assert_eq!(
             Consumer::filter_valid_transaction_indexes(&[
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
+                (Err(TransactionError::BlockhashNotFound), None, None, None),
+                (Err(TransactionError::BlockhashNotFound), None, None, None),
+                (Ok(()), None, None, None),
+                (Err(TransactionError::BlockhashNotFound), None, None, None),
+                (Ok(()), None, None, None),
+                (Ok(()), None, None, None),
             ]),
             [2, 4, 5]
         );
 
         assert_eq!(
             Consumer::filter_valid_transaction_indexes(&[
-                (Ok(()), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Err(TransactionError::BlockhashNotFound), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
-                (Ok(()), None, None),
+                (Ok(()), None, None, None),
+                (Err(TransactionError::BlockhashNotFound), None, None, None),
+                (Err(TransactionError::BlockhashNotFound), None, None, None),
+                (Ok(()), None, None, None),
+                (Ok(()), None, None, None),
+                (Ok(()), None, None, None),
             ]),
             [0, 3, 4, 5]
         );

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -750,23 +750,7 @@ impl Consumer {
         // pack block.
         // In a sense, how many what transactions are fitered out here is the main purpose
         // of SIMD-0110
-        let mut write_locks_fee = 0;
-        //*
-        let writable_accounts :Vec<solana_sdk::pubkey::Pubkey> = message
-            .account_keys()
-            .iter()
-            .enumerate()
-            .filter_map(|(i, k)| {
-                if message.is_writable(i) {
-                    Some(*k)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        write_locks_fee = bank.write_lock_fee_cache.read().unwrap().calculate_write_lock_fee(&writable_accounts, budget_limits.compute_unit_limit);
-        // */
-        //
+        let write_locks_fee = bank.calculate_write_lock_fee(message);
         let fee = bank.fee_structure.calculate_fee(
             message,
             bank.get_lamports_per_signature(),

--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -170,7 +170,7 @@ impl SchedulerController {
         let fee_check_results: Vec<_> = check_results
             .into_iter()
             .zip(transactions)
-            .map(|((result, _nonce, _lamports), tx)| {
+            .map(|((result, _nonce, _lamports, _), tx)| {
                 result?; // if there's already error do nothing
                 Consumer::check_fee_payer_unlocked(bank, tx.message(), &mut error_counters)
             })
@@ -228,7 +228,7 @@ impl SchedulerController {
                 &mut error_counters,
             );
 
-            for ((result, _nonce, _lamports), id) in check_results.into_iter().zip(chunk.iter()) {
+            for ((result, _nonce, _lamports, _), id) in check_results.into_iter().zip(chunk.iter()) {
                 if result.is_err() {
                     saturating_add_assign!(self.count_metrics.num_dropped_on_age_and_status, 1);
                     self.container.remove_by_id(&id.id);

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -802,7 +802,7 @@ impl ThreadLocalUnprocessedPackets {
             .iter()
             .enumerate()
             .filter_map(
-                |(tx_index, (result, _, _))| if result.is_ok() { Some(tx_index) } else { None },
+                |(tx_index, (result, _, _, _))| if result.is_ok() { Some(tx_index) } else { None },
             )
             .collect_vec()
     }

--- a/cost-model/Cargo.toml
+++ b/cost-model/Cargo.toml
@@ -12,6 +12,7 @@ edition = { workspace = true }
 [dependencies]
 lazy_static = { workspace = true }
 log = { workspace = true }
+lru = { workspace = true }
 solana-address-lookup-table-program = { workspace = true }
 solana-bpf-loader-program = { workspace = true }
 solana-compute-budget-program = { workspace = true }

--- a/cost-model/src/compute_unit_pricer.rs
+++ b/cost-model/src/compute_unit_pricer.rs
@@ -47,6 +47,11 @@ impl Default for ComputeUnitPricer {
 }
 
 impl ComputeUnitPricer {
+    // return fee_rate in millilamports/cu
+    pub fn get_fee_rate(&self) -> u64 {
+        self.cu_price
+    }
+
     // use currently cu_price to calculate total fee in lamports
     pub fn calculate_fee(&self, compute_units: u64) -> u64 {
         compute_units.saturating_mul(self.cu_price).saturating_div(1_000)

--- a/cost-model/src/compute_unit_pricer.rs
+++ b/cost-model/src/compute_unit_pricer.rs
@@ -1,0 +1,114 @@
+use{
+    crate::ema::AggregatedVarianceStats,
+    solana_sdk::clock::Slot,
+    std::cmp::Ordering,
+};
+
+#[derive(Clone, Debug)]
+pub struct ComputeUnitPricer {
+    /// only for exprimenting println!
+    pub slot: Slot,
+
+    /// moving average block_utilization read from previous blocks in percentage (10 means 10%);
+    /// this block's tracking stats contribute to next block's average block_utilization
+    pub block_utilization: AggregatedVarianceStats,
+
+    /// milli-lamports per CU. The rate dynamically floats based on block_utilization. In general,
+    ///    if block_utilization > 90% full, increase the cu_price by 1.125x
+    ///    if block_utilization < 50% full, decrease the cu_price by 0.875x
+    /// it starts w 1000 milli-lamport/cu
+    pub cu_price: u64,
+}
+
+const NORMAL_CU_PRICE: u64 = 1_000;
+const PRICE_CHANGE_RATE: u64 = 125;
+const PRICE_CHANGE_SCALE: u64 = 1_000;
+
+// the `mean` of block_utilizatino ema, returned from script
+const BLOCK_TARGET_UTILIZATION: u64 = 81;
+// the distance from target utilization that should be considered as "normal",
+// set to be 2*stddev of raw block_utilization, return from script;
+const UTILIZATION_BAND_WIDTH: u64 = 7;
+const BLOCK_UTILIZATION_UPPER_BOUND: u64 = BLOCK_TARGET_UTILIZATION + UTILIZATION_BAND_WIDTH;
+const BLOCK_UTILIZATION_LOWER_BOUND: u64 = BLOCK_TARGET_UTILIZATION - UTILIZATION_BAND_WIDTH;
+
+// NOTE, not setting MIN/MAX cu_price yet for expriment, perhaps a good idea to have them when go
+// out of exprimenting
+//
+
+impl Default for ComputeUnitPricer {
+    fn default() -> Self {
+        Self {
+            slot: 0,
+            block_utilization: AggregatedVarianceStats::new_with_initial_ema(BLOCK_TARGET_UTILIZATION),
+            cu_price: NORMAL_CU_PRICE,
+        }
+    }
+}
+
+impl ComputeUnitPricer {
+    // use currently cu_price to calculate total fee in lamports
+    pub fn calculate_fee(&self, compute_units: u64) -> u64 {
+        compute_units.saturating_mul(self.cu_price).saturating_div(1_000)
+    }
+
+    pub fn update(&mut self, slot: Slot, block_cost: u64, block_cost_limit: u64) {
+        let prev_block_utilization_ema = self.block_utilization.get_ema();
+        let prev_block_utilization_stddev = self.block_utilization.get_stddev();
+        let prev_cu_price = self.cu_price;
+        let this_block_utilization = block_cost * 100 / block_cost_limit;
+
+        self.slot = slot;
+        self.block_utilization.aggregate(this_block_utilization);
+        let post_block_utilization_ema = self.block_utilization.get_ema();
+        let post_block_utilization_stddev = self.block_utilization.get_stddev();
+
+        if post_block_utilization_ema >= BLOCK_UTILIZATION_UPPER_BOUND {
+            self.cu_price = PRICE_CHANGE_SCALE
+                .saturating_add(PRICE_CHANGE_RATE)
+                .saturating_mul(self.cu_price.max(10)) // quick hack for in case cu_priced reduced to `0`,
+                .saturating_div(PRICE_CHANGE_SCALE);
+        } else if post_block_utilization_ema <= BLOCK_UTILIZATION_LOWER_BOUND {
+            self.cu_price = PRICE_CHANGE_SCALE
+                .saturating_sub(PRICE_CHANGE_RATE)
+                .saturating_mul(self.cu_price)
+                .saturating_div(PRICE_CHANGE_SCALE);
+        } else {
+            // mean reversion
+            match self.cu_price.cmp(&NORMAL_CU_PRICE) {
+                Ordering::Equal => (),
+                Ordering::Greater => {
+                    self.cu_price = PRICE_CHANGE_SCALE
+                        .saturating_sub(PRICE_CHANGE_RATE)
+                        .saturating_mul(self.cu_price)
+                        .saturating_div(PRICE_CHANGE_SCALE)
+                        .max(NORMAL_CU_PRICE);
+                }
+                Ordering::Less => {
+                    self.cu_price = PRICE_CHANGE_SCALE
+                        .saturating_add(PRICE_CHANGE_RATE)
+                        .saturating_mul(self.cu_price)
+                        .saturating_div(PRICE_CHANGE_SCALE)
+                        .min(NORMAL_CU_PRICE);
+                }
+            }
+        }
+
+        println!("=== slot {} block_cost {} block_cost_limit {} this_block_util {} \
+                 prev_block_util_ems {} prev_block_util_stddev {} \
+                 post_block_util_ema {} post_block_util_stddev {} \
+                 prev_cu_price {} post_cu_price {}",
+                 self.slot,
+                 block_cost,
+                 block_cost_limit,
+                 this_block_utilization,
+                 prev_block_utilization_ema,
+                 prev_block_utilization_stddev,
+                 post_block_utilization_ema,
+                 post_block_utilization_stddev,
+                 prev_cu_price,
+                 self.cu_price,
+                 );
+    }
+}
+

--- a/cost-model/src/compute_unit_pricer.rs
+++ b/cost-model/src/compute_unit_pricer.rs
@@ -56,6 +56,7 @@ impl ComputeUnitPricer {
     pub fn get_fee_rate_micro_lamports_per_cu(&self) -> u64 {
         self.cu_price
     }
+    #[allow(dead_code)]
     pub fn get_ema(&self) -> u64 {
         self.cu_utilization.get_ema()
     }

--- a/cost-model/src/cost_model.rs
+++ b/cost-model/src/cost_model.rs
@@ -57,7 +57,7 @@ impl CostModel {
         transaction.signatures().len() as u64 * SIGNATURE_COST
     }
 
-    fn get_writable_accounts(transaction: &SanitizedTransaction) -> Vec<Pubkey> {
+    pub fn get_writable_accounts(transaction: &SanitizedTransaction) -> Vec<Pubkey> {
         let message = transaction.message();
         message
             .account_keys()

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -58,6 +58,10 @@ pub struct CostTracker {
     vote_cost: u64,
     transaction_count: u64,
     account_data_size: u64,
+
+    // NOTE: cost_tracker is initialized into `default` for new bank, write-lock-fee-cache (that
+    // contains each write-lock pricer) is passed down from parent (or init from ledger fields)
+    // therefore, it'd better belong to bank directly instead of being part of cost-tracker.
 }
 
 impl Default for CostTracker {

--- a/cost-model/src/cost_tracker.rs
+++ b/cost-model/src/cost_tracker.rs
@@ -148,7 +148,7 @@ impl CostTracker {
             .collect()
     }
 
-    // NOTE testing SIMD-0110, return all writable accounts and their allocated CUs
+    // NOTE testing SIMD-0110, return all writable accounts pubkey and their allocated CUs
     pub fn get_write_lock_account_and_cu(&self) -> Vec<(Pubkey, u64)> {
         self.cost_by_writable_accounts.iter().map(|(&pubkey, &cost)| (pubkey, cost)).collect()
     }

--- a/cost-model/src/ema.rs
+++ b/cost-model/src/ema.rs
@@ -1,6 +1,6 @@
 // N is number of datapoints used in exponential weighted moving average calculoation.
-// default to 16 blocks
-const N: i128 = 16;
+// default to 128 blocks per SIMD-0110
+const N: i128 = 128;
 // The EMA_ALPHA represents the degree of weighting decrease in EMA,
 // a constant smoothing factor between 0 and 1. A higher alpha
 // discounts older observations faster.

--- a/cost-model/src/ema.rs
+++ b/cost-model/src/ema.rs
@@ -1,6 +1,5 @@
 // N is number of datapoints used in exponential weighted moving average calculoation.
-// default to 128 blocks per SIMD-0110
-const N: i128 = 128;
+const N: i128 = 8;  // trying 2 leaders slots, 128 slots as specified in simd was too slow to react
 // The EMA_ALPHA represents the degree of weighting decrease in EMA,
 // a constant smoothing factor between 0 and 1. A higher alpha
 // discounts older observations faster.

--- a/cost-model/src/ema.rs
+++ b/cost-model/src/ema.rs
@@ -1,0 +1,108 @@
+// N is number of datapoints used in exponential weighted moving average calculoation.
+// default to 16 blocks
+const N: i128 = 16;
+// The EMA_ALPHA represents the degree of weighting decrease in EMA,
+// a constant smoothing factor between 0 and 1. A higher alpha
+// discounts older observations faster.
+// Estimate it to 0.117 by `2/(N+1)` if N=16
+const EMA_SCALE: i128 = 1000;
+const EMA_ALPHA: i128 = 2 * EMA_SCALE / (N + 1);
+
+// exponential moving average algorithm
+// https://en.wikipedia.org/wiki/Moving_average#Exponentially_weighted_moving_variance_and_standard_deviation
+#[derive(Clone, Debug, Default)]
+pub struct AggregatedVarianceStats {
+    ema: u64,
+    ema_var: u64,
+}
+
+impl AggregatedVarianceStats {
+    pub fn new_with_initial_ema(value: u64) -> Self {
+        Self {
+            ema: value,
+            ema_var: 0u64,
+        }
+    }
+
+    pub fn get_ema(&self) -> u64 {
+        self.ema
+    }
+
+    pub fn get_stddev(&self) -> u64 {
+        (self.ema_var as f64).sqrt().ceil() as u64
+    }
+
+    fn aggregate_ema(&mut self, theta: i128) {
+        self.ema = u64::try_from(
+            i128::from(self.ema)
+                .saturating_mul(EMA_SCALE)
+                .saturating_add(theta.saturating_mul(EMA_ALPHA))
+                .saturating_div(EMA_SCALE),
+        )
+        .ok()
+        .unwrap_or(self.ema);
+    }
+
+    fn aggregate_variance(&mut self, theta: i128) {
+        self.ema_var = u64::try_from(
+            i128::from(self.ema_var)
+                .saturating_mul(EMA_SCALE)
+                .saturating_add(theta.saturating_pow(2).saturating_mul(EMA_ALPHA))
+                .saturating_mul(EMA_SCALE - EMA_ALPHA)
+                .saturating_div(EMA_SCALE.saturating_pow(2)),
+        )
+        .ok()
+        .unwrap_or(self.ema_var);
+    }
+
+    pub fn aggregate(&mut self, new_value: u64) {
+        if self.get_ema() == 0 {
+            // first datapoint
+            self.ema = new_value;
+            self.ema_var = 0u64;
+        } else {
+            let theta = i128::from(new_value) - i128::from(self.get_ema());
+            self.aggregate_ema(theta);
+            self.aggregate_variance(theta);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_aggregate_variance_stats() {
+        solana_logger::setup();
+        let cost: u64 = u64::MAX;
+
+        // set initial value at MAX
+        let mut aggregated_variance_stats = AggregatedVarianceStats {
+            ema: cost,
+            ema_var: 0,
+        };
+        assert_eq!(cost, aggregated_variance_stats.get_ema());
+        assert_eq!(0, aggregated_variance_stats.get_stddev());
+
+        // expected variance
+        let expected_var = 33u64;
+        // insert a positive theta, ema will be saturated, hence remain at its MAX value
+        {
+            let theta = 100i128;
+            aggregated_variance_stats.aggregate_ema(theta);
+            aggregated_variance_stats.aggregate_variance(theta);
+            assert_eq!(cost, aggregated_variance_stats.get_ema());
+            assert_eq!(expected_var, aggregated_variance_stats.get_stddev());
+        }
+
+        // insert a negative theta, would reduce ema, increase variance
+        {
+            let theta = -100i128;
+            aggregated_variance_stats.aggregate_ema(theta);
+            aggregated_variance_stats.aggregate_variance(theta);
+            assert!(cost > aggregated_variance_stats.get_ema());
+            assert!(expected_var < aggregated_variance_stats.get_stddev());
+        }
+    }
+}

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cost_model;
 pub mod cost_tracker;
 pub(crate) mod ema;
 pub mod transaction_cost;
+pub mod write_lock_fee_cache;
 
 #[macro_use]
 extern crate solana_frozen_abi_macro;

--- a/cost-model/src/lib.rs
+++ b/cost-model/src/lib.rs
@@ -2,8 +2,10 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 pub mod block_cost_limits;
+pub(crate) mod compute_unit_pricer;
 pub mod cost_model;
 pub mod cost_tracker;
+pub(crate) mod ema;
 pub mod transaction_cost;
 
 #[macro_use]

--- a/cost-model/src/write_lock_fee_cache.rs
+++ b/cost-model/src/write_lock_fee_cache.rs
@@ -1,0 +1,101 @@
+use {
+    crate::compute_unit_pricer::ComputeUnitPricer,
+    lru::LruCache,
+    solana_sdk::{clock::Slot, pubkey::Pubkey,},
+};
+
+/// Cache capacity is 2 times worst attacking blocks, which would have number of hot accounts
+/// = 2 * (128 accounts/tx * 48M/6M txs) = 2048
+const CACHE_CAPACITY: usize = 2048;
+
+//TODO testing SIMD-0110, if it belongs to bank, it's abi
+//#[frozen_abi(digest = "8upYCMG37Awf4FGQ5kKtZARHP1QfD2GMpQCPnwCCsxhu")]
+//#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample)]
+#[derive(Debug)]
+pub struct WriteLockFeeCache {
+    cache: LruCache<Pubkey, ComputeUnitPricer>,
+}
+
+impl Default for WriteLockFeeCache {
+    fn default() -> Self {
+        Self::new(CACHE_CAPACITY)
+    }
+}
+
+impl Clone for WriteLockFeeCache {
+    fn clone(&self) -> Self {
+        let mut other = LruCache::new(self.cache.cap());
+
+        for (key, value) in self.cache.iter().rev() {
+            other.push(*key, value.clone());
+        }
+
+        WriteLockFeeCache {
+            cache: other,
+        }
+    }
+}
+
+impl WriteLockFeeCache {
+    pub fn new(capacity: usize) -> Self {
+        WriteLockFeeCache{
+            cache: LruCache::new(capacity),
+        }
+    }
+
+    // search cache for fee_rate for given pubkey.
+    // return current fee_rate, in lamports_per_cu, if accout is in cache
+    // return None otherwise
+    pub fn get_write_lock_fee_rate(&self, pubkey: &Pubkey) -> Option<u64> {
+        self.cache.peek(pubkey).map(|pricer| pricer.get_fee_rate())
+    }
+
+    // Update Cache with write locked accounts from just-frozen bank.
+    // if account is in Cache, update its Pricer, adjusting fee rate higher or lower;
+    // else, if account is "hot", evict cheapest account from Cache is at capacity, 
+    // then add new hot account to Cache
+    pub fn update(&mut self, slot: Slot, accounts: Vec<(Pubkey, u64)>) {
+        accounts.iter().for_each(|(pubkey, cost)| {
+            if self.has_account(pubkey) {
+                self.update_account(slot, pubkey, cost);
+            } else if self.is_hot_account(*cost) {
+                if self.at_capacity() {
+                    self.evict();
+                }
+                self.add_account(slot, pubkey, cost);
+            }
+        });
+    }
+
+    fn has_account(&self, pubkey: &Pubkey) -> bool {
+        self.cache.contains(pubkey)
+    }
+
+    fn update_account(&mut self, slot: Slot, pubkey: &Pubkey, cost: &u64) {
+        let pricer = self.cache.peek_mut(pubkey);
+        if pricer.is_some() {
+            pricer.unwrap().update(slot, *cost, crate::block_cost_limits::MAX_WRITABLE_ACCOUNT_UNITS);
+        }
+    }
+
+    fn is_hot_account(&self, cost: u64) -> bool {
+        cost > crate::block_cost_limits::MAX_WRITABLE_ACCOUNT_UNITS - cost
+    }
+
+    fn at_capacity(&self) -> bool {
+        self.cache.len() == self.cache.cap()
+    }
+
+    fn add_account(&mut self, slot: Slot, pubkey: &Pubkey, cost: &u64) {
+        let mut pricer = ComputeUnitPricer::default();
+        pricer.update(slot, *cost, crate::block_cost_limits::MAX_WRITABLE_ACCOUNT_UNITS);
+        self.cache.push(*pubkey, pricer);
+    }
+
+    // eviction policy:
+    // At end of block, add new hot accounts to cache, if cache is full,
+    // evict the account has lowest fee_rate. Designed to prevent cache attack
+    fn evict(&mut self) {
+        // TODO, if to impl own evidtin policy, then dont need to use LruCache.
+    }
+}

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -432,15 +432,21 @@ fn rebatch_and_execute_batches(
         })
         .collect::<Vec<_>>();
 
+    // NOTE: testing SIMD-0110, which requires replay to enable cost_tracker
+    // so it can EMA each account's CU utilization at end of block.
+    /*
     if bank
         .feature_set
         .is_active(&feature_set::apply_cost_tracker_during_replay::id())
+    /// */
     {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         for tx_cost in &tx_costs {
             cost_tracker
                 .try_add(tx_cost)
-                .map_err(TransactionError::from)?;
+                .map_err(TransactionError::from);
+                // NOTE: testing SIMD-0110, cotinue tracking block costs
+                // .map_err(TransactionError::from)?;
         }
     }
 

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -443,8 +443,7 @@ fn rebatch_and_execute_batches(
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         for tx_cost in &tx_costs {
             let _ = cost_tracker
-                .try_add(tx_cost)
-                .map_err(TransactionError::from);
+                .try_add(tx_cost);
                 // NOTE: testing SIMD-0110, cotinue tracking block costs
                 // .map_err(TransactionError::from)?;
         }

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -46,7 +46,8 @@ use {
     },
     solana_sdk::{
         clock::{Slot, MAX_PROCESSING_AGE},
-        feature_set,
+        // TODO SIMD-0110
+        // feature_set,
         genesis_config::GenesisConfig,
         hash::Hash,
         pubkey::Pubkey,

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -442,7 +442,7 @@ fn rebatch_and_execute_batches(
     {
         let mut cost_tracker = bank.write_cost_tracker().unwrap();
         for tx_cost in &tx_costs {
-            cost_tracker
+            let _ = cost_tracker
                 .try_add(tx_cost)
                 .map_err(TransactionError::from);
                 // NOTE: testing SIMD-0110, cotinue tracking block costs

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4153,7 +4153,7 @@ impl Bank {
         )
     }
 
-    fn calculate_write_lock_fee(
+    pub fn calculate_write_lock_fee(
         &self,
         message: &SanitizedMessage,
     ) -> u64 {

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -1,6 +1,6 @@
 use {
     super::Bank,
-    crate::svm::account_rent_state::RentState,
+    crate::{bank::CollectorFeeDetails, svm::account_rent_state::RentState},
     log::{debug, warn},
     solana_accounts_db::stake_rewards::RewardInfo,
     solana_sdk::{
@@ -46,47 +46,55 @@ impl Bank {
     // still being stake-weighted.
     // Ref: distribute_rent_to_validators
     pub(super) fn distribute_transaction_fees(&self) {
-        let collector_fees = self.collector_fees.load(Relaxed);
-        if collector_fees != 0 {
-            let (deposit, mut burn) = self.fee_rate_governor.burn(collector_fees);
-            if deposit > 0 {
-                let validate_fee_collector = self.validate_fee_collector_account();
-                match self.deposit_fees(
-                    &self.collector_id,
-                    deposit,
-                    DepositFeeOptions {
-                        check_account_owner: validate_fee_collector,
-                        check_rent_paying: validate_fee_collector,
-                    },
-                ) {
-                    Ok(post_balance) => {
-                        self.rewards.write().unwrap().push((
-                            self.collector_id,
-                            RewardInfo {
-                                reward_type: RewardType::Fee,
-                                lamports: deposit as i64,
-                                post_balance,
-                                commission: None,
-                            },
-                        ));
-                    }
-                    Err(err) => {
-                        debug!(
-                            "Burned {} lamport tx fee instead of sending to {} due to {}",
-                            deposit, self.collector_id, err
-                        );
-                        datapoint_warn!(
-                            "bank-burned_fee",
-                            ("slot", self.slot(), i64),
-                            ("num_lamports", deposit, i64),
-                            ("error", err.to_string(), String),
-                        );
-                        burn += deposit;
-                    }
+        let CollectorFeeDetails {
+            transaction_fee,
+            priority_fee,
+            write_lock_fee,
+        } = self.collector_fee_details.read().unwrap().get();
+        let (mut deposit, mut burn) = if transaction_fee != 0 {
+            self.fee_rate_governor.burn(transaction_fee)
+        } else {
+            (0, 0)
+        };
+        deposit = deposit.saturating_add(priority_fee);
+        burn = burn.saturating_add(write_lock_fee);
+        if deposit > 0 {
+            let validate_fee_collector = self.validate_fee_collector_account();
+            match self.deposit_fees(
+                &self.collector_id,
+                deposit,
+                DepositFeeOptions {
+                    check_account_owner: validate_fee_collector,
+                    check_rent_paying: validate_fee_collector,
+                },
+            ) {
+                Ok(post_balance) => {
+                    self.rewards.write().unwrap().push((
+                        self.collector_id,
+                        RewardInfo {
+                            reward_type: RewardType::Fee,
+                            lamports: deposit as i64,
+                            post_balance,
+                            commission: None,
+                        },
+                    ));
+                }
+                Err(err) => {
+                    debug!(
+                        "Burned {} lamport tx fee instead of sending to {} due to {}",
+                        deposit, self.collector_id, err
+                    );
+                    datapoint_warn!(
+                        "bank-burned_fee",
+                        ("slot", self.slot(), i64),
+                        ("num_lamports", deposit, i64),
+                        ("error", err.to_string(), String),
+                    );
+                    burn = burn.saturating_add(deposit);
                 }
             }
-            self.capitalization.fetch_sub(burn, Relaxed);
         }
+        self.capitalization.fetch_sub(burn, Relaxed);
     }
 
     // Deposits fees into a specified account and if successful, returns the new balance of that account
@@ -295,8 +303,8 @@ pub mod tests {
             create_genesis_config_with_vote_accounts, ValidatorVoteKeypairs,
         },
         solana_sdk::{
-            account::AccountSharedData, feature_set, native_token::sol_to_lamports, pubkey,
-            rent::Rent, signature::Signer,
+            account::AccountSharedData, feature_set, fee::FeeDetails,
+            native_token::sol_to_lamports, pubkey, rent::Rent, signature::Signer,
         },
     };
 
@@ -343,11 +351,17 @@ pub mod tests {
             let min_rent_exempt_balance = rent.minimum_balance(0);
             genesis.genesis_config.rent = rent; // Ensure rent is non-zero, as genesis_utils sets Rent::free by default
             let bank = Bank::new_for_tests(&genesis.genesis_config);
-            let transaction_fees = 100;
-            bank.collector_fees.fetch_add(transaction_fees, Relaxed);
-            assert_eq!(transaction_fees, bank.collector_fees.load(Relaxed));
+            let fee_details = FeeDetails {
+                transaction_fee: 100,
+                prioritization_fee: 0,
+            };
+            bank.collector_fee_details.write().unwrap().add(&fee_details, 0);
+            assert_eq!(
+                fee_details.transaction_fee,
+                bank.collector_fee_details.read().unwrap().dummy()
+            );
             let (expected_collected_fees, burn_amount) =
-                bank.fee_rate_governor.burn(transaction_fees);
+                bank.fee_rate_governor.burn(fee_details.transaction_fee);
             assert!(burn_amount > 0);
 
             if test_case.scenario == Scenario::RentPaying {
@@ -355,7 +369,7 @@ pub mod tests {
                 let initial_balance = 100;
                 let account = AccountSharedData::new(initial_balance, 0, &system_program::id());
                 bank.store_account(bank.collector_id(), &account);
-                assert!(initial_balance + transaction_fees < min_rent_exempt_balance);
+                assert!(initial_balance + fee_details.transaction_fee < min_rent_exempt_balance);
             } else if test_case.scenario == Scenario::InvalidOwner {
                 // ensure that account owner is invalid and fee distribution will fail
                 let account =
@@ -375,7 +389,7 @@ pub mod tests {
             if test_case.scenario != Scenario::Normal && !test_case.disable_checks {
                 assert_eq!(initial_collector_id_balance, new_collector_id_balance);
                 assert_eq!(
-                    initial_capitalization - transaction_fees,
+                    initial_capitalization - fee_details.transaction_fee,
                     bank.capitalization()
                 );
                 let locked_rewards = bank.rewards.read().unwrap();
@@ -416,7 +430,7 @@ pub mod tests {
     fn test_distribute_transaction_fees_zero() {
         let genesis = create_genesis_config(0);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        assert_eq!(bank.collector_fees.load(Relaxed), 0);
+        assert_eq!(bank.collector_fee_details.read().unwrap().dummy(), 0);
 
         let initial_capitalization = bank.capitalization();
         let initial_collector_id_balance = bank.get_balance(bank.collector_id());
@@ -437,9 +451,15 @@ pub mod tests {
         let mut genesis = create_genesis_config(0);
         genesis.genesis_config.fee_rate_governor.burn_percent = 100;
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let transaction_fees = 100;
-        bank.collector_fees.fetch_add(transaction_fees, Relaxed);
-        assert_eq!(transaction_fees, bank.collector_fees.load(Relaxed));
+        let fee_details = FeeDetails {
+            transaction_fee: 100,
+            prioritization_fee: 0,
+        };
+        bank.collector_fee_details.write().unwrap().add(&fee_details, 0);
+        assert_eq!(
+            fee_details.transaction_fee,
+            bank.collector_fee_details.read().unwrap().dummy()
+        );
 
         let initial_capitalization = bank.capitalization();
         let initial_collector_id_balance = bank.get_balance(bank.collector_id());
@@ -448,7 +468,7 @@ pub mod tests {
 
         assert_eq!(initial_collector_id_balance, new_collector_id_balance);
         assert_eq!(
-            initial_capitalization - transaction_fees,
+            initial_capitalization - fee_details.transaction_fee,
             bank.capitalization()
         );
         let locked_rewards = bank.rewards.read().unwrap();
@@ -462,9 +482,15 @@ pub mod tests {
     fn test_distribute_transaction_fees_overflow_failure() {
         let genesis = create_genesis_config(0);
         let bank = Bank::new_for_tests(&genesis.genesis_config);
-        let transaction_fees = 100;
-        bank.collector_fees.fetch_add(transaction_fees, Relaxed);
-        assert_eq!(transaction_fees, bank.collector_fees.load(Relaxed));
+        let fee_details = FeeDetails {
+            transaction_fee: 100,
+            prioritization_fee: 0,
+        };
+        bank.collector_fee_details.write().unwrap().add(&fee_details, 0);
+        assert_eq!(
+            fee_details.transaction_fee,
+            bank.collector_fee_details.read().unwrap().dummy()
+        );
 
         // ensure that account balance will overflow and fee distribution will fail
         let account = AccountSharedData::new(u64::MAX, 0, &system_program::id());
@@ -477,7 +503,7 @@ pub mod tests {
 
         assert_eq!(initial_collector_id_balance, new_collector_id_balance);
         assert_eq!(
-            initial_capitalization - transaction_fees,
+            initial_capitalization - fee_details.transaction_fee,
             bank.capitalization()
         );
         let locked_rewards = bank.rewards.read().unwrap();

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -42,6 +42,7 @@ pub(crate) struct NewBankTimings {
     pub(crate) recompilation_time_us: u64,
     pub(crate) update_sysvars_time_us: u64,
     pub(crate) fill_sysvar_cache_time_us: u64,
+    pub(crate) write_lock_fee_cache_time_us: u64,
 }
 
 pub(crate) fn report_new_epoch_metrics(
@@ -152,6 +153,7 @@ pub(crate) fn report_new_bank_metrics(
             timings.fill_sysvar_cache_time_us,
             i64
         ),
+        ("write_lock_fee_cache_us", timings.blockhash_queue_time_us, i64),
     );
 }
 

--- a/runtime/src/bank/metrics.rs
+++ b/runtime/src/bank/metrics.rs
@@ -153,7 +153,7 @@ pub(crate) fn report_new_bank_metrics(
             timings.fill_sysvar_cache_time_us,
             i64
         ),
-        ("write_lock_fee_cache_us", timings.blockhash_queue_time_us, i64),
+        ("write_lock_fee_cache_us", timings.write_lock_fee_cache_time_us, i64),
     );
 }
 

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3335,7 +3335,6 @@ fn test_bank_parent_account_spend() {
     let key2 = Keypair::new();
     let (parent, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
     let amount = genesis_config.rent.minimum_balance(0);
-    println!("==== amount {}", amount);
 
     let tx =
         system_transaction::transfer(&mint_keypair, &key1.pubkey(), amount, genesis_config.hash());

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10989,7 +10989,7 @@ fn test_rent_state_list_len() {
         &bank.accounts().accounts_db,
         &bank.ancestors,
         &[sanitized_tx.clone()],
-        &[(Ok(()), None, Some(0))],
+        &[(Ok(()), None, Some(0), None)],
         &mut error_counters,
         &bank.rent_collector,
         &bank.feature_set,
@@ -13748,7 +13748,7 @@ fn test_filter_executable_program_accounts() {
     let programs = bank.filter_executable_program_accounts(
         &ancestors,
         &[sanitized_tx1, sanitized_tx2],
-        &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
+        &mut [(Ok(()), None, Some(0), None), (Ok(()), None, Some(0), None)],
         owners,
     );
 
@@ -13840,7 +13840,7 @@ fn test_filter_executable_program_accounts_invalid_blockhash() {
 
     let ancestors = vec![(0, 0)].into_iter().collect();
     let owners = &[program1_pubkey, program2_pubkey];
-    let mut lock_results = vec![(Ok(()), None, Some(0)), (Ok(()), None, None)];
+    let mut lock_results = vec![(Ok(()), None, Some(0), None), (Ok(()), None, None, None)];
     let programs = bank.filter_executable_program_accounts(
         &ancestors,
         &[sanitized_tx1, sanitized_tx2],

--- a/sdk/src/fee.rs
+++ b/sdk/src/fee.rs
@@ -33,13 +33,22 @@ pub struct FeeStructure {
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct FeeDetails {
-    transaction_fee: u64,
-    prioritization_fee: u64,
+    pub transaction_fee: u64,
+    pub prioritization_fee: u64,
 }
 
 impl FeeDetails {
     pub fn total_fee(&self) -> u64 {
         self.transaction_fee.saturating_add(self.prioritization_fee)
+    }
+
+    pub fn accumulate(&mut self, fee_details: &FeeDetails) {
+        self.transaction_fee = self
+            .transaction_fee
+            .saturating_add(fee_details.transaction_fee);
+        self.prioritization_fee = self
+            .prioritization_fee
+            .saturating_add(fee_details.prioritization_fee)
     }
 }
 


### PR DESCRIPTION
#### Problem

basktesting SIMD-0110 idea

#### Summary of Changes
- Fee calculation is done on three different types (transaction_fee, priority_fee, write_lock_fee) separately
- Fee collection and distribution updated to 100% reward Priority fee, 50/50 transaction fee and 100% burn write-lock-fee
- Compute_unit_pricer tracks EMA CU utilization, price fee_rate (lamports-per-cu) based on simple algo
- enable cost-tracker at replay_stage, so CU utilization can be tracked by ema
- add write-lock-fee-cache and collector-fee-details to bank, have not included in snapshot so ledger-tool can still load snapshots from mnb/testnet 

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
