### PR TITLE
blockstore: atomize slot clearing, relax parent slot meta check 

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1155,7 +1155,7 @@ impl Blockstore {
     }
 
     /// Range-delete all entries which prefix matches the specified `slot`,
-    /// remove `slot` its' parents SlotMeta next_slots list, and
+    /// remove `slot`'s  parent's SlotMeta next_slots list, and
     /// clear `slot`'s SlotMeta (except for next_slots).
     ///
     /// This function currently requires `insert_shreds_lock`, as both
@@ -1166,7 +1166,7 @@ impl Blockstore {
         let _lock = self.insert_shreds_lock.lock().unwrap();
         // Clear all slot related information, and cleanup slot meta by removing
         // `slot` from parents `next_slots`, but retaining `slot`'s `next_slots`.
-        match self.run_purge(slot, slot, PurgeType::ExactAndCleanupChaining) {
+        match self.purge_slot_cleanup_chaining(slot) {
             Ok(_) => {}
             Err(BlockstoreError::SlotUnavailable) => error!(
                 "clear_unconfirmed_slot() called on slot {} with no SlotMeta",

--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -1164,9 +1164,9 @@ impl Blockstore {
     pub fn clear_unconfirmed_slot(&self, slot: Slot) {
         let _lock = self.insert_shreds_lock.lock().unwrap();
         // Purge the slot and insert an empty `SlotMeta` with only the `next_slots` field preserved.
-        // Shreds inherently contain the slot of their parent which updates the parent's `next_slots`
-        // when the child is inserted through `Blockstore::handle_chaining()`.
-        // However we are only purging and repairing the parent slot here. Since the child will not be
+        // Shreds inherently know their parent slot, and a parent's SlotMeta `next_slots` list
+        // will be updated when the child is inserted (see `Blockstore::handle_chaining()`).
+        // However, we are only purging and repairing the parent slot here. Since the child will not be
         // reinserted the chaining will be lost. In order for bank forks discovery to ingest the child,
         // we must retain the chain by preserving `next_slots`.
         match self.purge_slot_cleanup_chaining(slot) {

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -147,7 +147,7 @@ impl Blockstore {
 
     /// Purges all columns relating to `slot`.
     ///
-    /// Additionally we cleanup the parent of `slot`, by clearing `slot` from
+    /// Additionally, we cleanup the parent of `slot` by clearing `slot` from
     /// the parent's `next_slots`. We reinsert an orphaned `slot_meta` for `slot`
     /// that preserves `slot`'s `next_slots`. This ensures that `slot`'s fork is
     /// replayable upon repair of `slot`.
@@ -177,7 +177,7 @@ impl Blockstore {
             }
         }
 
-        // Reinsert parts of `slot_meta` that are important to retain, like the `next_slots` field.
+        // Retain a SlotMeta for `slot` with the `next_slots` field retained
         slot_meta.clear_unconfirmed_slot();
         write_batch.put::<cf::SlotMeta>(slot, &slot_meta)?;
 

--- a/ledger/src/blockstore/blockstore_purge.rs
+++ b/ledger/src/blockstore/blockstore_purge.rs
@@ -155,10 +155,7 @@ impl Blockstore {
         let Some(mut slot_meta) = self.meta(slot)? else {
             return Err(BlockstoreError::SlotUnavailable);
         };
-        let mut write_batch = self
-            .db
-            .batch()
-            .expect("Database Error: Failed to get write batch");
+        let mut write_batch = self.db.batch()?;
 
         let columns_purged = self.purge_range(&mut write_batch, slot, slot, PurgeType::Exact)?;
 
@@ -209,10 +206,7 @@ impl Blockstore {
         purge_type: PurgeType,
         purge_stats: &mut PurgeStats,
     ) -> Result<bool> {
-        let mut write_batch = self
-            .db
-            .batch()
-            .expect("Database Error: Failed to get write batch");
+        let mut write_batch = self.db.batch()?;
 
         let mut delete_range_timer = Measure::start("delete_range");
         let columns_purged = self.purge_range(&mut write_batch, from_slot, to_slot, purge_type)?;

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -151,6 +151,8 @@ pub enum BlockstoreError {
     MissingTransactionMetadata,
     #[error("transaction-index overflow")]
     TransactionIndexOverflow,
+    #[error("invalid purge range for slot meta cleanup")]
+    InvalidRangeForSlotMetaCleanup,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 

--- a/ledger/src/blockstore_db.rs
+++ b/ledger/src/blockstore_db.rs
@@ -151,8 +151,6 @@ pub enum BlockstoreError {
     MissingTransactionMetadata,
     #[error("transaction-index overflow")]
     TransactionIndexOverflow,
-    #[error("invalid purge range for slot meta cleanup")]
-    InvalidRangeForSlotMetaCleanup,
 }
 pub type Result<T> = std::result::Result<T, BlockstoreError>;
 


### PR DESCRIPTION
clear_unconfirmed_slot can leave blockstore in an irrecoverable state
if it panics in the middle. write batch this function, so that any
errors can be recovered after restart.
