### PR TITLE
SVM: Move RewardInfo from accounts-db to Solana SDK

### DIFF
--- a/accounts-db/src/rent_debits.rs
+++ b/accounts-db/src/rent_debits.rs
@@ -1,6 +1,5 @@
 use {
-    crate::stake_rewards::RewardInfo,
-    solana_sdk::{pubkey::Pubkey, reward_type::RewardType},
+    solana_sdk::{pubkey::Pubkey, reward_info::RewardInfo, reward_type::RewardType},
     std::collections::HashMap,
 };
 

--- a/accounts-db/src/stake_rewards.rs
+++ b/accounts-db/src/stake_rewards.rs
@@ -3,20 +3,9 @@
 use {
     crate::storable_accounts::StorableAccounts,
     solana_sdk::{
-        account::AccountSharedData, clock::Slot, pubkey::Pubkey, reward_type::RewardType,
+        account::AccountSharedData, clock::Slot, pubkey::Pubkey, reward_info::RewardInfo,
     },
 };
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample, Clone, Copy)]
-pub struct RewardInfo {
-    pub reward_type: RewardType,
-    /// Reward amount
-    pub lamports: i64,
-    /// Account balance in lamports after `lamports` was applied
-    pub post_balance: u64,
-    /// Vote account commission when the reward was credited, only present for voting and staking rewards
-    pub commission: Option<u8>,
-}
 
 #[derive(AbiExample, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct StakeReward {
@@ -94,7 +83,7 @@ impl StakeReward {
         Self {
             stake_pubkey: Pubkey::new_unique(),
             stake_reward_info: RewardInfo {
-                reward_type: RewardType::Staking,
+                reward_type: solana_sdk::reward_type::RewardType::Staking,
                 lamports: rng.gen_range(1..200),
                 post_balance: 0,  /* unused atm */
                 commission: None, /* unused atm */

--- a/core/src/rewards_recorder_service.rs
+++ b/core/src/rewards_recorder_service.rs
@@ -1,8 +1,7 @@
 use {
     crossbeam_channel::{Receiver, RecvTimeoutError, Sender},
-    solana_accounts_db::stake_rewards::RewardInfo,
     solana_ledger::blockstore::Blockstore,
-    solana_sdk::{clock::Slot, pubkey::Pubkey},
+    solana_sdk::{clock::Slot, pubkey::Pubkey, reward_info::RewardInfo},
     solana_transaction_status::Reward,
     std::{
         sync::{

--- a/geyser-plugin-manager/src/block_metadata_notifier.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier.rs
@@ -4,13 +4,12 @@ use {
         geyser_plugin_manager::GeyserPluginManager,
     },
     log::*,
-    solana_accounts_db::stake_rewards::RewardInfo,
     solana_geyser_plugin_interface::geyser_plugin_interface::{
         ReplicaBlockInfoV3, ReplicaBlockInfoVersions,
     },
     solana_measure::measure::Measure,
     solana_metrics::*,
-    solana_sdk::{clock::UnixTimestamp, pubkey::Pubkey},
+    solana_sdk::{clock::UnixTimestamp, pubkey::Pubkey, reward_info::RewardInfo},
     solana_transaction_status::{Reward, Rewards},
     std::sync::{Arc, RwLock},
 };

--- a/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
+++ b/geyser-plugin-manager/src/block_metadata_notifier_interface.rs
@@ -1,6 +1,5 @@
 use {
-    solana_accounts_db::stake_rewards::RewardInfo,
-    solana_sdk::{clock::UnixTimestamp, pubkey::Pubkey},
+    solana_sdk::{clock::UnixTimestamp, pubkey::Pubkey, reward_info::RewardInfo},
     std::sync::{Arc, RwLock},
 };
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -91,7 +91,7 @@ use {
         rent_collector::{CollectedInfo, RentCollector, RENT_EXEMPT_RENT_EPOCH},
         rent_debits::RentDebits,
         sorted_storages::SortedStorages,
-        stake_rewards::{RewardInfo, StakeReward},
+        stake_rewards::StakeReward,
         storable_accounts::StorableAccounts,
         transaction_results::{
             TransactionCheckResult, TransactionExecutionDetails, TransactionExecutionResult,
@@ -143,6 +143,7 @@ use {
         precompiles::get_precompiles,
         pubkey::Pubkey,
         rent::RentDue,
+        reward_info::RewardInfo,
         saturating_add_assign,
         signature::{Keypair, Signature},
         slot_hashes::SlotHashes,

--- a/runtime/src/bank/fee_distribution.rs
+++ b/runtime/src/bank/fee_distribution.rs
@@ -1,10 +1,10 @@
 use {
     super::Bank,
     log::{debug, warn},
-    solana_accounts_db::stake_rewards::RewardInfo,
     solana_sdk::{
         account::{ReadableAccount, WritableAccount},
         pubkey::Pubkey,
+        reward_info::RewardInfo,
         reward_type::RewardType,
         system_program,
     },

--- a/runtime/src/bank/serde_snapshot.rs
+++ b/runtime/src/bank/serde_snapshot.rs
@@ -605,7 +605,7 @@ mod tests {
 
         // This some what long test harness is required to freeze the ABI of
         // Bank's serialization due to versioned nature
-        #[frozen_abi(digest = "12WNiuA7qeLU8JFweQszX5sCnCj1fYnYV4i9DeACqhQD")]
+        #[frozen_abi(digest = "77zuTwvAGH5Rf28XHUNkRWsrcJ8uMyARMCZZMg9BBu5S")]
         #[derive(Serialize, AbiExample)]
         pub struct BankAbiTestWrapperNewer {
             #[serde(serialize_with = "wrapper_newer")]

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -92,6 +92,7 @@ pub mod program_utils;
 pub mod pubkey;
 pub mod quic;
 pub mod recent_blockhashes_account;
+pub mod reward_info;
 pub mod reward_type;
 pub mod rpc_port;
 pub mod secp256k1_instruction;

--- a/sdk/src/reward_info.rs
+++ b/sdk/src/reward_info.rs
@@ -1,0 +1,12 @@
+use crate::reward_type::RewardType;
+
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, AbiExample, Clone, Copy)]
+pub struct RewardInfo {
+    pub reward_type: RewardType,
+    /// Reward amount
+    pub lamports: i64,
+    /// Account balance in lamports after `lamports` was applied
+    pub post_balance: u64,
+    /// Vote account commission when the reward was credited, only present for voting and staking rewards
+    pub commission: Option<u8>,
+}


### PR DESCRIPTION
# Summary of changes

Move definition of `RewardInfo` struct from accounts-db to solana_sdk. This is an intermediate step for breaking the dependency of SVM on accounts-db. Done in the process of working on #35094.