### PR TITLE
SVM: Move TransactionCheckResult definition from accounts-db to SVM

### DIFF
--- a/accounts-db/src/transaction_results.rs
+++ b/accounts-db/src/transaction_results.rs
@@ -7,14 +7,12 @@ pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList}
 use {
     solana_program_runtime::loaded_programs::LoadedProgramsForTxBatch,
     solana_sdk::{
-        nonce_info::{NonceFull, NonceInfo, NoncePartial},
+        nonce_info::{NonceFull, NonceInfo},
         rent_debits::RentDebits,
         transaction::{self, TransactionError},
         transaction_context::TransactionReturnData,
     },
 };
-
-pub type TransactionCheckResult = (transaction::Result<()>, Option<NoncePartial>, Option<u64>);
 
 pub struct TransactionResults {
     pub fee_collection_results: Vec<transaction::Result<()>>,

--- a/core/src/banking_stage/consumer.rs
+++ b/core/src/banking_stage/consumer.rs
@@ -9,7 +9,6 @@ use {
         BankingStageStats,
     },
     itertools::Itertools,
-    solana_accounts_db::transaction_results::TransactionCheckResult,
     solana_ledger::token_balances::collect_token_balances,
     solana_measure::{measure::Measure, measure_us},
     solana_poh::poh_recorder::{
@@ -33,7 +32,8 @@ use {
         transaction::{self, AddressLoader, SanitizedTransaction, TransactionError},
     },
     solana_svm::{
-        account_loader::validate_fee_payer, transaction_error_metrics::TransactionErrorMetrics,
+        account_loader::{validate_fee_payer, TransactionCheckResult},
+        transaction_error_metrics::TransactionErrorMetrics,
     },
     std::{
         sync::{atomic::Ordering, Arc},

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -90,8 +90,7 @@ use {
         stake_rewards::StakeReward,
         storable_accounts::StorableAccounts,
         transaction_results::{
-            TransactionCheckResult, TransactionExecutionDetails, TransactionExecutionResult,
-            TransactionResults,
+            TransactionExecutionDetails, TransactionExecutionResult, TransactionResults,
         },
     },
     solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
@@ -161,6 +160,7 @@ use {
         self, InflationPointCalculationEvent, PointValue, StakeStateV2,
     },
     solana_svm::{
+        account_loader::TransactionCheckResult,
         account_overrides::AccountOverrides,
         runtime_config::RuntimeConfig,
         transaction_error_metrics::TransactionErrorMetrics,

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -6,10 +6,7 @@ use {
     },
     itertools::Itertools,
     log::warn,
-    solana_accounts_db::{
-        accounts::{LoadedTransaction, TransactionLoadResult, TransactionRent},
-        transaction_results::TransactionCheckResult,
-    },
+    solana_accounts_db::accounts::{LoadedTransaction, TransactionLoadResult, TransactionRent},
     solana_program_runtime::{
         compute_budget_processor::process_compute_budget_instructions,
         loaded_programs::LoadedProgramsForTxBatch,
@@ -24,19 +21,21 @@ use {
         message::SanitizedMessage,
         native_loader,
         nonce::State as NonceState,
-        nonce_info::NonceFull,
+        nonce_info::{NonceFull, NoncePartial},
         pubkey::Pubkey,
         rent::RentDue,
         rent_collector::{RentCollector, RENT_EXEMPT_RENT_EPOCH},
         rent_debits::RentDebits,
         saturating_add_assign,
         sysvar::{self, instructions::construct_instructions_data},
-        transaction::{Result, SanitizedTransaction, TransactionError},
+        transaction::{self, Result, SanitizedTransaction, TransactionError},
         transaction_context::IndexOfAccount,
     },
     solana_system_program::{get_system_account_kind, SystemAccountKind},
     std::{collections::HashMap, num::NonZeroUsize},
 };
+
+pub type TransactionCheckResult = (transaction::Result<()>, Option<NoncePartial>, Option<u64>);
 
 pub fn load_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -1,7 +1,9 @@
 use {
     crate::{
-        account_loader::load_accounts, account_overrides::AccountOverrides,
-        runtime_config::RuntimeConfig, transaction_account_state_info::TransactionAccountStateInfo,
+        account_loader::{load_accounts, TransactionCheckResult},
+        account_overrides::AccountOverrides,
+        runtime_config::RuntimeConfig,
+        transaction_account_state_info::TransactionAccountStateInfo,
         transaction_error_metrics::TransactionErrorMetrics,
     },
     log::debug,
@@ -9,8 +11,7 @@ use {
     solana_accounts_db::{
         accounts::{LoadedTransaction, TransactionLoadResult},
         transaction_results::{
-            DurableNonceFee, TransactionCheckResult, TransactionExecutionDetails,
-            TransactionExecutionResult,
+            DurableNonceFee, TransactionExecutionDetails, TransactionExecutionResult,
         },
     },
     solana_measure::measure::Measure,


### PR DESCRIPTION
#### Problem

Continue breaking ties between accounts-db and SVM.

#### Summary of Changes

Move definition of TransactionCheckResult type from accounts-db create to SVM, fixing up corresponding imports.

