### PR TITLE
Remove unnecessary usage of RentCollector

### DIFF
--- a/accounts-db/src/accounts.rs
+++ b/accounts-db/src/accounts.rs
@@ -7,7 +7,6 @@ use {
         accounts_index::{IndexKey, ScanConfig, ScanError, ScanResult, ZeroLamport},
         ancestors::Ancestors,
         nonce_info::{NonceFull, NonceInfo},
-        rent_collector::RentCollector,
         rent_debits::RentDebits,
         storable_accounts::StorableAccounts,
         transaction_results::TransactionExecutionResult,
@@ -655,18 +654,11 @@ impl Accounts {
         txs: &[SanitizedTransaction],
         res: &[TransactionExecutionResult],
         loaded: &mut [TransactionLoadResult],
-        rent_collector: &RentCollector,
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
     ) {
-        let (accounts_to_store, transactions) = self.collect_accounts_to_store(
-            txs,
-            res,
-            loaded,
-            rent_collector,
-            durable_nonce,
-            lamports_per_signature,
-        );
+        let (accounts_to_store, transactions) =
+            self.collect_accounts_to_store(txs, res, loaded, durable_nonce, lamports_per_signature);
         self.accounts_db
             .store_cached_inline_update_index((slot, &accounts_to_store[..]), Some(&transactions));
     }
@@ -689,7 +681,6 @@ impl Accounts {
         txs: &'a [SanitizedTransaction],
         execution_results: &'a [TransactionExecutionResult],
         load_results: &'a mut [TransactionLoadResult],
-        _rent_collector: &RentCollector,
         durable_nonce: &DurableNonce,
         lamports_per_signature: u64,
     ) -> (
@@ -813,10 +804,7 @@ fn prepare_if_nonce_account(
 mod tests {
     use {
         super::*,
-        crate::{
-            rent_collector::RentCollector,
-            transaction_results::{DurableNonceFee, TransactionExecutionDetails},
-        },
+        crate::transaction_results::{DurableNonceFee, TransactionExecutionDetails},
         assert_matches::assert_matches,
         solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
         solana_sdk::{
@@ -1512,8 +1500,6 @@ mod tests {
         let account1 = AccountSharedData::new(2, 0, &Pubkey::default());
         let account2 = AccountSharedData::new(3, 0, &Pubkey::default());
 
-        let rent_collector = RentCollector::default();
-
         let instructions = vec![CompiledInstruction::new(2, &(), vec![0, 1])];
         let message = Message::new_with_compiled_instructions(
             1,
@@ -1581,7 +1567,6 @@ mod tests {
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &DurableNonce::default(),
             0,
         );
@@ -1884,8 +1869,6 @@ mod tests {
 
     #[test]
     fn test_nonced_failure_accounts_rollback_from_pays() {
-        let rent_collector = RentCollector::default();
-
         let nonce_address = Pubkey::new_unique();
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -1962,7 +1945,6 @@ mod tests {
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &durable_nonce,
             0,
         );
@@ -1994,8 +1976,6 @@ mod tests {
 
     #[test]
     fn test_nonced_failure_accounts_rollback_nonce_pays() {
-        let rent_collector = RentCollector::default();
-
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let nonce_address = nonce_authority.pubkey();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -2071,7 +2051,6 @@ mod tests {
             &txs,
             &execution_results,
             loaded.as_mut_slice(),
-            &rent_collector,
             &durable_nonce,
             0,
         );

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4911,7 +4911,6 @@ impl Bank {
             sanitized_txs,
             &execution_results,
             loaded_txs,
-            &self.rent_collector,
             &durable_nonce,
             lamports_per_signature,
         );


### PR DESCRIPTION
#### Problem
`Accounts` methods are being passed instance of `RentCollector`, but it's never used. Maybe it can be removed.

#### Summary of Changes
Update methods to not take `RentCollector` as an argument.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
