### PR TITLE
SVM: Move `MatchAccountOwnerError` to SDK

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -31,9 +31,7 @@ use {
             AccountStorage, AccountStorageStatus, ShrinkInProgress,
         },
         accounts_cache::{AccountsCache, CachedAccount, SlotCache},
-        accounts_file::{
-            AccountsFile, AccountsFileError, MatchAccountOwnerError, ALIGN_BOUNDARY_OFFSET,
-        },
+        accounts_file::{AccountsFile, AccountsFileError, ALIGN_BOUNDARY_OFFSET},
         accounts_hash::{
             AccountHash, AccountsDeltaHash, AccountsHash, AccountsHashKind, AccountsHasher,
             CalcAccountsHashConfig, CalculateHashIntermediate, HashStats, IncrementalAccountsHash,
@@ -85,7 +83,9 @@ use {
     solana_nohash_hasher::{IntMap, IntSet},
     solana_rayon_threadlimit::get_thread_count,
     solana_sdk::{
-        account::{Account, AccountSharedData, ReadableAccount, WritableAccount},
+        account::{
+            Account, AccountSharedData, MatchAccountOwnerError, ReadableAccount, WritableAccount,
+        },
         clock::{BankId, Epoch, Slot},
         epoch_schedule::EpochSchedule,
         genesis_config::{ClusterType, GenesisConfig},

--- a/accounts-db/src/accounts_file.rs
+++ b/accounts-db/src/accounts_file.rs
@@ -8,7 +8,11 @@ use {
         storable_accounts::StorableAccounts,
         tiered_storage::error::TieredStorageError,
     },
-    solana_sdk::{account::ReadableAccount, clock::Slot, pubkey::Pubkey},
+    solana_sdk::{
+        account::{MatchAccountOwnerError, ReadableAccount},
+        clock::Slot,
+        pubkey::Pubkey,
+    },
     std::{
         borrow::Borrow,
         mem,
@@ -38,14 +42,6 @@ pub enum AccountsFileError {
 
     #[error("TieredStorageError: {0}")]
     TieredStorageError(#[from] TieredStorageError),
-}
-
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum MatchAccountOwnerError {
-    #[error("The account owner does not match with the provided list")]
-    NoMatch,
-    #[error("Unable to load the account")]
-    UnableToLoad,
 }
 
 pub type Result<T> = std::result::Result<T, AccountsFileError>;

--- a/accounts-db/src/append_vec.rs
+++ b/accounts-db/src/append_vec.rs
@@ -10,7 +10,7 @@ use {
             AccountMeta, StorableAccountsWithHashesAndWriteVersions, StoredAccountInfo,
             StoredAccountMeta, StoredMeta, StoredMetaWriteVersion,
         },
-        accounts_file::{AccountsFileError, MatchAccountOwnerError, Result, ALIGN_BOUNDARY_OFFSET},
+        accounts_file::{AccountsFileError, Result, ALIGN_BOUNDARY_OFFSET},
         accounts_hash::AccountHash,
         storable_accounts::StorableAccounts,
         u64_align,
@@ -18,7 +18,7 @@ use {
     log::*,
     memmap2::MmapMut,
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, MatchAccountOwnerError, ReadableAccount},
         clock::Slot,
         pubkey::Pubkey,
         stake_history::Epoch,

--- a/accounts-db/src/tiered_storage/hot.rs
+++ b/accounts-db/src/tiered_storage/hot.rs
@@ -3,7 +3,6 @@
 use {
     crate::{
         account_storage::meta::{StoredAccountInfo, StoredAccountMeta},
-        accounts_file::MatchAccountOwnerError,
         accounts_hash::AccountHash,
         tiered_storage::{
             byte_block,
@@ -22,7 +21,9 @@ use {
     memmap2::{Mmap, MmapOptions},
     modular_bitfield::prelude::*,
     solana_sdk::{
-        account::ReadableAccount, pubkey::Pubkey, rent_collector::RENT_EXEMPT_RENT_EPOCH,
+        account::{MatchAccountOwnerError, ReadableAccount},
+        pubkey::Pubkey,
+        rent_collector::RENT_EXEMPT_RENT_EPOCH,
         stake_history::Epoch,
     },
     std::{borrow::Borrow, fs::OpenOptions, option::Option, path::Path},

--- a/accounts-db/src/tiered_storage/readable.rs
+++ b/accounts-db/src/tiered_storage/readable.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
         account_storage::meta::StoredAccountMeta,
-        accounts_file::MatchAccountOwnerError,
         accounts_hash::AccountHash,
         tiered_storage::{
             footer::{AccountMetaFormat, TieredStorageFooter},
@@ -11,7 +10,11 @@ use {
             TieredStorageResult,
         },
     },
-    solana_sdk::{account::ReadableAccount, pubkey::Pubkey, stake_history::Epoch},
+    solana_sdk::{
+        account::{MatchAccountOwnerError, ReadableAccount},
+        pubkey::Pubkey,
+        stake_history::Epoch,
+    },
     std::path::Path,
 };
 

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,6 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
             CalcAccountsHashDataSource, VerifyAccountsHashAndLamportsConfig,
         },
-        accounts_file::MatchAccountOwnerError,
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
         },
@@ -110,8 +109,8 @@ use {
     solana_sdk::{
         account::{
             create_account_shared_data_with_fields as create_account, create_executable_meta,
-            from_account, Account, AccountSharedData, InheritableAccountFields, ReadableAccount,
-            WritableAccount,
+            from_account, Account, AccountSharedData, InheritableAccountFields,
+            MatchAccountOwnerError, ReadableAccount, WritableAccount,
         },
         clock::{
             BankId, Epoch, Slot, SlotCount, SlotIndex, UnixTimestamp, DEFAULT_HASHES_PER_TICK,

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -24,6 +24,7 @@ use {
         rc::Rc,
         sync::Arc,
     },
+    thiserror::Error,
 };
 
 /// An Account with data that is stored on chain
@@ -95,6 +96,14 @@ impl Serialize for Account {
     {
         crate::account::account_serialize::serialize_account(self, serializer)
     }
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum MatchAccountOwnerError {
+    #[error("The account owner does not match with the provided list")]
+    NoMatch,
+    #[error("Unable to load the account")]
+    UnableToLoad,
 }
 
 impl Serialize for AccountSharedData {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -451,16 +451,13 @@ mod tests {
     use {
         super::*,
         nonce::state::Versions as NonceVersions,
-        solana_accounts_db::{
-            accounts::Accounts, accounts_db::AccountsDb, accounts_file::MatchAccountOwnerError,
-            ancestors::Ancestors,
-        },
+        solana_accounts_db::{accounts::Accounts, accounts_db::AccountsDb, ancestors::Ancestors},
         solana_program_runtime::{
             compute_budget_processor,
             prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
         },
         solana_sdk::{
-            account::{AccountSharedData, WritableAccount},
+            account::{AccountSharedData, MatchAccountOwnerError, WritableAccount},
             bpf_loader_upgradeable,
             compute_budget::ComputeBudgetInstruction,
             epoch_schedule::EpochSchedule,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -8,7 +8,6 @@ use {
     percentage::Percentage,
     solana_accounts_db::{
         accounts::{LoadedTransaction, TransactionLoadResult},
-        accounts_file::MatchAccountOwnerError,
         transaction_results::{
             DurableNonceFee, TransactionCheckResult, TransactionExecutionDetails,
             TransactionExecutionResult,
@@ -28,7 +27,7 @@ use {
         timings::{ExecuteDetailsTimings, ExecuteTimingType, ExecuteTimings},
     },
     solana_sdk::{
-        account::{AccountSharedData, ReadableAccount, PROGRAM_OWNERS},
+        account::{AccountSharedData, MatchAccountOwnerError, ReadableAccount, PROGRAM_OWNERS},
         account_utils::StateMut,
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
         clock::{Epoch, Slot},


### PR DESCRIPTION
#### Problem
`MatchAccountOwnerError` being in `accounts-db` causes SVM to depend on `accounts-db`. This can be moved out to SDK to resolve the deps.

#### Summary of Changes
Move `MatchAccountOwnerError` to SDK.

Fixes #35096 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
