### PR TITLE
Add GHA to close new issues with a comment

### DIFF
--- a/.github/workflows/close-new-issues.yml
+++ b/.github/workflows/close-new-issues.yml
@@ -1,0 +1,20 @@
+name: Close new issues
+
+on:
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  comment-and-close:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT: >
+            This repository is no longer in use. Please re-open this 
+            issue in the agave repo: https://github.com/anza-xyz/agave
+        run: >
+          gh issue close "$ISSUE_NUMBER" --comment "$COMMENT"

--- a/.github/workflows/close-new-issues.yml
+++ b/.github/workflows/close-new-issues.yml
@@ -14,7 +14,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           COMMENT: >
-            This repository is no longer in use. Please re-open this 
+            This repository is no longer in use. Please re-open this
             issue in the agave repo: https://github.com/anza-xyz/agave
         run: >
           gh issue close "$ISSUE_NUMBER" --comment "$COMMENT"


### PR DESCRIPTION
#### Problem
After we move to anza-xyz/agave we don't want people to create new issues here.

#### Summary of Changes
Add a GHA to automatically close new or re-opened issues 

This shouldn't be merged until Saturday.

Tested on my fork and it works:
https://github.com/willhickey/solana/issues/17