### PR TITLE
Removes copying owner when serializing Account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6007,7 +6007,6 @@ dependencies = [
  "either",
  "generic-array 0.14.7",
  "im",
- "lazy_static",
  "log",
  "memmap2",
  "rustc_version 0.4.0",

--- a/frozen-abi/Cargo.toml
+++ b/frozen-abi/Cargo.toml
@@ -12,7 +12,6 @@ edition = { workspace = true }
 [dependencies]
 bs58 = { workspace = true }
 bv = { workspace = true, features = ["serde"] }
-lazy_static = { workspace = true }
 log = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_bytes = { workspace = true }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5037,7 +5037,6 @@ dependencies = [
  "either",
  "generic-array 0.14.7",
  "im",
- "lazy_static",
  "log",
  "memmap2",
  "rustc_version",

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -740,25 +740,6 @@ macro_rules! impl_borsh_serialize {
 impl_borsh_serialize!(borsh0_10);
 impl_borsh_serialize!(borsh0_9);
 
-/*
- * #[cfg(RUSTC_WITH_SPECIALIZATION)]
- * impl solana_frozen_abi::abi_example::AbiExample for Pubkey {
- *     fn example() -> Self {
- *         log::info!("AbiExample for &Pubkey: {}", std::any::type_name::<Self>());
- *         const EXAMPLE: Pubkey = Pubkey([0; 32]);
- *         EXAMPLE
- *     }
- * }
- */
-
-#[cfg(RUSTC_WITH_SPECIALIZATION)]
-impl solana_frozen_abi::abi_example::AbiExample for &Pubkey {
-    fn example() -> Self {
-        log::info!("AbiExample for &Pubkey: {}", std::any::type_name::<Self>());
-        &Pubkey([0; 32])
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use {super::*, std::str::from_utf8};


### PR DESCRIPTION
#### Problem

When serializing an Account/AccountSharedData, the owner is copied. This is unnecessary.


#### Summary of Changes

* Change the owner field to be a reference
* Update AbiExample for references