### PR TITLE
uses Merkle shreds in broadcast duplicates

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5608,11 +5608,11 @@ fn test_invalid_forks_persisted_on_restart() {
             .entries_to_shreds(
                 &majority_keypair,
                 &entries,
-                true,  // is_full_slot
-                None,  // chained_merkle_root
-                0,     // next_shred_index,
-                0,     // next_code_index
-                false, // merkle_variant
+                true, // is_full_slot
+                None, // chained_merkle_root
+                0,    // next_shred_index,
+                0,    // next_code_index
+                true, // merkle_variant
                 &ReedSolomonCache::default(),
                 &mut ProcessShredsStats::default(),
             )

--- a/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
+++ b/turbine/src/broadcast_stage/broadcast_duplicates_run.rs
@@ -176,7 +176,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
             None, // chained_merkle_root
             self.next_shred_index,
             self.next_code_index,
-            false, // merkle_variant
+            true, // merkle_variant
             &self.reed_solomon_cache,
             &mut ProcessShredsStats::default(),
         );
@@ -194,7 +194,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     None, // chained_merkle_root
                     self.next_shred_index,
                     self.next_code_index,
-                    false, // merkle_variant
+                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );
@@ -208,7 +208,7 @@ impl BroadcastRun for BroadcastDuplicatesRun {
                     None, // chained_merkle_root
                     self.next_shred_index,
                     self.next_code_index,
-                    false, // merkle_variant
+                    true, // merkle_variant
                     &self.reed_solomon_cache,
                     &mut ProcessShredsStats::default(),
                 );


### PR DESCRIPTION
#### Problem
Testing with legacy shreds is not good.

#### Summary of Changes
Use Merkle shreds in broadcast duplicates.