### PR TITLE
set epoch reward pda rent epoch to max

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -3606,12 +3606,13 @@ impl Bank {
 
         let data_len = bincode::serialized_size(&epoch_rewards_partition_data).unwrap() as usize;
         let account_balance = self.get_minimum_balance_for_rent_exemption(data_len);
-        let new_account = AccountSharedData::new_data(
+        let mut new_account = AccountSharedData::new_data(
             account_balance,
             &epoch_rewards_partition_data,
             &solana_sdk::sysvar::id(),
         )
         .unwrap();
+        new_account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
 
         info!(
             "create epoch rewards partition data account {} {address} \


### PR DESCRIPTION
#### Problem

We deprecated rent accounts on the network. This means all `new accounts` must be rent exempt. We also activated `set_rent_epoch_max` feature. One of the implications is that for rent exempt account, its `rent_epoch` is set to
`u64::max`. However, currently, reward pda accounts are created rent-exempted but its rent_epoch is set 0. We rely on rent_collect to update to u64::max. In future, when we skip rent collect, the new PDA account's rent epoch will not be updated and stuck to zero. 

To fix this, the pda account can simply be created with `rent_epoch` to u64::max and don't depend on rent collect to update `rent_epoch` later.

#### Summary of Changes

- set epoch reward pda accounts rent_epoch to u64::max at creation.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
