### PR TITLE
Refactor - Adds check that only loaded programs can be unloaded

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -382,6 +382,20 @@ impl LoadedProgram {
     }
 
     pub fn to_unloaded(&self) -> Option<Self> {
+        match &self.program {
+            LoadedProgramType::LegacyV0(_)
+            | LoadedProgramType::LegacyV1(_)
+            | LoadedProgramType::Typed(_) => {}
+            #[cfg(test)]
+            LoadedProgramType::TestLoaded(_) => {}
+            LoadedProgramType::FailedVerification(_)
+            | LoadedProgramType::Closed
+            | LoadedProgramType::DelayVisibility
+            | LoadedProgramType::Unloaded(_)
+            | LoadedProgramType::Builtin(_) => {
+                return None;
+            }
+        }
         Some(Self {
             program: LoadedProgramType::Unloaded(self.program.get_environment()?.clone()),
             account_size: self.account_size,
@@ -1081,11 +1095,6 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
                         .entry(*id)
                         .and_modify(|c| saturating_add_assign!(*c, 1))
                         .or_insert(1);
-                } else {
-                    error!(
-                        "Failed to create an unloaded cache entry for a program type {:?}",
-                        entry.program
-                    );
                 }
             }
         }

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -1085,26 +1085,6 @@ impl<FG: ForkGraph> LoadedPrograms<FG> {
         }
     }
 
-    fn unload_program(&mut self, id: &Pubkey) {
-        if let Some(second_level) = self.entries.get_mut(id) {
-            for entry in second_level.slot_versions.iter_mut() {
-                if let Some(unloaded) = entry.to_unloaded() {
-                    *entry = Arc::new(unloaded);
-                    self.stats
-                        .evictions
-                        .entry(*id)
-                        .and_modify(|c| saturating_add_assign!(*c, 1))
-                        .or_insert(1);
-                }
-            }
-        }
-    }
-
-    pub fn unload_all_programs(&mut self) {
-        let keys = self.entries.keys().copied().collect::<Vec<Pubkey>>();
-        keys.iter().for_each(|key| self.unload_program(key));
-    }
-
     /// This function removes the given entry for the given program from the cache.
     /// The function expects that the program and entry exists in the cache. Otherwise it'll panic.
     fn unload_program_entry(&mut self, program: &Pubkey, remove_entry: &Arc<LoadedProgram>) {

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4525,13 +4525,6 @@ impl Bank {
         balances
     }
 
-    pub fn clear_program_cache(&self) {
-        self.loaded_programs_cache
-            .write()
-            .unwrap()
-            .unload_all_programs();
-    }
-
     #[allow(clippy::type_complexity)]
     pub fn load_and_execute_transactions(
         &self,


### PR DESCRIPTION
#### Problem
Currently the only thing stopping a tombstone from being unloaded is that it never gets selected as a candidate by `LoadedPrograms::get_flattened_entries()`.

#### Summary of Changes
Adds check that prevents anything but loaded programs from being unloaded.
