### PR TITLE
Add feature activate to snapshot creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6350,6 +6350,7 @@ name = "solana-ledger-tool"
 version = "1.18.0"
 dependencies = [
  "assert_cmd",
+ "bincode",
  "bs58",
  "bytecount",
  "chrono",

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true }
 bs58 = { workspace = true }
 chrono = { workspace = true, features = ["default"] }
 clap = { workspace = true }


### PR DESCRIPTION
#### Problem

No way to activate a feature with ledger-tool create-snapshot.

#### Summary of Changes

Add an argument to enable a feature on create-snapshot, this can come in handy if we want to create a restart snapshot with a feature-gate already enabled which potentially was a fix for an issue causing a restart.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
