### PR TITLE
cli: add transaction retry pool max size

### DIFF
--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -28,8 +28,8 @@ use {
     },
 };
 
-/// Maximum size of the transaction queue
-const MAX_TRANSACTION_QUEUE_SIZE: usize = 10_000; // This seems like a lot but maybe it needs to be bigger one day
+/// Maximum size of the transaction retry pool
+const MAX_TRANSACTION_RETRY_POOL_SIZE: usize = 10_000; // This seems like a lot but maybe it needs to be bigger one day
 
 /// Default retry interval
 const DEFAULT_RETRY_RATE_MS: u64 = 2_000;
@@ -114,6 +114,8 @@ pub struct Config {
     pub batch_size: usize,
     /// How frequently batches are sent
     pub batch_send_rate_ms: u64,
+    /// On exceeding max transaction pool size new transactions would be dropped
+    pub transaction_retry_pool_max_size: usize,
 }
 
 impl Default for Config {
@@ -125,6 +127,7 @@ impl Default for Config {
             service_max_retries: DEFAULT_SERVICE_MAX_RETRIES,
             batch_size: DEFAULT_TRANSACTION_BATCH_SIZE,
             batch_send_rate_ms: DEFAULT_BATCH_SEND_RATE_MS,
+            transaction_retry_pool_max_size: MAX_TRANSACTION_RETRY_POOL_SIZE,
         }
     }
 }
@@ -477,7 +480,7 @@ impl SendTransactionService {
                             let retry_len = retry_transactions.len();
                             let entry = retry_transactions.entry(signature);
                             if let Entry::Vacant(_) = entry {
-                                if retry_len >= MAX_TRANSACTION_QUEUE_SIZE {
+                                if retry_len >= config.transaction_retry_pool_max_size {
                                     datapoint_warn!("send_transaction_service-queue-overflow");
                                     break;
                                 } else {

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1046,6 +1046,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .help("The size of transactions to be sent in batch."),
         )
         .arg(
+            Arg::with_name("rpc_send_transaction_retry_pool_max_size")
+                .long("rpc-send-transaction-retry-pool-max-size")
+                .value_name("NUMBER")
+                .takes_value(true)
+                .validator(is_parsable::<usize>)
+                .default_value(&default_args.rpc_send_transaction_retry_pool_max_size)
+                .help("The maximum size of transactions retry pool.")
+        )
+        .arg(
             Arg::with_name("rpc_scan_and_fix_roots")
                 .long("rpc-scan-and-fix-roots")
                 .takes_value(false)
@@ -1957,6 +1966,7 @@ pub struct DefaultArgs {
     pub rpc_send_transaction_leader_forward_count: String,
     pub rpc_send_transaction_service_max_retries: String,
     pub rpc_send_transaction_batch_size: String,
+    pub rpc_send_transaction_retry_pool_max_size: String,
     pub rpc_threads: String,
     pub rpc_niceness_adjustment: String,
     pub rpc_bigtable_timeout: String,
@@ -2041,6 +2051,9 @@ impl DefaultArgs {
                 .to_string(),
             rpc_send_transaction_batch_size: default_send_transaction_service_config
                 .batch_size
+                .to_string(),
+            rpc_send_transaction_retry_pool_max_size: default_send_transaction_service_config
+                .transaction_retry_pool_max_size
                 .to_string(),
             rpc_threads: num_cpus::get().to_string(),
             rpc_niceness_adjustment: "0".to_string(),

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1412,6 +1412,11 @@ pub fn main() {
             ),
             batch_send_rate_ms: rpc_send_batch_send_rate_ms,
             batch_size: rpc_send_batch_size,
+            transaction_retry_pool_max_size: value_t_or_exit!(
+                matches,
+                "rpc_send_transaction_retry_pool_max_size",
+                usize
+            ),
         },
         no_poh_speed_test: matches.is_present("no_poh_speed_test"),
         no_os_memory_stats_reporting: matches.is_present("no_os_memory_stats_reporting"),


### PR DESCRIPTION
#### Problem

Retry pool size is not configurable

#### Summary of Changes

Allow to set retry pool size in CLI arguments