### PR TITLE
[TieredStorage] Make TieredStorage::write_accounts() thread-safe

### DIFF
--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -115,9 +115,12 @@ impl TieredStorage {
         skip: usize,
         format: &TieredStorageFormat,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
-        let was_written =
-            self.already_written
-                .compare_exchange(false, true, Ordering::Acquired, Ordering::Released);
+        let was_written = self.already_written.compare_exchange(
+            false,
+            true,
+            Ordering::Acquired,
+            Ordering::Released,
+        );
 
         // If it was not previously written, and the current thread has
         // successfully updated the already_written flag, then the current

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -118,8 +118,8 @@ impl TieredStorage {
         let was_written = self.already_written.compare_exchange(
             false,
             true,
-            Ordering::Acquired,
-            Ordering::Released,
+            Ordering::AcqRel,
+            Ordering::Relaxed,
         );
 
         // If it was not previously written, and the current thread has

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -115,12 +115,9 @@ impl TieredStorage {
         skip: usize,
         format: &TieredStorageFormat,
     ) -> TieredStorageResult<Vec<StoredAccountInfo>> {
-        let was_written = self.already_written.compare_exchange(
-            false,
-            true,
-            Ordering::AcqRel,
-            Ordering::Relaxed,
-        );
+        let was_written =
+            self.already_written
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed);
 
         // If it was not previously written, and the current thread has
         // successfully updated the already_written flag, then the current

--- a/accounts-db/src/tiered_storage.rs
+++ b/accounts-db/src/tiered_storage.rs
@@ -136,7 +136,7 @@ impl TieredStorage {
                     .set(TieredStorageReader::new_from_path(&self.path)?)
                     .unwrap();
 
-                return result;
+                result
             } else {
                 Err(TieredStorageError::UnknownFormat(self.path.to_path_buf()))
             }


### PR DESCRIPTION
#### Problem
While accounts-db might not invoke appends_account twice
for the same AccountsFile, TieredStorage::write_accounts()
itself isn't thread-safe, and it depends on the above accounts-db
assumption.

#### Summary of Changes
This PR makes TieredStorage::write_accounts() thread-safe.
So only the first thread who successfully updates the readonly
flag can proceed and writes the input accounts.  All subsequent
calls to write_accounts() will be no-op and return AttemptToUpdateReadOnly
Error.

