### PR TITLE
SVM: Remove dependency on MatchAccountOwnerError

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -76,7 +76,6 @@ use {
             AccountShrinkThreshold, AccountStorageEntry, AccountsDb, AccountsDbConfig,
             CalcAccountsHashDataSource, VerifyAccountsHashAndLamportsConfig,
         },
-        accounts_file::MatchAccountOwnerError,
         accounts_hash::{
             AccountHash, AccountsHash, CalcAccountsHashConfig, HashStats, IncrementalAccountsHash,
         },
@@ -7488,15 +7487,12 @@ impl Bank {
 }
 
 impl TransactionProcessingCallback for Bank {
-    fn account_matches_owners(
-        &self,
-        account: &Pubkey,
-        owners: &[Pubkey],
-    ) -> std::result::Result<usize, MatchAccountOwnerError> {
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
         self.rc
             .accounts
             .accounts_db
             .account_matches_owners(&self.ancestors, account, owners)
+            .ok()
     }
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -451,10 +451,7 @@ mod tests {
     use {
         super::*,
         nonce::state::Versions as NonceVersions,
-        solana_accounts_db::{
-            accounts::Accounts, accounts_db::AccountsDb, accounts_file::MatchAccountOwnerError,
-            ancestors::Ancestors,
-        },
+        solana_accounts_db::{accounts::Accounts, accounts_db::AccountsDb, ancestors::Ancestors},
         solana_program_runtime::{
             compute_budget_processor,
             prioritization_fee::{PrioritizationFeeDetails, PrioritizationFeeType},
@@ -487,12 +484,8 @@ mod tests {
     }
 
     impl TransactionProcessingCallback for TestCallbacks {
-        fn account_matches_owners(
-            &self,
-            _account: &Pubkey,
-            _owners: &[Pubkey],
-        ) -> std::result::Result<usize, MatchAccountOwnerError> {
-            Err(MatchAccountOwnerError::UnableToLoad)
+        fn account_matches_owners(&self, _account: &Pubkey, _owners: &[Pubkey]) -> Option<usize> {
+            None
         }
 
         fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -8,7 +8,6 @@ use {
     percentage::Percentage,
     solana_accounts_db::{
         accounts::{LoadedTransaction, TransactionLoadResult},
-        accounts_file::MatchAccountOwnerError,
         transaction_results::{
             DurableNonceFee, TransactionCheckResult, TransactionExecutionDetails,
             TransactionExecutionResult,
@@ -70,11 +69,7 @@ pub struct LoadAndExecuteSanitizedTransactionsOutput {
 }
 
 pub trait TransactionProcessingCallback {
-    fn account_matches_owners(
-        &self,
-        account: &Pubkey,
-        owners: &[Pubkey],
-    ) -> std::result::Result<usize, MatchAccountOwnerError>;
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize>;
 
     fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData>;
 
@@ -340,7 +335,7 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                                 saturating_add_assign!(*count, 1);
                             }
                             Entry::Vacant(entry) => {
-                                if let Ok(index) =
+                                if let Some(index) =
                                     callbacks.account_matches_owners(key, program_owners)
                                 {
                                     program_owners


### PR DESCRIPTION
#### Problem
`MatchAccountOwnerError` being in accounts-db causes SVM to depend on accounts-db. This dependency must be removed to break SVM dep on accounts-db.

#### Summary of Changes
Use Option<usize> as the return value from the trait and impls.

Fixes #35096 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
