### PR TITLE
bpf-loader-upgradeable: export `get_program_data_address` helper

### DIFF
--- a/sdk/program/src/bpf_loader_upgradeable.rs
+++ b/sdk/program/src/bpf_loader_upgradeable.rs
@@ -119,6 +119,11 @@ impl UpgradeableLoaderState {
     }
 }
 
+/// Returns the program data address for a program ID
+pub fn get_program_data_address(program_address: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[program_address.as_ref()], &id()).0
+}
+
 /// Returns the instructions required to initialize a Buffer account.
 pub fn create_buffer(
     payer_address: &Pubkey,
@@ -175,7 +180,7 @@ pub fn deploy_with_max_program_len(
     program_lamports: u64,
     max_data_len: usize,
 ) -> Result<Vec<Instruction>, InstructionError> {
-    let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
+    let programdata_address = get_program_data_address(program_address);
     Ok(vec![
         system_instruction::create_account(
             payer_address,
@@ -208,7 +213,7 @@ pub fn upgrade(
     authority_address: &Pubkey,
     spill_address: &Pubkey,
 ) -> Instruction {
-    let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
+    let programdata_address = get_program_data_address(program_address);
     Instruction::new_with_bincode(
         id(),
         &UpgradeableLoaderInstruction::Upgrade,
@@ -281,7 +286,7 @@ pub fn set_upgrade_authority(
     current_authority_address: &Pubkey,
     new_authority_address: Option<&Pubkey>,
 ) -> Instruction {
-    let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
+    let programdata_address = get_program_data_address(program_address);
 
     let mut metas = vec![
         AccountMeta::new(programdata_address, false),
@@ -300,7 +305,7 @@ pub fn set_upgrade_authority_checked(
     current_authority_address: &Pubkey,
     new_authority_address: &Pubkey,
 ) -> Instruction {
-    let (programdata_address, _) = Pubkey::find_program_address(&[program_address.as_ref()], &id());
+    let programdata_address = get_program_data_address(program_address);
 
     let metas = vec![
         AccountMeta::new(programdata_address, false),
@@ -355,8 +360,7 @@ pub fn extend_program(
     payer_address: Option<&Pubkey>,
     additional_bytes: u32,
 ) -> Instruction {
-    let (program_data_address, _) =
-        Pubkey::find_program_address(&[program_address.as_ref()], &id());
+    let program_data_address = get_program_data_address(program_address);
     let mut metas = vec![
         AccountMeta::new(program_data_address, false),
         AccountMeta::new(*program_address, false),


### PR DESCRIPTION
#### Problem
The BPF Loader Upgradeable uses a deterministic derivation for the
address of an upgradeable program's data account. However, this
derivation is done manually through `Pubkey::find_program_address(..)`
each time within the loader's code.

It's also not available to anyone downstream using the SDK. Having this
helper available through the SDK - or at least through the BPF Loader
Upgradeable module - will come in handy for building out the module to
migrate built-in programs to Core BPF (BPF Upgradeable).

#### Summary of Changes
Export the helper!
