### PR TITLE
Rename priority to compute_unit_price

### DIFF
--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -24,9 +24,9 @@ use {
     },
     solana_runtime::{
         bank::{Bank, LoadAndExecuteTransactionsOutput},
+        compute_budget_details::GetComputeBudgetDetails,
         svm::account_loader::validate_fee_payer,
         transaction_batch::TransactionBatch,
-        transaction_priority_details::GetTransactionPriorityDetails,
     },
     solana_sdk::{
         clock::{Slot, FORWARD_TRANSACTIONS_TO_LEADER_AT_SLOT_OFFSET, MAX_PROCESSING_AGE},
@@ -586,7 +586,7 @@ impl Consumer {
             .filter_map(|transaction| {
                 let round_compute_unit_price_enabled = false; // TODO get from working_bank.feature_set
                 transaction
-                    .get_transaction_priority_details(round_compute_unit_price_enabled)
+                    .get_compute_budget_details(round_compute_unit_price_enabled)
                     .map(|details| details.compute_unit_price)
             })
             .minmax();

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -587,7 +587,7 @@ impl Consumer {
                 let round_compute_unit_price_enabled = false; // TODO get from working_bank.feature_set
                 transaction
                     .get_transaction_priority_details(round_compute_unit_price_enabled)
-                    .map(|details| details.priority)
+                    .map(|details| details.compute_unit_price)
             })
             .minmax();
         let (min_prioritization_fees, max_prioritization_fees) =

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -56,7 +56,7 @@ impl ImmutableDeserializedPacket {
             .get_compute_budget_details(packet.meta().round_compute_unit_price())
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
 
-        // set priority to zero for vote transactions
+        // set compute unit price to zero for vote transactions
         if is_simple_vote {
             compute_budget_details.compute_unit_price = 0;
         };

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -60,7 +60,7 @@ impl ImmutableDeserializedPacket {
 
         // set priority to zero for vote transactions
         if is_simple_vote {
-            priority_details.priority = 0;
+            priority_details.compute_unit_price = 0;
         };
 
         Ok(Self {
@@ -88,8 +88,8 @@ impl ImmutableDeserializedPacket {
         self.is_simple_vote
     }
 
-    pub fn priority(&self) -> u64 {
-        self.priority_details.priority
+    pub fn compute_unit_price(&self) -> u64 {
+        self.priority_details.compute_unit_price
     }
 
     pub fn compute_unit_limit(&self) -> u64 {
@@ -131,7 +131,7 @@ impl PartialOrd for ImmutableDeserializedPacket {
 
 impl Ord for ImmutableDeserializedPacket {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.priority().cmp(&other.priority())
+        self.compute_unit_price().cmp(&other.compute_unit_price())
     }
 }
 

--- a/core/src/banking_stage/immutable_deserialized_packet.rs
+++ b/core/src/banking_stage/immutable_deserialized_packet.rs
@@ -1,8 +1,6 @@
 use {
     solana_perf::packet::Packet,
-    solana_runtime::transaction_priority_details::{
-        GetTransactionPriorityDetails, TransactionPriorityDetails,
-    },
+    solana_runtime::compute_budget_details::{ComputeBudgetDetails, GetComputeBudgetDetails},
     solana_sdk::{
         feature_set,
         hash::Hash,
@@ -42,7 +40,7 @@ pub struct ImmutableDeserializedPacket {
     transaction: SanitizedVersionedTransaction,
     message_hash: Hash,
     is_simple_vote: bool,
-    priority_details: TransactionPriorityDetails,
+    compute_budget_details: ComputeBudgetDetails,
 }
 
 impl ImmutableDeserializedPacket {
@@ -54,13 +52,13 @@ impl ImmutableDeserializedPacket {
         let is_simple_vote = packet.meta().is_simple_vote_tx();
 
         // drop transaction if prioritization fails.
-        let mut priority_details = sanitized_transaction
-            .get_transaction_priority_details(packet.meta().round_compute_unit_price())
+        let mut compute_budget_details = sanitized_transaction
+            .get_compute_budget_details(packet.meta().round_compute_unit_price())
             .ok_or(DeserializedPacketError::PrioritizationFailure)?;
 
         // set priority to zero for vote transactions
         if is_simple_vote {
-            priority_details.compute_unit_price = 0;
+            compute_budget_details.compute_unit_price = 0;
         };
 
         Ok(Self {
@@ -68,7 +66,7 @@ impl ImmutableDeserializedPacket {
             transaction: sanitized_transaction,
             message_hash,
             is_simple_vote,
-            priority_details,
+            compute_budget_details,
         })
     }
 
@@ -89,15 +87,15 @@ impl ImmutableDeserializedPacket {
     }
 
     pub fn compute_unit_price(&self) -> u64 {
-        self.priority_details.compute_unit_price
+        self.compute_budget_details.compute_unit_price
     }
 
     pub fn compute_unit_limit(&self) -> u64 {
-        self.priority_details.compute_unit_limit
+        self.compute_budget_details.compute_unit_limit
     }
 
-    pub fn priority_details(&self) -> TransactionPriorityDetails {
-        self.priority_details.clone()
+    pub fn compute_budget_details(&self) -> ComputeBudgetDetails {
+        self.compute_budget_details.clone()
     }
 
     // This function deserializes packets into transactions, computes the blake3 hash of transaction

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -491,7 +491,7 @@ mod tests {
         crossbeam_channel::{unbounded, Receiver},
         itertools::Itertools,
         solana_cost_model::cost_model::CostModel,
-        solana_runtime::transaction_priority_details::TransactionPriorityDetails,
+        solana_runtime::compute_budget_details::ComputeBudgetDetails,
         solana_sdk::{
             compute_budget::ComputeBudgetInstruction, feature_set::FeatureSet, hash::Hash,
             message::Message, pubkey::Pubkey, signature::Keypair, signer::Signer,
@@ -580,7 +580,7 @@ mod tests {
             container.insert_new_transaction(
                 id,
                 transaction_ttl,
-                TransactionPriorityDetails {
+                ComputeBudgetDetails {
                     compute_unit_price,
                     compute_unit_limit: 1,
                 },

--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -562,12 +562,16 @@ mod tests {
         >,
     ) -> TransactionStateContainer {
         let mut container = TransactionStateContainer::with_capacity(10 * 1024);
-        for (index, (from_keypair, to_pubkeys, lamports, priority)) in
+        for (index, (from_keypair, to_pubkeys, lamports, compute_unit_price)) in
             tx_infos.into_iter().enumerate()
         {
             let id = TransactionId::new(index as u64);
-            let transaction =
-                prioritized_tranfers(from_keypair.borrow(), to_pubkeys, lamports, priority);
+            let transaction = prioritized_tranfers(
+                from_keypair.borrow(),
+                to_pubkeys,
+                lamports,
+                compute_unit_price,
+            );
             let transaction_cost = CostModel::calculate_cost(&transaction, &FeatureSet::default());
             let transaction_ttl = SanitizedTransactionTTL {
                 transaction,
@@ -577,7 +581,7 @@ mod tests {
                 id,
                 transaction_ttl,
                 TransactionPriorityDetails {
-                    priority,
+                    compute_unit_price,
                     compute_unit_limit: 1,
                 },
                 transaction_cost,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -1,6 +1,6 @@
 use {
     solana_cost_model::transaction_cost::TransactionCost,
-    solana_runtime::transaction_priority_details::TransactionPriorityDetails,
+    solana_runtime::compute_budget_details::ComputeBudgetDetails,
     solana_sdk::{slot_history::Slot, transaction::SanitizedTransaction},
 };
 
@@ -34,13 +34,13 @@ pub(crate) enum TransactionState {
     /// The transaction is available for scheduling.
     Unprocessed {
         transaction_ttl: SanitizedTransactionTTL,
-        transaction_priority_details: TransactionPriorityDetails,
+        compute_budget_details: ComputeBudgetDetails,
         transaction_cost: TransactionCost,
         forwarded: bool,
     },
     /// The transaction is currently scheduled or being processed.
     Pending {
-        transaction_priority_details: TransactionPriorityDetails,
+        compute_budget_details: ComputeBudgetDetails,
         transaction_cost: TransactionCost,
         forwarded: bool,
     },
@@ -50,28 +50,28 @@ impl TransactionState {
     /// Creates a new `TransactionState` in the `Unprocessed` state.
     pub(crate) fn new(
         transaction_ttl: SanitizedTransactionTTL,
-        transaction_priority_details: TransactionPriorityDetails,
+        compute_budget_details: ComputeBudgetDetails,
         transaction_cost: TransactionCost,
     ) -> Self {
         Self::Unprocessed {
             transaction_ttl,
-            transaction_priority_details,
+            compute_budget_details,
             transaction_cost,
             forwarded: false,
         }
     }
 
-    /// Returns a reference to the priority details of the transaction.
-    pub(crate) fn transaction_priority_details(&self) -> &TransactionPriorityDetails {
+    /// Returns a reference to the compute budget details of the transaction.
+    pub(crate) fn compute_budget_details(&self) -> &ComputeBudgetDetails {
         match self {
             Self::Unprocessed {
-                transaction_priority_details,
+                compute_budget_details,
                 ..
-            } => transaction_priority_details,
+            } => compute_budget_details,
             Self::Pending {
-                transaction_priority_details,
+                compute_budget_details,
                 ..
-            } => transaction_priority_details,
+            } => compute_budget_details,
         }
     }
 
@@ -88,8 +88,8 @@ impl TransactionState {
     }
 
     /// Returns the priority of the transaction.
-    pub(crate) fn priority(&self) -> u64 {
-        self.transaction_priority_details().compute_unit_price
+    pub(crate) fn compute_unit_price(&self) -> u64 {
+        self.compute_budget_details().compute_unit_price
     }
 
     /// Returns whether or not the transaction has already been forwarded.
@@ -119,12 +119,12 @@ impl TransactionState {
         match self.take() {
             TransactionState::Unprocessed {
                 transaction_ttl,
-                transaction_priority_details,
+                compute_budget_details,
                 transaction_cost,
                 forwarded,
             } => {
                 *self = TransactionState::Pending {
-                    transaction_priority_details,
+                    compute_budget_details,
                     transaction_cost,
                     forwarded,
                 };
@@ -146,13 +146,13 @@ impl TransactionState {
         match self.take() {
             TransactionState::Unprocessed { .. } => panic!("already unprocessed"),
             TransactionState::Pending {
-                transaction_priority_details,
+                compute_budget_details,
                 transaction_cost,
                 forwarded,
             } => {
                 *self = Self::Unprocessed {
                     transaction_ttl,
-                    transaction_priority_details,
+                    compute_budget_details,
                     transaction_cost,
                     forwarded,
                 }
@@ -179,7 +179,7 @@ impl TransactionState {
         core::mem::replace(
             self,
             Self::Pending {
-                transaction_priority_details: TransactionPriorityDetails {
+                compute_budget_details: ComputeBudgetDetails {
                     compute_unit_price: 0,
                     compute_unit_limit: 0,
                 },
@@ -227,7 +227,7 @@ mod tests {
 
         TransactionState::new(
             transaction_ttl,
-            TransactionPriorityDetails {
+            ComputeBudgetDetails {
                 compute_unit_price,
                 compute_unit_limit: 0,
             },
@@ -294,16 +294,16 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_priority_details() {
+    fn test_compute_budget_details() {
         let priority = 15;
         let mut transaction_state = create_transaction_state(priority);
-        assert_eq!(transaction_state.priority(), priority);
+        assert_eq!(transaction_state.compute_unit_price(), priority);
 
         // ensure priority is not lost through state transitions
         let transaction_ttl = transaction_state.transition_to_pending();
-        assert_eq!(transaction_state.priority(), priority);
+        assert_eq!(transaction_state.compute_unit_price(), priority);
         transaction_state.transition_to_unprocessed(transaction_ttl);
-        assert_eq!(transaction_state.priority(), priority);
+        assert_eq!(transaction_state.compute_unit_price(), priority);
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -89,7 +89,7 @@ impl TransactionState {
 
     /// Returns the priority of the transaction.
     pub(crate) fn priority(&self) -> u64 {
-        self.transaction_priority_details().priority
+        self.transaction_priority_details().compute_unit_price
     }
 
     /// Returns whether or not the transaction has already been forwarded.
@@ -180,7 +180,7 @@ impl TransactionState {
             self,
             Self::Pending {
                 transaction_priority_details: TransactionPriorityDetails {
-                    priority: 0,
+                    compute_unit_price: 0,
                     compute_unit_limit: 0,
                 },
                 transaction_cost: TransactionCost::SimpleVote {
@@ -203,7 +203,7 @@ mod tests {
         },
     };
 
-    fn create_transaction_state(priority: u64) -> TransactionState {
+    fn create_transaction_state(compute_unit_price: u64) -> TransactionState {
         let from_keypair = Keypair::new();
         let ixs = vec![
             system_instruction::transfer(
@@ -211,7 +211,7 @@ mod tests {
                 &solana_sdk::pubkey::new_rand(),
                 1,
             ),
-            ComputeBudgetInstruction::set_compute_unit_price(priority),
+            ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
         ];
         let message = Message::new(&ixs, Some(&from_keypair.pubkey()));
         let tx = Transaction::new(&[&from_keypair], message, Hash::default());
@@ -228,7 +228,7 @@ mod tests {
         TransactionState::new(
             transaction_ttl,
             TransactionPriorityDetails {
-                priority,
+                compute_unit_price,
                 compute_unit_limit: 0,
             },
             transaction_cost,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state.rs
@@ -87,7 +87,7 @@ impl TransactionState {
         }
     }
 
-    /// Returns the priority of the transaction.
+    /// Returns the compute unit price of the transaction.
     pub(crate) fn compute_unit_price(&self) -> u64 {
         self.compute_budget_details().compute_unit_price
     }
@@ -294,16 +294,16 @@ mod tests {
     }
 
     #[test]
-    fn test_compute_budget_details() {
-        let priority = 15;
-        let mut transaction_state = create_transaction_state(priority);
-        assert_eq!(transaction_state.compute_unit_price(), priority);
+    fn test_compute_unit_price() {
+        let compute_unit_price = 15;
+        let mut transaction_state = create_transaction_state(compute_unit_price);
+        assert_eq!(transaction_state.compute_unit_price(), compute_unit_price);
 
-        // ensure priority is not lost through state transitions
+        // ensure compute unit price is not lost through state transitions
         let transaction_ttl = transaction_state.transition_to_pending();
-        assert_eq!(transaction_state.compute_unit_price(), priority);
+        assert_eq!(transaction_state.compute_unit_price(), compute_unit_price);
         transaction_state.transition_to_unprocessed(transaction_ttl);
-        assert_eq!(transaction_state.compute_unit_price(), priority);
+        assert_eq!(transaction_state.compute_unit_price(), compute_unit_price);
     }
 
     #[test]

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -102,8 +102,10 @@ impl TransactionStateContainer {
         transaction_priority_details: TransactionPriorityDetails,
         transaction_cost: TransactionCost,
     ) -> bool {
-        let priority_id =
-            TransactionPriorityId::new(transaction_priority_details.priority, transaction_id);
+        let priority_id = TransactionPriorityId::new(
+            transaction_priority_details.compute_unit_price,
+            transaction_id,
+        );
         self.id_to_transaction_state.insert(
             transaction_id,
             TransactionState::new(
@@ -210,7 +212,7 @@ mod tests {
         (
             transaction_ttl,
             TransactionPriorityDetails {
-                priority,
+                compute_unit_price: priority,
                 compute_unit_limit: 0,
             },
             transaction_cost,

--- a/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
+++ b/core/src/banking_stage/transaction_scheduler/transaction_state_container.rs
@@ -7,7 +7,7 @@ use {
     itertools::MinMaxResult,
     min_max_heap::MinMaxHeap,
     solana_cost_model::transaction_cost::TransactionCost,
-    solana_runtime::transaction_priority_details::TransactionPriorityDetails,
+    solana_runtime::compute_budget_details::ComputeBudgetDetails,
     std::collections::HashMap,
 };
 
@@ -99,20 +99,14 @@ impl TransactionStateContainer {
         &mut self,
         transaction_id: TransactionId,
         transaction_ttl: SanitizedTransactionTTL,
-        transaction_priority_details: TransactionPriorityDetails,
+        compute_budget_details: ComputeBudgetDetails,
         transaction_cost: TransactionCost,
     ) -> bool {
-        let priority_id = TransactionPriorityId::new(
-            transaction_priority_details.compute_unit_price,
-            transaction_id,
-        );
+        let priority_id =
+            TransactionPriorityId::new(compute_budget_details.compute_unit_price, transaction_id);
         self.id_to_transaction_state.insert(
             transaction_id,
-            TransactionState::new(
-                transaction_ttl,
-                transaction_priority_details,
-                transaction_cost,
-            ),
+            TransactionState::new(transaction_ttl, compute_budget_details, transaction_cost),
         );
         self.push_id_into_queue(priority_id)
     }
@@ -127,7 +121,8 @@ impl TransactionStateContainer {
         let transaction_state = self
             .get_mut_transaction_state(&transaction_id)
             .expect("transaction must exist");
-        let priority_id = TransactionPriorityId::new(transaction_state.priority(), transaction_id);
+        let priority_id =
+            TransactionPriorityId::new(transaction_state.compute_unit_price(), transaction_id);
         transaction_state.transition_to_unprocessed(transaction_ttl);
         self.push_id_into_queue(priority_id);
     }
@@ -186,7 +181,7 @@ mod tests {
         priority: u64,
     ) -> (
         SanitizedTransactionTTL,
-        TransactionPriorityDetails,
+        ComputeBudgetDetails,
         TransactionCost,
     ) {
         let from_keypair = Keypair::new();
@@ -211,7 +206,7 @@ mod tests {
         };
         (
             transaction_ttl,
-            TransactionPriorityDetails {
+            ComputeBudgetDetails {
                 compute_unit_price: priority,
                 compute_unit_limit: 0,
             },
@@ -222,12 +217,12 @@ mod tests {
     fn push_to_container(container: &mut TransactionStateContainer, num: usize) {
         for id in 0..num as u64 {
             let priority = id;
-            let (transaction_ttl, transaction_priority_details, transaction_cost) =
+            let (transaction_ttl, compute_budget_details, transaction_cost) =
                 test_transaction(priority);
             container.insert_new_transaction(
                 TransactionId::new(id),
                 transaction_ttl,
-                transaction_priority_details,
+                compute_budget_details,
                 transaction_cost,
             );
         }
@@ -253,7 +248,7 @@ mod tests {
             container
                 .id_to_transaction_state
                 .iter()
-                .map(|ts| ts.1.priority())
+                .map(|ts| ts.1.compute_unit_price())
                 .next()
                 .unwrap(),
             4

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -49,8 +49,8 @@ impl PartialOrd for DeserializedPacket {
 impl Ord for DeserializedPacket {
     fn cmp(&self, other: &Self) -> Ordering {
         self.immutable_section()
-            .priority()
-            .cmp(&other.immutable_section().priority())
+            .compute_unit_price()
+            .cmp(&other.immutable_section().compute_unit_price())
     }
 }
 
@@ -193,12 +193,16 @@ impl UnprocessedPacketBatches {
         self.packet_priority_queue.is_empty()
     }
 
-    pub fn get_min_priority(&self) -> Option<u64> {
-        self.packet_priority_queue.peek_min().map(|x| x.priority())
+    pub fn get_min_compute_unit_price(&self) -> Option<u64> {
+        self.packet_priority_queue
+            .peek_min()
+            .map(|x| x.compute_unit_price())
     }
 
-    pub fn get_max_priority(&self) -> Option<u64> {
-        self.packet_priority_queue.peek_max().map(|x| x.priority())
+    pub fn get_max_compute_unit_price(&self) -> Option<u64> {
+        self.packet_priority_queue
+            .peek_max()
+            .map(|x| x.compute_unit_price())
     }
 
     fn push_internal(&mut self, deserialized_packet: DeserializedPacket) {

--- a/core/src/banking_stage/unprocessed_packet_batches.rs
+++ b/core/src/banking_stage/unprocessed_packet_batches.rs
@@ -329,12 +329,15 @@ mod tests {
         DeserializedPacket::new(packet).unwrap()
     }
 
-    fn packet_with_priority_details(priority: u64, compute_unit_limit: u64) -> DeserializedPacket {
+    fn packet_with_compute_budget_details(
+        compute_unit_price: u64,
+        compute_unit_limit: u64,
+    ) -> DeserializedPacket {
         let from_account = solana_sdk::pubkey::new_rand();
         let tx = Transaction::new_unsigned(Message::new(
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(compute_unit_limit as u32),
-                ComputeBudgetInstruction::set_compute_unit_price(priority),
+                ComputeBudgetInstruction::set_compute_unit_price(compute_unit_price),
                 system_instruction::transfer(&from_account, &solana_sdk::pubkey::new_rand(), 1),
             ],
             Some(&from_account),
@@ -360,10 +363,10 @@ mod tests {
     #[test]
     fn test_unprocessed_packet_batches_insert_minimum_packet_over_capacity() {
         let heavier_packet_weight = 2;
-        let heavier_packet = packet_with_priority_details(heavier_packet_weight, 200_000);
+        let heavier_packet = packet_with_compute_budget_details(heavier_packet_weight, 200_000);
 
         let lesser_packet_weight = heavier_packet_weight - 1;
-        let lesser_packet = packet_with_priority_details(lesser_packet_weight, 200_000);
+        let lesser_packet = packet_with_compute_budget_details(lesser_packet_weight, 200_000);
 
         // Test that the heavier packet is actually heavier
         let mut unprocessed_packet_batches = UnprocessedPacketBatches::with_capacity(2);

--- a/core/src/banking_stage/unprocessed_transaction_storage.rs
+++ b/core/src/banking_stage/unprocessed_transaction_storage.rs
@@ -286,7 +286,7 @@ impl UnprocessedTransactionStorage {
         match self {
             Self::VoteStorage(_) => None,
             Self::LocalTransactionStorage(transaction_storage) => {
-                transaction_storage.get_min_priority()
+                transaction_storage.get_min_compute_unit_price()
             }
         }
     }
@@ -295,7 +295,7 @@ impl UnprocessedTransactionStorage {
         match self {
             Self::VoteStorage(_) => None,
             Self::LocalTransactionStorage(transaction_storage) => {
-                transaction_storage.get_max_priority()
+                transaction_storage.get_max_compute_unit_price()
             }
         }
     }
@@ -547,12 +547,12 @@ impl ThreadLocalUnprocessedPackets {
         self.unprocessed_packet_batches.len()
     }
 
-    pub fn get_min_priority(&self) -> Option<u64> {
-        self.unprocessed_packet_batches.get_min_priority()
+    pub fn get_min_compute_unit_price(&self) -> Option<u64> {
+        self.unprocessed_packet_batches.get_min_compute_unit_price()
     }
 
-    pub fn get_max_priority(&self) -> Option<u64> {
-        self.unprocessed_packet_batches.get_max_priority()
+    pub fn get_max_compute_unit_price(&self) -> Option<u64> {
+        self.unprocessed_packet_batches.get_max_compute_unit_price()
     }
 
     fn max_receive_size(&self) -> usize {

--- a/program-runtime/src/prioritization_fee.rs
+++ b/program-runtime/src/prioritization_fee.rs
@@ -10,15 +10,15 @@ pub enum PrioritizationFeeType {
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct PrioritizationFeeDetails {
     fee: u64,
-    priority: u64,
+    compute_unit_price: u64,
 }
 
 impl PrioritizationFeeDetails {
     pub fn new(fee_type: PrioritizationFeeType, compute_unit_limit: u64) -> Self {
         match fee_type {
-            PrioritizationFeeType::ComputeUnitPrice(cu_price) => {
+            PrioritizationFeeType::ComputeUnitPrice(compute_unit_price) => {
                 let micro_lamport_fee: MicroLamports =
-                    (cu_price as u128).saturating_mul(compute_unit_limit as u128);
+                    (compute_unit_price as u128).saturating_mul(compute_unit_limit as u128);
                 let fee = micro_lamport_fee
                     .saturating_add(MICRO_LAMPORTS_PER_LAMPORT.saturating_sub(1) as u128)
                     .checked_div(MICRO_LAMPORTS_PER_LAMPORT as u128)
@@ -27,7 +27,7 @@ impl PrioritizationFeeDetails {
 
                 Self {
                     fee,
-                    priority: cu_price,
+                    compute_unit_price,
                 }
             }
         }
@@ -37,8 +37,8 @@ impl PrioritizationFeeDetails {
         self.fee
     }
 
-    pub fn get_priority(&self) -> u64 {
-        self.priority
+    pub fn get_compute_unit_price(&self) -> u64 {
+        self.compute_unit_price
     }
 }
 
@@ -62,7 +62,7 @@ mod test {
             FeeDetails::new(FeeType::ComputeUnitPrice(MICRO_LAMPORTS_PER_LAMPORT - 1), 1),
             FeeDetails {
                 fee: 1,
-                priority: MICRO_LAMPORTS_PER_LAMPORT - 1,
+                compute_unit_price: MICRO_LAMPORTS_PER_LAMPORT - 1,
             },
             "should round up (<1.0) lamport fee to 1 lamport"
         );
@@ -71,7 +71,7 @@ mod test {
             FeeDetails::new(FeeType::ComputeUnitPrice(MICRO_LAMPORTS_PER_LAMPORT), 1),
             FeeDetails {
                 fee: 1,
-                priority: MICRO_LAMPORTS_PER_LAMPORT,
+                compute_unit_price: MICRO_LAMPORTS_PER_LAMPORT,
             },
         );
 
@@ -79,7 +79,7 @@ mod test {
             FeeDetails::new(FeeType::ComputeUnitPrice(MICRO_LAMPORTS_PER_LAMPORT + 1), 1),
             FeeDetails {
                 fee: 2,
-                priority: MICRO_LAMPORTS_PER_LAMPORT + 1,
+                compute_unit_price: MICRO_LAMPORTS_PER_LAMPORT + 1,
             },
             "should round up (>1.0) lamport fee to 2 lamports"
         );
@@ -88,7 +88,7 @@ mod test {
             FeeDetails::new(FeeType::ComputeUnitPrice(200), 100_000),
             FeeDetails {
                 fee: 20,
-                priority: 200,
+                compute_unit_price: 200,
             },
         );
 
@@ -99,7 +99,7 @@ mod test {
             ),
             FeeDetails {
                 fee: u64::MAX,
-                priority: MICRO_LAMPORTS_PER_LAMPORT,
+                compute_unit_price: MICRO_LAMPORTS_PER_LAMPORT,
             },
         );
 
@@ -107,7 +107,7 @@ mod test {
             FeeDetails::new(FeeType::ComputeUnitPrice(u64::MAX), u64::MAX),
             FeeDetails {
                 fee: u64::MAX,
-                priority: u64::MAX,
+                compute_unit_price: u64::MAX,
             },
         );
     }

--- a/runtime/src/compute_budget_details.rs
+++ b/runtime/src/compute_budget_details.rs
@@ -8,34 +8,34 @@ use {
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TransactionPriorityDetails {
+pub struct ComputeBudgetDetails {
     pub compute_unit_price: u64,
     pub compute_unit_limit: u64,
 }
 
-pub trait GetTransactionPriorityDetails {
-    fn get_transaction_priority_details(
+pub trait GetComputeBudgetDetails {
+    fn get_compute_budget_details(
         &self,
         round_compute_unit_price_enabled: bool,
-    ) -> Option<TransactionPriorityDetails>;
+    ) -> Option<ComputeBudgetDetails>;
 
     fn process_compute_budget_instruction<'a>(
         instructions: impl Iterator<Item = (&'a Pubkey, &'a CompiledInstruction)>,
         _round_compute_unit_price_enabled: bool,
-    ) -> Option<TransactionPriorityDetails> {
+    ) -> Option<ComputeBudgetDetails> {
         let compute_budget_limits = process_compute_budget_instructions(instructions).ok()?;
-        Some(TransactionPriorityDetails {
+        Some(ComputeBudgetDetails {
             compute_unit_price: compute_budget_limits.compute_unit_price,
             compute_unit_limit: u64::from(compute_budget_limits.compute_unit_limit),
         })
     }
 }
 
-impl GetTransactionPriorityDetails for SanitizedVersionedTransaction {
-    fn get_transaction_priority_details(
+impl GetComputeBudgetDetails for SanitizedVersionedTransaction {
+    fn get_compute_budget_details(
         &self,
         round_compute_unit_price_enabled: bool,
-    ) -> Option<TransactionPriorityDetails> {
+    ) -> Option<ComputeBudgetDetails> {
         Self::process_compute_budget_instruction(
             self.get_message().program_instructions_iter(),
             round_compute_unit_price_enabled,
@@ -43,11 +43,11 @@ impl GetTransactionPriorityDetails for SanitizedVersionedTransaction {
     }
 }
 
-impl GetTransactionPriorityDetails for SanitizedTransaction {
-    fn get_transaction_priority_details(
+impl GetComputeBudgetDetails for SanitizedTransaction {
+    fn get_compute_budget_details(
         &self,
         round_compute_unit_price_enabled: bool,
-    ) -> Option<TransactionPriorityDetails> {
+    ) -> Option<ComputeBudgetDetails> {
         Self::process_compute_budget_instruction(
             self.message().program_instructions_iter(),
             round_compute_unit_price_enabled,
@@ -70,7 +70,7 @@ mod tests {
     };
 
     #[test]
-    fn test_get_priority_with_valid_request_heap_frame_tx() {
+    fn test_get_compute_budget_details_with_valid_request_heap_frame_tx() {
         let keypair = Keypair::new();
         let transaction = Transaction::new_unsigned(Message::new(
             &[
@@ -85,8 +85,8 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_versioned_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
@@ -98,8 +98,8 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_priority_with_valid_set_compute_units_limit() {
+    fn test_get_compute_budget_details_with_valid_set_compute_units_limit() {
         let requested_cu = 101u32;
         let keypair = Keypair::new();
         let transaction = Transaction::new_unsigned(Message::new(
@@ -125,8 +125,8 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_versioned_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit: requested_cu as u64,
             })
@@ -136,8 +136,8 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: 0,
                 compute_unit_limit: requested_cu as u64,
             })
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_priority_with_valid_set_compute_unit_price() {
+    fn test_get_compute_budget_details_with_valid_set_compute_unit_price() {
         let requested_price = 1_000;
         let keypair = Keypair::new();
         let transaction = Transaction::new_unsigned(Message::new(
@@ -161,8 +161,8 @@ mod tests {
         let sanitized_versioned_transaction =
             SanitizedVersionedTransaction::try_new(versioned_transaction).unwrap();
         assert_eq!(
-            sanitized_versioned_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_versioned_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: requested_price,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
@@ -174,8 +174,8 @@ mod tests {
         let sanitized_transaction =
             SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
         assert_eq!(
-            sanitized_transaction.get_transaction_priority_details(false),
-            Some(TransactionPriorityDetails {
+            sanitized_transaction.get_compute_budget_details(false),
+            Some(ComputeBudgetDetails {
                 compute_unit_price: requested_price,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bank_forks;
 pub mod bank_utils;
 pub mod builtins;
 pub mod commitment;
+pub mod compute_budget_details;
 mod epoch_rewards_hasher;
 pub mod epoch_stakes;
 pub mod genesis_utils;
@@ -38,7 +39,6 @@ pub mod static_ids;
 pub mod status_cache;
 pub mod svm;
 pub mod transaction_batch;
-pub mod transaction_priority_details;
 
 #[macro_use]
 extern crate solana_metrics;

--- a/runtime/src/prioritization_fee.rs
+++ b/runtime/src/prioritization_fee.rs
@@ -124,9 +124,9 @@ pub enum PrioritizationFeeError {
     // minimum fees.
     FailGetTransactionAccountLocks,
 
-    // Not able to read priority details, including compute-unit price, from transaction.
+    // Not able to read compute budget details, including compute-unit price, from transaction.
     // Compute-unit price is required to update block minimum fees.
-    FailGetTransactionPriorityDetails,
+    FailGetComputeBudgetDetails,
 
     // Block is already finalized, trying to finalize it again is usually unexpected
     BlockIsAlreadyFinalized,

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -205,8 +205,8 @@ impl PrioritizationFeeCache {
         }
     }
 
-    /// Update with a list of non-vote transactions' tx_compute_budget_details and tx_account_locks; Only
-    /// transactions have both valid priority_detail and account_locks will be used to update
+    /// Update with a list of non-vote transactions' compute_budget_details and account_locks; Only
+    /// transactions have both valid compute_budget_details and account_locks will be used to update
     /// fee_cache asynchronously.
     pub fn update<'a>(&self, bank: &Bank, txs: impl Iterator<Item = &'a SanitizedTransaction>) {
         let (_, send_updates_time) = measure!(

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        bank::Bank, prioritization_fee::*,
-        transaction_priority_details::GetTransactionPriorityDetails,
-    },
+    crate::{bank::Bank, compute_budget_details::GetComputeBudgetDetails, prioritization_fee::*},
     crossbeam_channel::{unbounded, Receiver, Sender},
     dashmap::DashMap,
     log::*,
@@ -208,7 +205,7 @@ impl PrioritizationFeeCache {
         }
     }
 
-    /// Update with a list of non-vote transactions' tx_priority_details and tx_account_locks; Only
+    /// Update with a list of non-vote transactions' tx_compute_budget_details and tx_account_locks; Only
     /// transactions have both valid priority_detail and account_locks will be used to update
     /// fee_cache asynchronously.
     pub fn update<'a>(&self, bank: &Bank, txs: impl Iterator<Item = &'a SanitizedTransaction>) {
@@ -222,19 +219,19 @@ impl PrioritizationFeeCache {
                     }
 
                     let round_compute_unit_price_enabled = false; // TODO: bank.feture_set.is_active(round_compute_unit_price)
-                    let priority_details = sanitized_transaction
-                        .get_transaction_priority_details(round_compute_unit_price_enabled);
+                    let compute_budget_details = sanitized_transaction
+                        .get_compute_budget_details(round_compute_unit_price_enabled);
                     let account_locks = sanitized_transaction
                         .get_account_locks(bank.get_transaction_account_lock_limit());
 
-                    if priority_details.is_none() || account_locks.is_err() {
+                    if compute_budget_details.is_none() || account_locks.is_err() {
                         continue;
                     }
-                    let priority_details = priority_details.unwrap();
+                    let compute_budget_details = compute_budget_details.unwrap();
 
                     // filter out any transaction that requests zero compute_unit_limit
                     // since its priority fee amount is not instructive
-                    if priority_details.compute_unit_limit == 0 {
+                    if compute_budget_details.compute_unit_limit == 0 {
                         continue;
                     }
 
@@ -251,7 +248,7 @@ impl PrioritizationFeeCache {
                         .send(CacheServiceUpdate::TransactionUpdate {
                             slot: bank.slot(),
                             bank_id: bank.bank_id(),
-                            transaction_fee: priority_details.compute_unit_price,
+                            transaction_fee: compute_budget_details.compute_unit_price,
                             writable_accounts,
                         })
                         .unwrap_or_else(|err| {

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -251,7 +251,7 @@ impl PrioritizationFeeCache {
                         .send(CacheServiceUpdate::TransactionUpdate {
                             slot: bank.slot(),
                             bank_id: bank.bank_id(),
-                            transaction_fee: priority_details.priority,
+                            transaction_fee: priority_details.compute_unit_price,
                             writable_accounts,
                         })
                         .unwrap_or_else(|err| {

--- a/runtime/src/transaction_priority_details.rs
+++ b/runtime/src/transaction_priority_details.rs
@@ -9,7 +9,7 @@ use {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TransactionPriorityDetails {
-    pub priority: u64,
+    pub compute_unit_price: u64,
     pub compute_unit_limit: u64,
 }
 
@@ -25,7 +25,7 @@ pub trait GetTransactionPriorityDetails {
     ) -> Option<TransactionPriorityDetails> {
         let compute_budget_limits = process_compute_budget_instructions(instructions).ok()?;
         Some(TransactionPriorityDetails {
-            priority: compute_budget_limits.compute_unit_price,
+            compute_unit_price: compute_budget_limits.compute_unit_price,
             compute_unit_limit: u64::from(compute_budget_limits.compute_unit_limit),
         })
     }
@@ -87,7 +87,7 @@ mod tests {
         assert_eq!(
             sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: 0,
+                compute_unit_price: 0,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
@@ -100,7 +100,7 @@ mod tests {
         assert_eq!(
             sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: 0,
+                compute_unit_price: 0,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
@@ -127,7 +127,7 @@ mod tests {
         assert_eq!(
             sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: 0,
+                compute_unit_price: 0,
                 compute_unit_limit: requested_cu as u64,
             })
         );
@@ -138,7 +138,7 @@ mod tests {
         assert_eq!(
             sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: 0,
+                compute_unit_price: 0,
                 compute_unit_limit: requested_cu as u64,
             })
         );
@@ -163,7 +163,7 @@ mod tests {
         assert_eq!(
             sanitized_versioned_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: requested_price,
+                compute_unit_price: requested_price,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,
@@ -176,7 +176,7 @@ mod tests {
         assert_eq!(
             sanitized_transaction.get_transaction_priority_details(false),
             Some(TransactionPriorityDetails {
-                priority: requested_price,
+                compute_unit_price: requested_price,
                 compute_unit_limit:
                     solana_program_runtime::compute_budget_processor::DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT
                     as u64,


### PR DESCRIPTION
#### Problem
- Term "priority" is overloaded and used in multiple places to mean different things

#### Summary of Changes
- Split out of #34888 to make the overloaded "priority" less overloaded
- Renames `TransactionPriorityDetails` `priority` field to `compute_unit_price`
- Renames `TransactionPriorityDetails` and associated traits to `ComputeBudgetDetails`

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
