### PR TITLE
send-transactions: optimize retry pool

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -996,7 +996,7 @@ impl Validator {
                 rpc_override_health_check.clone(),
                 startup_verification_complete,
                 optimistically_confirmed_bank.clone(),
-                config.send_transaction_service_config.clone(),
+                config.send_transaction_service_config,
                 max_slots.clone(),
                 leader_schedule_cache.clone(),
                 connection_cache.clone(),

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -38,7 +38,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         debug_keys: config.debug_keys.clone(),
         contact_debug_interval: config.contact_debug_interval,
         contact_save_interval: config.contact_save_interval,
-        send_transaction_service_config: config.send_transaction_service_config.clone(),
+        send_transaction_service_config: config.send_transaction_service_config,
         no_poh_speed_test: config.no_poh_speed_test,
         no_os_memory_stats_reporting: config.no_os_memory_stats_reporting,
         no_os_network_stats_reporting: config.no_os_network_stats_reporting,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -662,12 +662,11 @@ impl SendTransactionService {
                     if need_send {
                         if transaction_info.last_sent_time.is_some() {
                             // Transaction sent before is unknown to the working bank, it might have been
-                            // dropped or landed in another fork.  Re-send it
+                            // dropped or landed in another fork. Re-send it.
 
                             info!("Retrying transaction: {}", signature);
                             result.retried += 1;
                             transaction_info.retries += 1;
-                            stats.retries.fetch_add(1, Ordering::Relaxed);
                         }
 
                         batched_transactions.push(*signature);
@@ -688,6 +687,8 @@ impl SendTransactionService {
                 }
             }
         });
+
+        stats.retries.fetch_add(result.retried, Ordering::Relaxed);
 
         if !batched_transactions.is_empty() {
             // Processing the transactions in batch

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -574,8 +574,8 @@ impl SendTransactionService {
         );
 
         let wire_transactions = transactions
-            .iter()
-            .map(|(_, transaction_info)| {
+            .values()
+            .map(|transaction_info| {
                 debug!(
                     "Sending transacation {} to (address, slot): {:?}",
                     transaction_info.signature, addresses,

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -167,7 +167,8 @@ where
             let now = Instant::now();
             let need_refresh = self
                 .last_leader_refresh
-                .map(|last| now.duration_since(last) >= self.refresh_rate)
+                .and_then(|last| now.checked_duration_since(last))
+                .map(|elapsed| elapsed >= self.refresh_rate)
                 .unwrap_or(true);
 
             if need_refresh {
@@ -630,7 +631,8 @@ impl SendTransactionService {
                 let now = Instant::now();
                 let expired = transaction_info
                     .last_sent_time
-                    .map(|last| now.duration_since(last) >= retry_rate)
+                    .and_then(|last| now.checked_duration_since(last))
+                    .map(|elapsed| elapsed >= retry_rate)
                     .unwrap_or(false);
                 let verify_nonce_account =
                     nonce_account::verify_nonce_account(&nonce_account, &durable_nonce);
@@ -653,7 +655,8 @@ impl SendTransactionService {
                     let now = Instant::now();
                     let need_send = transaction_info
                         .last_sent_time
-                        .map(|last| now.duration_since(last) >= retry_rate)
+                        .and_then(|last| now.checked_duration_since(last))
+                        .map(|elapsed| elapsed >= retry_rate)
                         .unwrap_or(true);
                     if need_send {
                         if transaction_info.last_sent_time.is_some() {

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -103,7 +103,7 @@ struct ProcessTransactionsResult {
     retained: u64,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Config {
     pub retry_rate_ms: u64,
     pub leader_forward_count: u64,
@@ -375,7 +375,7 @@ impl SendTransactionService {
             receiver,
             leader_info_provider.clone(),
             connection_cache.clone(),
-            config.clone(),
+            config,
             retry_transactions.clone(),
             stats_report.clone(),
             exit.clone(),

--- a/send-transaction-service/src/send_transaction_service.rs
+++ b/send-transaction-service/src/send_transaction_service.rs
@@ -565,11 +565,14 @@ impl SendTransactionService {
                     stats_report.report();
 
                     retry_interval_ms = retry_interval_ms_default
-                        - result
-                            .last_sent_time
-                            .and_then(|last| Instant::now().checked_duration_since(last))
-                            .and_then(|interval| interval.as_millis().try_into().ok())
-                            .unwrap_or(0);
+                        .checked_sub(
+                            result
+                                .last_sent_time
+                                .and_then(|last| Instant::now().checked_duration_since(last))
+                                .and_then(|interval| interval.as_millis().try_into().ok())
+                                .unwrap_or(0),
+                        )
+                        .unwrap_or(retry_interval_ms_default);
                 }
             })
             .unwrap()


### PR DESCRIPTION
#### Problem

Transactions not included in the retry pool  on full utilization

#### Summary of Changes

- do not insert transactions with zero max_retries to the retry pool
- remove transactions reached max_retries in the same iteration of the loop
- dynamically select sleep time between iterations based on `last_sent_time` in `TransactionInfo`