### PR TITLE
Refactor - `LoadedPrograms::replenish()`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -1363,7 +1363,7 @@ impl Bank {
                     drop(loaded_programs_cache);
                     let recompiled = new.load_program(&key, false, Some(program_to_recompile));
                     let mut loaded_programs_cache = new.loaded_programs_cache.write().unwrap();
-                    loaded_programs_cache.replenish(key, recompiled);
+                    loaded_programs_cache.assign_program(key, recompiled);
                 }
             } else if new.epoch() != loaded_programs_cache.latest_root_epoch
                 || slot_index.saturating_add(slots_in_recompilation_phase) >= slots_in_epoch
@@ -7056,7 +7056,7 @@ impl Bank {
         self.loaded_programs_cache
             .write()
             .unwrap()
-            .replenish(program_id, Arc::new(builtin));
+            .assign_program(program_id, Arc::new(builtin));
         debug!("Added program {} under {:?}", name, program_id);
     }
 


### PR DESCRIPTION
#### Problem
`LoadedPrograms::replenish()` was originally implemented to support deduplication of loaded entries when threads raced to load their TX batches. Now, with cooperative loading an entry should never be loaded twice.

#### Summary of Changes
- Replaces all occurrences of `LoadedPrograms::replenish()` by `LoadedPrograms::assign_program()`.
- Disallows replacement of tombstone, but allows replacement of built-ins