### PR TITLE
Upgrades Rust to 1.76.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html
https://releases.rs/docs/1.76.0/