### PR TITLE
Removes redundant check on STORE_META_OVERHEAD

### DIFF
--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -724,13 +724,6 @@ pub mod tests {
         }
     }
 
-    static_assertions::const_assert_eq!(
-        STORE_META_OVERHEAD,
-        std::mem::size_of::<StoredMeta>()
-            + std::mem::size_of::<AccountMeta>()
-            + std::mem::size_of::<Hash>()
-    );
-
     // Hash is [u8; 32], which has no alignment
     static_assertions::assert_eq_align!(u64, StoredMeta, AccountMeta);
 


### PR DESCRIPTION
#### Problem

I added a check for `STORE_META_OVERHEAD` in #35053, but turns out there already was one down in the tests module. It was pointed out here: https://github.com/solana-labs/solana/pull/35053#issuecomment-1924836417. So now we have two basically identical checks, but only need one.


#### Summary of Changes

Remove the test-only check.