### PR TITLE
SVM: Split transaction processing code into its own struct

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -86,6 +86,7 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
             CalcAccountsHashDataSource, VerifyAccountsHashAndLamportsConfig,
         },
+        accounts_file::MatchAccountOwnerError,
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
         },
@@ -576,7 +577,6 @@ impl PartialEq for Bank {
             freeze_started: _,
             vote_only_bank: _,
             cost_tracker: _,
-            sysvar_cache: _,
             accounts_data_size_initial: _,
             accounts_data_size_delta_on_chain: _,
             accounts_data_size_delta_off_chain: _,
@@ -584,6 +584,7 @@ impl PartialEq for Bank {
             incremental_snapshot_persistence: _,
             loaded_programs_cache: _,
             epoch_reward_status: _,
+            transaction_processor: _,
             // Ignore new fields explicitly if they do not impact PartialEq.
             // Adding ".." will remove compile-time checks that if a new field
             // is added to the struct, this PartialEq is accordingly updated.
@@ -823,8 +824,6 @@ pub struct Bank {
 
     cost_tracker: RwLock<CostTracker>,
 
-    sysvar_cache: RwLock<SysvarCache>,
-
     /// The initial accounts data size at the start of this Bank, before processing any transactions/etc
     accounts_data_size_initial: u64,
     /// The change to accounts data size in this Bank, due on-chain events (i.e. transactions)
@@ -844,6 +843,8 @@ pub struct Bank {
     pub loaded_programs_cache: Arc<RwLock<LoadedPrograms<BankForks>>>,
 
     epoch_reward_status: EpochRewardStatus,
+
+    transaction_processor: TransactionBatchProcessor,
 }
 
 struct VoteWithStakeDelegations {
@@ -1023,7 +1024,6 @@ impl Bank {
             freeze_started: AtomicBool::default(),
             vote_only_bank: false,
             cost_tracker: RwLock::<CostTracker>::default(),
-            sysvar_cache: RwLock::<SysvarCache>::default(),
             accounts_data_size_initial: 0,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
@@ -1033,7 +1033,10 @@ impl Bank {
                 Epoch::default(),
             ))),
             epoch_reward_status: EpochRewardStatus::default(),
+            transaction_processor: TransactionBatchProcessor::default(),
         };
+
+        bank.transaction_processor = TransactionBatchProcessor::new(&bank);
 
         let accounts_data_size_initial = bank.get_total_accounts_stats().unwrap().data_len as u64;
         bank.accounts_data_size_initial = accounts_data_size_initial;
@@ -1335,14 +1338,16 @@ impl Bank {
             )),
             freeze_started: AtomicBool::new(false),
             cost_tracker: RwLock::new(CostTracker::default()),
-            sysvar_cache: RwLock::new(SysvarCache::default()),
             accounts_data_size_initial,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
             fee_structure: parent.fee_structure.clone(),
             loaded_programs_cache: parent.loaded_programs_cache.clone(),
             epoch_reward_status: parent.epoch_reward_status.clone(),
+            transaction_processor: TransactionBatchProcessor::default(),
         };
+
+        new.transaction_processor = TransactionBatchProcessor::new(&new);
 
         let (_, ancestors_time_us) = measure_us!({
             let mut ancestors = Vec::with_capacity(1 + new.parents().len());
@@ -1838,7 +1843,6 @@ impl Bank {
             freeze_started: AtomicBool::new(fields.hash != Hash::default()),
             vote_only_bank: false,
             cost_tracker: RwLock::new(CostTracker::default()),
-            sysvar_cache: RwLock::new(SysvarCache::default()),
             accounts_data_size_initial,
             accounts_data_size_delta_on_chain: AtomicI64::new(0),
             accounts_data_size_delta_off_chain: AtomicI64::new(0),
@@ -1848,7 +1852,11 @@ impl Bank {
                 fields.epoch,
             ))),
             epoch_reward_status: fields.epoch_reward_status,
+            transaction_processor: TransactionBatchProcessor::default(),
         };
+
+        bank.transaction_processor = TransactionBatchProcessor::new(&bank);
+
         bank.finish_init(
             genesis_config,
             additional_builtins,
@@ -4584,20 +4592,22 @@ impl Bank {
     }
 }
 
-impl<'b> TransactionBatchProcessor<'b> {
-    fn program_modification_slot(&self, pubkey: &Pubkey) -> Result<Slot> {
-        let program = self
-            .bank
-            .get_account_with_fixed_root(pubkey)
+impl TransactionBatchProcessor {
+    fn program_modification_slot<CB: TransactionProcessingCallback>(
+        &self,
+        callbacks: &CB,
+        pubkey: &Pubkey,
+    ) -> Result<Slot> {
+        let program = callbacks
+            .get_account_shared_data(pubkey)
             .ok_or(TransactionError::ProgramAccountNotFound)?;
         if bpf_loader_upgradeable::check_id(program.owner()) {
             if let Ok(UpgradeableLoaderState::Program {
                 programdata_address,
             }) = program.state()
             {
-                let programdata = self
-                    .bank
-                    .get_account_with_fixed_root(&programdata_address)
+                let programdata = callbacks
+                    .get_account_shared_data(&programdata_address)
                     .ok_or(TransactionError::ProgramAccountNotFound)?;
                 if let Ok(UpgradeableLoaderState::ProgramData {
                     slot,
@@ -4617,12 +4627,13 @@ impl<'b> TransactionBatchProcessor<'b> {
         }
     }
 
-    fn load_program_accounts(
+    fn load_program_accounts<CB: TransactionProcessingCallback>(
         &self,
+        callbacks: &CB,
         pubkey: &Pubkey,
         environments: &ProgramRuntimeEnvironments,
     ) -> ProgramAccountLoadResult {
-        let program_account = match self.bank.get_account_with_fixed_root(pubkey) {
+        let program_account = match callbacks.get_account_shared_data(pubkey) {
             None => return ProgramAccountLoadResult::AccountNotFound,
             Some(account) => account,
         };
@@ -4651,11 +4662,11 @@ impl<'b> TransactionBatchProcessor<'b> {
             programdata_address,
         }) = program_account.state()
         {
-            let programdata_account =
-                match self.bank.get_account_with_fixed_root(&programdata_address) {
-                    None => return ProgramAccountLoadResult::AccountNotFound,
-                    Some(account) => account,
-                };
+            let programdata_account = match callbacks.get_account_shared_data(&programdata_address)
+            {
+                None => return ProgramAccountLoadResult::AccountNotFound,
+                Some(account) => account,
+            };
 
             if let Ok(UpgradeableLoaderState::ProgramData {
                 slot,
@@ -4709,8 +4720,9 @@ impl<'b> TransactionBatchProcessor<'b> {
         }
     }
 
-    pub fn load_program(
+    pub fn load_program<CB: TransactionProcessingCallback>(
         &self,
+        callbacks: &CB,
         pubkey: &Pubkey,
         reload: bool,
         recompile: Option<Arc<LoadedProgram>>,
@@ -4727,80 +4739,81 @@ impl<'b> TransactionBatchProcessor<'b> {
             ..LoadProgramMetrics::default()
         };
 
-        let mut loaded_program = match self.load_program_accounts(pubkey, environments) {
-            ProgramAccountLoadResult::AccountNotFound => Ok(LoadedProgram::new_tombstone(
-                self.slot,
-                LoadedProgramType::Closed,
-            )),
+        let mut loaded_program =
+            match self.load_program_accounts(callbacks, pubkey, environments) {
+                ProgramAccountLoadResult::AccountNotFound => Ok(LoadedProgram::new_tombstone(
+                    self.slot,
+                    LoadedProgramType::Closed,
+                )),
 
-            ProgramAccountLoadResult::InvalidAccountData(env) => Err((self.slot, env)),
+                ProgramAccountLoadResult::InvalidAccountData(env) => Err((self.slot, env)),
 
-            ProgramAccountLoadResult::ProgramOfLoaderV1orV2(program_account) => {
-                Self::load_program_from_bytes(
-                    &mut load_program_metrics,
-                    program_account.data(),
-                    program_account.owner(),
-                    program_account.data().len(),
-                    0,
-                    environments.program_runtime_v1.clone(),
-                    reload,
-                )
-                .map_err(|_| (0, environments.program_runtime_v1.clone()))
-            }
-
-            ProgramAccountLoadResult::ProgramOfLoaderV3(
-                program_account,
-                programdata_account,
-                slot,
-            ) => programdata_account
-                .data()
-                .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
-                .ok_or(Box::new(InstructionError::InvalidAccountData).into())
-                .and_then(|programdata| {
+                ProgramAccountLoadResult::ProgramOfLoaderV1orV2(program_account) => {
                     Self::load_program_from_bytes(
                         &mut load_program_metrics,
-                        programdata,
+                        program_account.data(),
                         program_account.owner(),
-                        program_account
-                            .data()
-                            .len()
-                            .saturating_add(programdata_account.data().len()),
-                        slot,
+                        program_account.data().len(),
+                        0,
                         environments.program_runtime_v1.clone(),
                         reload,
                     )
-                })
-                .map_err(|_| (slot, environments.program_runtime_v1.clone())),
+                    .map_err(|_| (0, environments.program_runtime_v1.clone()))
+                }
 
-            ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, slot) => program_account
-                .data()
-                .get(LoaderV4State::program_data_offset()..)
-                .ok_or(Box::new(InstructionError::InvalidAccountData).into())
-                .and_then(|elf_bytes| {
-                    Self::load_program_from_bytes(
-                        &mut load_program_metrics,
-                        elf_bytes,
-                        &loader_v4::id(),
-                        program_account.data().len(),
-                        slot,
-                        environments.program_runtime_v2.clone(),
-                        reload,
-                    )
-                })
-                .map_err(|_| (slot, environments.program_runtime_v2.clone())),
-        }
-        .unwrap_or_else(|(slot, env)| {
-            LoadedProgram::new_tombstone(slot, LoadedProgramType::FailedVerification(env))
-        });
+                ProgramAccountLoadResult::ProgramOfLoaderV3(
+                    program_account,
+                    programdata_account,
+                    slot,
+                ) => programdata_account
+                    .data()
+                    .get(UpgradeableLoaderState::size_of_programdata_metadata()..)
+                    .ok_or(Box::new(InstructionError::InvalidAccountData).into())
+                    .and_then(|programdata| {
+                        Self::load_program_from_bytes(
+                            &mut load_program_metrics,
+                            programdata,
+                            program_account.owner(),
+                            program_account
+                                .data()
+                                .len()
+                                .saturating_add(programdata_account.data().len()),
+                            slot,
+                            environments.program_runtime_v1.clone(),
+                            reload,
+                        )
+                    })
+                    .map_err(|_| (slot, environments.program_runtime_v1.clone())),
+
+                ProgramAccountLoadResult::ProgramOfLoaderV4(program_account, slot) => {
+                    program_account
+                        .data()
+                        .get(LoaderV4State::program_data_offset()..)
+                        .ok_or(Box::new(InstructionError::InvalidAccountData).into())
+                        .and_then(|elf_bytes| {
+                            Self::load_program_from_bytes(
+                                &mut load_program_metrics,
+                                elf_bytes,
+                                &loader_v4::id(),
+                                program_account.data().len(),
+                                slot,
+                                environments.program_runtime_v2.clone(),
+                                reload,
+                            )
+                        })
+                        .map_err(|_| (slot, environments.program_runtime_v2.clone()))
+                }
+            }
+            .unwrap_or_else(|(slot, env)| {
+                LoadedProgram::new_tombstone(slot, LoadedProgramType::FailedVerification(env))
+            });
 
         let mut timings = ExecuteDetailsTimings::default();
         load_program_metrics.submit_datapoint(&mut timings);
         if let Some(recompile) = recompile {
-            loaded_program.effective_slot = loaded_program.effective_slot.max(
-                self.bank
-                    .epoch_schedule()
-                    .get_first_slot_in_epoch(effective_epoch),
-            );
+            loaded_program.effective_slot = loaded_program
+                .effective_slot
+                .max(self.epoch_schedule.get_first_slot_in_epoch(effective_epoch));
             loaded_program.tx_usage_counter =
                 AtomicU64::new(recompile.tx_usage_counter.load(Ordering::Relaxed));
             loaded_program.ix_usage_counter =
@@ -4820,12 +4833,13 @@ impl Bank {
     }
 }
 
-impl<'b> TransactionBatchProcessor<'b> {
+impl TransactionBatchProcessor {
     /// Execute a transaction using the provided loaded accounts and update
     /// the executors cache if the transaction was successful.
     #[allow(clippy::too_many_arguments)]
-    fn execute_loaded_transaction(
+    fn execute_loaded_transaction<CB: TransactionProcessingCallback>(
         &self,
+        callback: &CB,
         tx: &SanitizedTransaction,
         loaded_transaction: &mut LoadedTransaction,
         compute_budget: ComputeBudget,
@@ -4857,7 +4871,7 @@ impl<'b> TransactionBatchProcessor<'b> {
 
         let mut transaction_context = TransactionContext::new(
             transaction_accounts,
-            self.rent_collector.rent.clone(),
+            callback.get_rent_collector().rent.clone(),
             compute_budget.max_invoke_stack_height,
             compute_budget.max_instruction_trace_length,
         );
@@ -4865,7 +4879,7 @@ impl<'b> TransactionBatchProcessor<'b> {
         transaction_context.set_signature(tx.signature());
 
         let pre_account_state_info = TransactionAccountStateInfo::new(
-            &self.rent_collector.rent,
+            &callback.get_rent_collector().rent,
             &transaction_context,
             tx.message(),
         );
@@ -4882,7 +4896,7 @@ impl<'b> TransactionBatchProcessor<'b> {
         };
 
         let (blockhash, lamports_per_signature) =
-            self.bank.last_blockhash_and_lamports_per_signature();
+            callback.get_last_blockhash_and_lamports_per_signature();
 
         let mut executed_units = 0u64;
         let mut programs_modified_by_tx = LoadedProgramsForTxBatch::new(
@@ -4897,10 +4911,10 @@ impl<'b> TransactionBatchProcessor<'b> {
             log_collector.clone(),
             programs_loaded_for_tx_batch,
             &mut programs_modified_by_tx,
-            self.feature_set.clone(),
+            callback.get_feature_set(),
             compute_budget,
             timings,
-            &self.bank.sysvar_cache.read().unwrap(),
+            &self.sysvar_cache.read().unwrap(),
             blockhash,
             lamports_per_signature,
             &mut executed_units,
@@ -4915,7 +4929,7 @@ impl<'b> TransactionBatchProcessor<'b> {
         let mut status = process_result
             .and_then(|info| {
                 let post_account_state_info = TransactionAccountStateInfo::new(
-                    &self.rent_collector.rent,
+                    &callback.get_rent_collector().rent,
                     &transaction_context,
                     tx.message(),
                 );
@@ -5000,8 +5014,9 @@ impl<'b> TransactionBatchProcessor<'b> {
         }
     }
 
-    fn replenish_program_cache(
+    fn replenish_program_cache<CB: TransactionProcessingCallback>(
         &self,
+        callback: &CB,
         program_accounts_map: &HashMap<Pubkey, (&Pubkey, u64)>,
     ) -> LoadedProgramsForTxBatch {
         let mut missing_programs: Vec<(Pubkey, (LoadedProgramMatchCriteria, u64))> =
@@ -5012,7 +5027,7 @@ impl<'b> TransactionBatchProcessor<'b> {
                         (
                             *pubkey,
                             (
-                                self.program_modification_slot(pubkey)
+                                self.program_modification_slot(callback, pubkey)
                                     .map_or(LoadedProgramMatchCriteria::Tombstone, |slot| {
                                         LoadedProgramMatchCriteria::DeployedOnOrAfterSlot(slot)
                                     }),
@@ -5063,7 +5078,7 @@ impl<'b> TransactionBatchProcessor<'b> {
 
             if let Some((key, count)) = program_to_load {
                 // Load, verify and compile one program.
-                let program = self.load_program(&key, false, None);
+                let program = self.load_program(callback, &key, false, None);
                 program.tx_usage_counter.store(count, Ordering::Relaxed);
                 program_to_store = Some((key, program));
             } else if missing_programs.is_empty() {
@@ -5082,9 +5097,9 @@ impl<'b> TransactionBatchProcessor<'b> {
     /// Returns a hash map of executable program accounts (program accounts that are not writable
     /// in the given transactions), and their owners, for the transactions with a valid
     /// blockhash or nonce.
-    fn filter_executable_program_accounts<'a>(
+    fn filter_executable_program_accounts<'a, CB: TransactionProcessingCallback>(
         &self,
-        ancestors: &Ancestors,
+        callbacks: &CB,
         txs: &[SanitizedTransaction],
         lock_results: &mut [TransactionCheckResult],
         program_owners: &'a [Pubkey],
@@ -5102,12 +5117,8 @@ impl<'b> TransactionBatchProcessor<'b> {
                                 saturating_add_assign!(*count, 1);
                             }
                             Entry::Vacant(entry) => {
-                                if let Ok(index) = self
-                                    .bank
-                                    .rc
-                                    .accounts
-                                    .accounts_db
-                                    .account_matches_owners(ancestors, key, program_owners)
+                                if let Ok(index) =
+                                    callbacks.account_matches_owners(key, program_owners)
                                 {
                                     program_owners
                                         .get(index)
@@ -5191,20 +5202,21 @@ impl Bank {
         debug!("check: {}us", check_time.as_us());
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_time.as_us());
 
-        let transaction_processor = TransactionBatchProcessor::new(self);
-
-        let sanitized_output = transaction_processor.load_and_execute_sanitized_transactions(
-            sanitized_txs,
-            &mut check_results,
-            &mut error_counters,
-            enable_cpi_recording,
-            enable_log_recording,
-            enable_return_data_recording,
-            timings,
-            account_overrides,
-            self.builtin_programs.iter(),
-            log_messages_bytes_limit,
-        );
+        let sanitized_output = self
+            .transaction_processor
+            .load_and_execute_sanitized_transactions(
+                self,
+                sanitized_txs,
+                &mut check_results,
+                &mut error_counters,
+                enable_cpi_recording,
+                enable_log_recording,
+                enable_return_data_recording,
+                timings,
+                account_overrides,
+                self.builtin_programs.iter(),
+                log_messages_bytes_limit,
+            );
 
         let mut signature_count = 0;
 
@@ -5334,10 +5346,11 @@ impl Bank {
     }
 }
 
-impl<'b> TransactionBatchProcessor<'b> {
+impl TransactionBatchProcessor {
     #[allow(clippy::too_many_arguments)]
-    fn load_and_execute_sanitized_transactions<'a>(
+    fn load_and_execute_sanitized_transactions<'a, CB: TransactionProcessingCallback>(
         &self,
+        callbacks: &CB,
         sanitized_txs: &[SanitizedTransaction],
         check_results: &mut [TransactionCheckResult],
         error_counters: &mut TransactionErrorMetrics,
@@ -5350,7 +5363,7 @@ impl<'b> TransactionBatchProcessor<'b> {
         log_messages_bytes_limit: Option<usize>,
     ) -> LoadAndExecuteSanitizedTransactionsOutput {
         let mut program_accounts_map = self.filter_executable_program_accounts(
-            &self.ancestors,
+            callbacks,
             sanitized_txs,
             check_results,
             PROGRAM_OWNERS,
@@ -5361,21 +5374,17 @@ impl<'b> TransactionBatchProcessor<'b> {
         }
 
         let programs_loaded_for_tx_batch = Rc::new(RefCell::new(
-            self.replenish_program_cache(&program_accounts_map),
+            self.replenish_program_cache(callbacks, &program_accounts_map),
         ));
 
         let mut load_time = Measure::start("accounts_load");
         let mut loaded_transactions = load_accounts(
-            &self.bank.rc.accounts.accounts_db,
-            &self.ancestors,
+            callbacks,
             sanitized_txs,
             check_results,
             error_counters,
-            &self.rent_collector,
-            &self.feature_set,
             &self.fee_structure,
             account_overrides,
-            self.bank.get_reward_interval(),
             &program_accounts_map,
             &programs_loaded_for_tx_batch.borrow(),
         );
@@ -5412,6 +5421,7 @@ impl<'b> TransactionBatchProcessor<'b> {
                         };
 
                     let result = self.execute_loaded_transaction(
+                        callbacks,
                         tx,
                         loaded_transaction,
                         compute_budget,
@@ -8202,7 +8212,7 @@ impl Bank {
 
     pub fn is_in_slot_hashes_history(&self, slot: &Slot) -> bool {
         if slot < &self.slot {
-            if let Ok(sysvar_cache) = self.sysvar_cache.read() {
+            if let Ok(sysvar_cache) = self.transaction_processor.sysvar_cache.read() {
                 if let Ok(slot_hashes) = sysvar_cache.get_slot_hashes() {
                     return slot_hashes.get(slot).is_some();
                 }
@@ -8212,7 +8222,7 @@ impl Bank {
     }
 
     pub fn check_program_modification_slot(&mut self) {
-        //        self.transaction_processor.check_program_modification_slot = true;
+        self.transaction_processor.check_program_modification_slot = true;
     }
 
     pub fn load_program(
@@ -8221,50 +8231,142 @@ impl Bank {
         reload: bool,
         recompile: Option<Arc<LoadedProgram>>,
     ) -> Arc<LoadedProgram> {
-        TransactionBatchProcessor::new(self).load_program(pubkey, reload, recompile)
+        self.transaction_processor
+            .load_program(self, pubkey, reload, recompile)
     }
 }
 
-struct TransactionBatchProcessor<'a> {
-    bank: &'a Bank,
+pub trait TransactionProcessingCallback {
+    fn account_matches_owners(
+        &self,
+        account: &Pubkey,
+        owners: &[Pubkey],
+    ) -> std::result::Result<usize, MatchAccountOwnerError>;
 
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
+
+    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64);
+
+    fn get_rent_collector(&self) -> &RentCollector;
+
+    fn get_feature_set(&self) -> Arc<FeatureSet>;
+
+    fn check_account_access(
+        &self,
+        _tx: &SanitizedTransaction,
+        _account_index: usize,
+        _account: &AccountSharedData,
+        _error_counters: &mut TransactionErrorMetrics,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl TransactionProcessingCallback for Bank {
+    fn account_matches_owners(
+        &self,
+        account: &Pubkey,
+        owners: &[Pubkey],
+    ) -> std::result::Result<usize, MatchAccountOwnerError> {
+        self.rc
+            .accounts
+            .accounts_db
+            .account_matches_owners(&self.ancestors, account, owners)
+    }
+
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        self.rc
+            .accounts
+            .accounts_db
+            .load_with_fixed_root(&self.ancestors, pubkey)
+            .map(|(acc, _)| acc)
+    }
+
+    fn get_last_blockhash_and_lamports_per_signature(&self) -> (Hash, u64) {
+        self.last_blockhash_and_lamports_per_signature()
+    }
+
+    fn get_rent_collector(&self) -> &RentCollector {
+        &self.rent_collector
+    }
+
+    fn get_feature_set(&self) -> Arc<FeatureSet> {
+        self.feature_set.clone()
+    }
+
+    fn check_account_access(
+        &self,
+        tx: &SanitizedTransaction,
+        account_index: usize,
+        account: &AccountSharedData,
+        error_counters: &mut TransactionErrorMetrics,
+    ) -> Result<()> {
+        if self.get_reward_interval() == RewardInterval::InsideInterval
+            && tx.message().is_writable(account_index)
+            && solana_stake_program::check_id(account.owner())
+        {
+            error_counters.program_execution_temporarily_restricted += 1;
+            Err(TransactionError::ProgramExecutionTemporarilyRestricted {
+                account_index: account_index as u8,
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(AbiExample, Debug)]
+struct TransactionBatchProcessor {
     /// Bank slot (i.e. block)
     slot: Slot,
 
     /// Bank epoch
     epoch: Epoch,
 
-    /// The set of parents including this bank
-    pub ancestors: Ancestors,
-
-    /// latest rent collector, knows the epoch
-    rent_collector: RentCollector,
-
-    pub feature_set: Arc<FeatureSet>,
+    /// initialized from genesis
+    epoch_schedule: EpochSchedule,
 
     /// Transaction fee structure
-    pub fee_structure: FeeStructure,
+    fee_structure: FeeStructure,
 
     pub check_program_modification_slot: bool,
 
     /// Optional config parameters that can override runtime behavior
     runtime_config: Arc<RuntimeConfig>,
 
+    sysvar_cache: RwLock<SysvarCache>,
+
     pub loaded_programs_cache: Arc<RwLock<LoadedPrograms<BankForks>>>,
 }
 
-impl<'b> TransactionBatchProcessor<'b> {
-    fn new(bank: &'b Bank) -> Self {
+impl Default for TransactionBatchProcessor {
+    fn default() -> Self {
         Self {
-            bank,
+            slot: Slot::default(),
+            epoch: Epoch::default(),
+            epoch_schedule: EpochSchedule::default(),
+            fee_structure: FeeStructure::default(),
+            check_program_modification_slot: false,
+            runtime_config: Arc::<RuntimeConfig>::default(),
+            sysvar_cache: RwLock::<SysvarCache>::default(),
+            loaded_programs_cache: Arc::new(RwLock::new(LoadedPrograms::new(
+                Slot::default(),
+                Epoch::default(),
+            ))),
+        }
+    }
+}
+
+impl TransactionBatchProcessor {
+    fn new(bank: &Bank) -> Self {
+        Self {
             slot: bank.slot(),
             epoch: bank.epoch(),
-            ancestors: bank.ancestors.clone(),
-            rent_collector: bank.rent_collector.clone(),
-            feature_set: bank.feature_set.clone(),
+            epoch_schedule: bank.epoch_schedule.clone(),
             fee_structure: bank.fee_structure.clone(),
             check_program_modification_slot: false,
             runtime_config: bank.runtime_config.clone(),
+            sysvar_cache: RwLock::<SysvarCache>::default(),
             loaded_programs_cache: bank.loaded_programs_cache.clone(),
         }
     }

--- a/runtime/src/bank/address_lookup_table.rs
+++ b/runtime/src/bank/address_lookup_table.rs
@@ -16,6 +16,7 @@ impl AddressLoader for &Bank {
         address_table_lookups: &[MessageAddressTableLookup],
     ) -> Result<LoadedAddresses, AddressLoaderError> {
         let slot_hashes = self
+            .transaction_processor
             .sysvar_cache
             .read()
             .unwrap()

--- a/runtime/src/bank/sysvar_cache.rs
+++ b/runtime/src/bank/sysvar_cache.rs
@@ -5,7 +5,7 @@ use {
 
 impl Bank {
     pub(crate) fn fill_missing_sysvar_cache_entries(&self) {
-        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        let mut sysvar_cache = self.transaction_processor.sysvar_cache.write().unwrap();
         sysvar_cache.fill_missing_entries(|pubkey, callback| {
             if let Some(account) = self.get_account_with_fixed_root(pubkey) {
                 callback(account.data());
@@ -14,12 +14,16 @@ impl Bank {
     }
 
     pub(crate) fn reset_sysvar_cache(&self) {
-        let mut sysvar_cache = self.sysvar_cache.write().unwrap();
+        let mut sysvar_cache = self.transaction_processor.sysvar_cache.write().unwrap();
         sysvar_cache.reset();
     }
 
     pub fn get_sysvar_cache_for_tests(&self) -> SysvarCache {
-        self.sysvar_cache.read().unwrap().clone()
+        self.transaction_processor
+            .sysvar_cache
+            .read()
+            .unwrap()
+            .clone()
     }
 }
 
@@ -40,7 +44,7 @@ mod tests {
         let (genesis_config, _mint_keypair) = create_genesis_config(100_000);
         let bank0 = Arc::new(Bank::new_for_tests(&genesis_config));
 
-        let bank0_sysvar_cache = bank0.sysvar_cache.read().unwrap();
+        let bank0_sysvar_cache = bank0.transaction_processor.sysvar_cache.read().unwrap();
         let bank0_cached_clock = bank0_sysvar_cache.get_clock();
         let bank0_cached_epoch_schedule = bank0_sysvar_cache.get_epoch_schedule();
         let bank0_cached_fees = bank0_sysvar_cache.get_fees();
@@ -60,7 +64,7 @@ mod tests {
             bank1_slot,
         ));
 
-        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
         let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
         let bank1_cached_fees = bank1_sysvar_cache.get_fees();
@@ -81,7 +85,7 @@ mod tests {
         let bank2_slot = bank1.slot() + 1;
         let bank2 = Bank::new_from_parent(bank1.clone(), &Pubkey::default(), bank2_slot);
 
-        let bank2_sysvar_cache = bank2.sysvar_cache.read().unwrap();
+        let bank2_sysvar_cache = bank2.transaction_processor.sysvar_cache.read().unwrap();
         let bank2_cached_clock = bank2_sysvar_cache.get_clock();
         let bank2_cached_epoch_schedule = bank2_sysvar_cache.get_epoch_schedule();
         let bank2_cached_fees = bank2_sysvar_cache.get_fees();
@@ -112,7 +116,7 @@ mod tests {
         let bank1_slot = bank0.slot() + 1;
         let mut bank1 = Bank::new_from_parent(bank0, &Pubkey::default(), bank1_slot);
 
-        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
         let bank1_cached_clock = bank1_sysvar_cache.get_clock();
         let bank1_cached_epoch_schedule = bank1_sysvar_cache.get_epoch_schedule();
         let bank1_cached_fees = bank1_sysvar_cache.get_fees();
@@ -130,7 +134,7 @@ mod tests {
         drop(bank1_sysvar_cache);
         bank1.reset_sysvar_cache();
 
-        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
         assert!(bank1_sysvar_cache.get_clock().is_err());
         assert!(bank1_sysvar_cache.get_epoch_schedule().is_err());
         assert!(bank1_sysvar_cache.get_fees().is_err());
@@ -155,7 +159,7 @@ mod tests {
 
         bank1.fill_missing_sysvar_cache_entries();
 
-        let bank1_sysvar_cache = bank1.sysvar_cache.read().unwrap();
+        let bank1_sysvar_cache = bank1.transaction_processor.sysvar_cache.read().unwrap();
         assert_eq!(bank1_sysvar_cache.get_clock(), bank1_cached_clock);
         assert_eq!(
             bank1_sysvar_cache.get_epoch_schedule(),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -10987,16 +10987,12 @@ fn test_rent_state_list_len() {
     let sanitized_tx = SanitizedTransaction::try_from_legacy_transaction(tx).unwrap();
     let mut error_counters = TransactionErrorMetrics::default();
     let loaded_txs = load_accounts(
-        &bank.accounts().accounts_db,
-        &bank.ancestors,
+        &bank,
         &[sanitized_tx.clone()],
         &[(Ok(()), None, Some(0))],
         &mut error_counters,
-        &bank.rent_collector,
-        &bank.feature_set,
         &FeeStructure::default(),
         None,
-        RewardInterval::OutsideInterval,
         &HashMap::new(),
         &LoadedProgramsForTxBatch::default(),
     );
@@ -13744,11 +13740,10 @@ fn test_filter_executable_program_accounts() {
     );
     let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
-    let ancestors = vec![(0, 0)].into_iter().collect();
     let owners = &[program1_pubkey, program2_pubkey];
     let transaction_processor = TransactionBatchProcessor::new(&bank);
     let programs = transaction_processor.filter_executable_program_accounts(
-        &ancestors,
+        &bank,
         &[sanitized_tx1, sanitized_tx2],
         &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
         owners,
@@ -13840,12 +13835,11 @@ fn test_filter_executable_program_accounts_invalid_blockhash() {
     // Let's not register blockhash from tx2. This should cause the tx2 to fail
     let sanitized_tx2 = SanitizedTransaction::from_transaction_for_tests(tx2);
 
-    let ancestors = vec![(0, 0)].into_iter().collect();
     let owners = &[program1_pubkey, program2_pubkey];
     let mut lock_results = vec![(Ok(()), None, Some(0)), (Ok(()), None, None)];
     let transaction_processor = TransactionBatchProcessor::new(&bank);
     let programs = transaction_processor.filter_executable_program_accounts(
-        &ancestors,
+        &bank,
         &[sanitized_tx1, sanitized_tx2],
         &mut lock_results,
         owners,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -13746,7 +13746,8 @@ fn test_filter_executable_program_accounts() {
 
     let ancestors = vec![(0, 0)].into_iter().collect();
     let owners = &[program1_pubkey, program2_pubkey];
-    let programs = bank.filter_executable_program_accounts(
+    let transaction_processor = TransactionBatchProcessor::new(&bank);
+    let programs = transaction_processor.filter_executable_program_accounts(
         &ancestors,
         &[sanitized_tx1, sanitized_tx2],
         &mut [(Ok(()), None, Some(0)), (Ok(()), None, Some(0))],
@@ -13842,7 +13843,8 @@ fn test_filter_executable_program_accounts_invalid_blockhash() {
     let ancestors = vec![(0, 0)].into_iter().collect();
     let owners = &[program1_pubkey, program2_pubkey];
     let mut lock_results = vec![(Ok(()), None, Some(0)), (Ok(()), None, None)];
-    let programs = bank.filter_executable_program_accounts(
+    let transaction_processor = TransactionBatchProcessor::new(&bank);
+    let programs = transaction_processor.filter_executable_program_accounts(
         &ancestors,
         &[sanitized_tx1, sanitized_tx2],
         &mut lock_results,

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -221,8 +221,9 @@ impl BankForks {
     }
 
     pub fn insert(&mut self, mut bank: Bank) -> BankWithScheduler {
-        bank.check_program_modification_slot =
-            self.root.load(Ordering::Relaxed) < self.highest_slot_at_startup;
+        if self.root.load(Ordering::Relaxed) < self.highest_slot_at_startup {
+            bank.check_program_modification_slot();
+        }
 
         let bank = Arc::new(bank);
         let bank = if let Some(scheduler_pool) = &self.scheduler_pool {


### PR DESCRIPTION
#### Problem
The transaction processing code is intertwined with `Bank`. It'll be easier for SVM implementation if the code could be split into its own struct and impl.

#### Summary of Changes
Move necessary code to its own struct. The impl is currently scattered around in `bank.rs` for ease of review. In a follow on PR the code will be moved to its own file, out of `bank.rs`.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
