### PR TITLE
Show error instead of panic on passphrase mismatch during solana-keygen

### DIFF
--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -488,7 +488,8 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let derivation_path = acquire_derivation_path(matches)?;
 
             let mnemonic = Mnemonic::new(mnemonic_type, language);
-            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).map_err(|err| format!("Unable to acquire passphrase: {err}"))?;
+            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches)
+                .map_err(|err| format!("Unable to acquire passphrase: {err}"))?;
 
             let seed = Seed::new(&mnemonic, &passphrase);
             let keypair = match derivation_path {

--- a/keygen/src/keygen.rs
+++ b/keygen/src/keygen.rs
@@ -488,7 +488,7 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             let derivation_path = acquire_derivation_path(matches)?;
 
             let mnemonic = Mnemonic::new(mnemonic_type, language);
-            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
+            let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).map_err(|err| format!("Unable to acquire passphrase: {err}"))?;
 
             let seed = Seed::new(&mnemonic, &passphrase);
             let keypair = match derivation_path {


### PR DESCRIPTION
#### Problem
During the `solana-keygen` process, if an user enters mismatching passphrases, then the program simply crashes and doesn't show any intuitive error message to the user. 

#### Summary of Changes
Just added `map_err` instead of `unwrap` on `acquire_passphrase_and_message`.

Fixes https://github.com/solana-labs/solana/issues/34811
<!-- OPTIONAL: Feature Gate Issue: # -->

<!-- Don't forget to add the "feature-gate" label -->
