### PR TITLE
Scheduler: Leader-Slot metrics for Scheduler

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
+++ b/core/src/banking_stage/transaction_scheduler/scheduler_controller.rs
@@ -5,7 +5,10 @@ use {
     super::{
         prio_graph_scheduler::PrioGraphScheduler,
         scheduler_error::SchedulerError,
-        scheduler_metrics::{SchedulerCountMetrics, SchedulerTimingMetrics},
+        scheduler_metrics::{
+            IntervalSchedulerCountMetrics, IntervalSchedulerTimingMetrics,
+            SlotSchedulerCountMetrics, SlotSchedulerTimingMetrics,
+        },
         transaction_id_generator::TransactionIdGenerator,
         transaction_state::SanitizedTransactionTTL,
         transaction_state_container::TransactionStateContainer,
@@ -30,6 +33,7 @@ use {
     },
     solana_svm::transaction_error_metrics::TransactionErrorMetrics,
     std::{
+        ops::DerefMut,
         sync::{Arc, RwLock},
         time::Duration,
     },
@@ -49,10 +53,18 @@ pub(crate) struct SchedulerController {
     container: TransactionStateContainer,
     /// State for scheduling and communicating with worker threads.
     scheduler: PrioGraphScheduler,
-    /// Metrics tracking counts on transactions in different states.
-    count_metrics: SchedulerCountMetrics,
-    /// Metrics tracking time spent in different code sections.
-    timing_metrics: SchedulerTimingMetrics,
+    /// Metrics tracking counts on transactions in different states
+    /// over an interval.
+    interval_count_metrics: IntervalSchedulerCountMetrics,
+    /// Metrics tracking counts on transactions in different states
+    /// during a leader slot.
+    slot_count_metrics: SlotSchedulerCountMetrics,
+    /// Metrics tracking time spent in different code sections
+    /// over an interval.
+    interval_timing_metrics: IntervalSchedulerTimingMetrics,
+    /// Metrics tracking time spent in different code sections
+    /// during a leader slot.
+    slot_timing_metrics: SlotSchedulerTimingMetrics,
     /// Metric report handles for the worker threads.
     worker_metrics: Vec<Arc<ConsumeWorkerMetrics>>,
 }
@@ -72,8 +84,10 @@ impl SchedulerController {
             transaction_id_generator: TransactionIdGenerator::default(),
             container: TransactionStateContainer::with_capacity(TOTAL_BUFFERED_PACKETS),
             scheduler,
-            count_metrics: SchedulerCountMetrics::default(),
-            timing_metrics: SchedulerTimingMetrics::default(),
+            interval_count_metrics: IntervalSchedulerCountMetrics::default(),
+            slot_count_metrics: SlotSchedulerCountMetrics::default(),
+            interval_timing_metrics: IntervalSchedulerTimingMetrics::default(),
+            slot_timing_metrics: SlotSchedulerTimingMetrics::default(),
             worker_metrics,
         }
     }
@@ -92,7 +106,15 @@ impl SchedulerController {
             // bypass sanitization and buffering and immediately drop the packets.
             let (decision, decision_time_us) =
                 measure_us!(self.decision_maker.make_consume_or_forward_decision());
-            saturating_add_assign!(self.timing_metrics.decision_time_us, decision_time_us);
+            saturating_add_assign!(
+                self.interval_timing_metrics.decision_time_us,
+                decision_time_us
+            );
+            let new_leader_slot = decision.bank_start().map(|b| b.working_bank.slot());
+            self.slot_count_metrics
+                .maybe_report_and_reset(new_leader_slot);
+            self.slot_timing_metrics
+                .maybe_report_and_reset(new_leader_slot);
 
             self.process_transactions(&decision)?;
             self.receive_completed()?;
@@ -101,11 +123,13 @@ impl SchedulerController {
             }
             // Report metrics only if there is data.
             // Reset intervals when appropriate, regardless of report.
-            let should_report = self.count_metrics.has_data();
-            self.count_metrics
+            let should_report = self.interval_count_metrics.has_data();
+            self.interval_count_metrics
                 .update_priority_stats(self.container.get_min_max_priority());
-            self.count_metrics.maybe_report_and_reset(should_report);
-            self.timing_metrics.maybe_report_and_reset(should_report);
+            self.interval_count_metrics
+                .maybe_report_and_reset(should_report);
+            self.interval_timing_metrics
+                .maybe_report_and_reset(should_report);
             self.worker_metrics
                 .iter()
                 .for_each(|metrics| metrics.maybe_report_and_reset());
@@ -128,31 +152,53 @@ impl SchedulerController {
                     },
                     |_| true // no pre-lock filter for now
                 )?);
-                saturating_add_assign!(
-                    self.count_metrics.num_scheduled,
-                    scheduling_summary.num_scheduled
-                );
-                saturating_add_assign!(
-                    self.count_metrics.num_unschedulable,
-                    scheduling_summary.num_unschedulable
-                );
-                saturating_add_assign!(
-                    self.count_metrics.num_schedule_filtered_out,
-                    scheduling_summary.num_filtered_out
-                );
-                saturating_add_assign!(
-                    self.timing_metrics.schedule_filter_time_us,
-                    scheduling_summary.filter_time_us
-                );
-                saturating_add_assign!(self.timing_metrics.schedule_time_us, schedule_time_us);
+
+                for count_metrics in [
+                    self.slot_count_metrics.deref_mut(),
+                    self.interval_count_metrics.deref_mut(),
+                ] {
+                    saturating_add_assign!(
+                        count_metrics.num_scheduled,
+                        scheduling_summary.num_scheduled
+                    );
+                    saturating_add_assign!(
+                        count_metrics.num_unschedulable,
+                        scheduling_summary.num_unschedulable
+                    );
+                    saturating_add_assign!(
+                        count_metrics.num_schedule_filtered_out,
+                        scheduling_summary.num_filtered_out
+                    );
+                }
+
+                for timing_metrics in [
+                    self.slot_timing_metrics.deref_mut(),
+                    self.interval_timing_metrics.deref_mut(),
+                ] {
+                    saturating_add_assign!(
+                        timing_metrics.schedule_filter_time_us,
+                        scheduling_summary.filter_time_us
+                    );
+                    saturating_add_assign!(timing_metrics.schedule_time_us, schedule_time_us);
+                }
             }
             BufferedPacketsDecision::Forward => {
                 let (_, clear_time_us) = measure_us!(self.clear_container());
-                saturating_add_assign!(self.timing_metrics.clear_time_us, clear_time_us);
+                for timing_metrics in [
+                    self.slot_timing_metrics.deref_mut(),
+                    self.interval_timing_metrics.deref_mut(),
+                ] {
+                    saturating_add_assign!(timing_metrics.clear_time_us, clear_time_us);
+                }
             }
             BufferedPacketsDecision::ForwardAndHold => {
                 let (_, clean_time_us) = measure_us!(self.clean_queue());
-                saturating_add_assign!(self.timing_metrics.clean_time_us, clean_time_us);
+                for timing_metrics in [
+                    self.slot_timing_metrics.deref_mut(),
+                    self.interval_timing_metrics.deref_mut(),
+                ] {
+                    saturating_add_assign!(timing_metrics.clean_time_us, clean_time_us);
+                }
             }
             BufferedPacketsDecision::Hold => {}
         }
@@ -187,9 +233,17 @@ impl SchedulerController {
     /// Clears the transaction state container.
     /// This only clears pending transactions, and does **not** clear in-flight transactions.
     fn clear_container(&mut self) {
+        let mut num_dropped_on_clear: usize = 0;
         while let Some(id) = self.container.pop() {
             self.container.remove_by_id(&id.id);
-            saturating_add_assign!(self.count_metrics.num_dropped_on_clear, 1);
+            saturating_add_assign!(num_dropped_on_clear, 1);
+        }
+
+        for count_metrics in [
+            self.slot_count_metrics.deref_mut(),
+            self.interval_count_metrics.deref_mut(),
+        ] {
+            saturating_add_assign!(count_metrics.num_dropped_on_clear, num_dropped_on_clear);
         }
     }
 
@@ -210,7 +264,7 @@ impl SchedulerController {
 
         const CHUNK_SIZE: usize = 128;
         let mut error_counters = TransactionErrorMetrics::default();
-
+        let mut num_dropped_on_age_and_status: usize = 0;
         for chunk in transaction_ids.chunks(CHUNK_SIZE) {
             let lock_results = vec![Ok(()); chunk.len()];
             let sanitized_txs: Vec<_> = chunk
@@ -233,10 +287,20 @@ impl SchedulerController {
 
             for ((result, _nonce, _lamports), id) in check_results.into_iter().zip(chunk.iter()) {
                 if result.is_err() {
-                    saturating_add_assign!(self.count_metrics.num_dropped_on_age_and_status, 1);
+                    saturating_add_assign!(num_dropped_on_age_and_status, 1);
                     self.container.remove_by_id(&id.id);
                 }
             }
+        }
+
+        for count_metrics in [
+            self.slot_count_metrics.deref_mut(),
+            self.interval_count_metrics.deref_mut(),
+        ] {
+            saturating_add_assign!(
+                count_metrics.num_dropped_on_age_and_status,
+                num_dropped_on_age_and_status
+            );
         }
     }
 
@@ -244,12 +308,23 @@ impl SchedulerController {
     fn receive_completed(&mut self) -> Result<(), SchedulerError> {
         let ((num_transactions, num_retryable), receive_completed_time_us) =
             measure_us!(self.scheduler.receive_completed(&mut self.container)?);
-        saturating_add_assign!(self.count_metrics.num_finished, num_transactions);
-        saturating_add_assign!(self.count_metrics.num_retryable, num_retryable);
-        saturating_add_assign!(
-            self.timing_metrics.receive_completed_time_us,
-            receive_completed_time_us
-        );
+        for count_metrics in [
+            self.slot_count_metrics.deref_mut(),
+            self.interval_count_metrics.deref_mut(),
+        ] {
+            saturating_add_assign!(count_metrics.num_finished, num_transactions);
+            saturating_add_assign!(count_metrics.num_retryable, num_retryable);
+        }
+
+        for timing_metrics in [
+            self.slot_timing_metrics.deref_mut(),
+            self.interval_timing_metrics.deref_mut(),
+        ] {
+            saturating_add_assign!(
+                timing_metrics.receive_completed_time_us,
+                receive_completed_time_us
+            );
+        }
         Ok(())
     }
 
@@ -276,22 +351,45 @@ impl SchedulerController {
         let (received_packet_results, receive_time_us) = measure_us!(self
             .packet_receiver
             .receive_packets(recv_timeout, remaining_queue_capacity));
-        saturating_add_assign!(self.timing_metrics.receive_time_us, receive_time_us);
+
+        for timing_metrics in [
+            self.slot_timing_metrics.deref_mut(),
+            self.interval_timing_metrics.deref_mut(),
+        ] {
+            saturating_add_assign!(timing_metrics.receive_time_us, receive_time_us);
+        }
 
         match received_packet_results {
             Ok(receive_packet_results) => {
                 let num_received_packets = receive_packet_results.deserialized_packets.len();
-                saturating_add_assign!(self.count_metrics.num_received, num_received_packets);
+
+                for count_metrics in [
+                    self.slot_count_metrics.deref_mut(),
+                    self.interval_count_metrics.deref_mut(),
+                ] {
+                    saturating_add_assign!(count_metrics.num_received, num_received_packets);
+                }
+
                 if should_buffer {
                     let (_, buffer_time_us) = measure_us!(
                         self.buffer_packets(receive_packet_results.deserialized_packets)
                     );
-                    saturating_add_assign!(self.timing_metrics.buffer_time_us, buffer_time_us);
+                    for timing_metrics in [
+                        self.slot_timing_metrics.deref_mut(),
+                        self.interval_timing_metrics.deref_mut(),
+                    ] {
+                        saturating_add_assign!(timing_metrics.buffer_time_us, buffer_time_us);
+                    }
                 } else {
-                    saturating_add_assign!(
-                        self.count_metrics.num_dropped_on_receive,
-                        num_received_packets
-                    );
+                    for count_metrics in [
+                        self.slot_count_metrics.deref_mut(),
+                        self.interval_count_metrics.deref_mut(),
+                    ] {
+                        saturating_add_assign!(
+                            count_metrics.num_dropped_on_receive,
+                            num_received_packets
+                        );
+                    }
                 }
             }
             Err(RecvTimeoutError::Timeout) => {}
@@ -343,6 +441,8 @@ impl SchedulerController {
             let post_lock_validation_count = transactions.len();
 
             let mut post_transaction_check_count: usize = 0;
+            let mut num_dropped_on_capacity: usize = 0;
+            let mut num_buffered: usize = 0;
             for ((transaction, fee_budget_limits), _) in transactions
                 .into_iter()
                 .zip(fee_budget_limits_vec)
@@ -365,9 +465,9 @@ impl SchedulerController {
                     priority,
                     cost,
                 ) {
-                    saturating_add_assign!(self.count_metrics.num_dropped_on_capacity, 1);
+                    saturating_add_assign!(num_dropped_on_capacity, 1);
                 }
-                saturating_add_assign!(self.count_metrics.num_buffered, 1);
+                saturating_add_assign!(num_buffered, 1);
             }
 
             // Update metrics for transactions that were dropped.
@@ -377,18 +477,28 @@ impl SchedulerController {
             let num_dropped_on_transaction_checks =
                 post_lock_validation_count.saturating_sub(post_transaction_check_count);
 
-            saturating_add_assign!(
-                self.count_metrics.num_dropped_on_sanitization,
-                num_dropped_on_sanitization
-            );
-            saturating_add_assign!(
-                self.count_metrics.num_dropped_on_validate_locks,
-                num_dropped_on_lock_validation
-            );
-            saturating_add_assign!(
-                self.count_metrics.num_dropped_on_receive_transaction_checks,
-                num_dropped_on_transaction_checks
-            );
+            for count_metrics in [
+                self.slot_count_metrics.deref_mut(),
+                self.interval_count_metrics.deref_mut(),
+            ] {
+                saturating_add_assign!(
+                    count_metrics.num_dropped_on_capacity,
+                    num_dropped_on_capacity
+                );
+                saturating_add_assign!(count_metrics.num_buffered, num_buffered);
+                saturating_add_assign!(
+                    count_metrics.num_dropped_on_sanitization,
+                    num_dropped_on_sanitization
+                );
+                saturating_add_assign!(
+                    count_metrics.num_dropped_on_validate_locks,
+                    num_dropped_on_lock_validation
+                );
+                saturating_add_assign!(
+                    count_metrics.num_dropped_on_receive_transaction_checks,
+                    num_dropped_on_transaction_checks
+                );
+            }
         }
     }
 


### PR DESCRIPTION
#### Problem
While interval-reported metrics show a more complete picture, it is often the first step of debugging to check stats on a non-specific leader. This is not easily done by checking the interval-reported metrics.

#### Summary of Changes
Collect and report count/timing metrics for scheduler at leader-slot level.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
