### PR TITLE
Reorder fields in shred_insert_is_full datapoint

### DIFF
--- a/ledger/src/slot_stats.rs
+++ b/ledger/src/slot_stats.rs
@@ -131,8 +131,8 @@ impl SlotsStats {
                 .unwrap_or(-1);
             datapoint_info!(
                 "shred_insert_is_full",
-                ("total_time_ms", total_time_ms, i64),
                 ("slot", slot, i64),
+                ("total_time_ms", total_time_ms, i64),
                 ("last_index", last_index, i64),
                 ("num_repaired", num_repaired, i64),
                 ("num_recovered", num_recovered, i64),


### PR DESCRIPTION
#### Summary of Changes
Put the slot as the first field to make grep'ing for datapoints for a specific slot in logs easier. This does not effect the datapoints submission / presentation in metrics database