### PR TITLE
ledger-tool: add warn log if capitalization changes during create-snapshot

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2062,7 +2062,7 @@ fn main() {
 
                     let post_capitalization = bank.capitalization();
 
-                    if pre_capitalization != post_capitalization {
+                    let capitalization_message = if pre_capitalization != post_capitalization {
                         let amount = if pre_capitalization > post_capitalization {
                             format!("-{}", pre_capitalization - post_capitalization)
                         } else {
@@ -2076,7 +2076,10 @@ fn main() {
                             );
                             exit(1);
                         }
-                    }
+                        Some(msg)
+                    } else {
+                        None
+                    };
 
                     let bank = if let Some(warp_slot) = warp_slot {
                         // need to flush the write cache in order to use Storages to calculate
@@ -2204,6 +2207,9 @@ fn main() {
                         }
                     }
 
+                    if let Some(msg) = capitalization_message {
+                        println!("{msg}");
+                    }
                     println!(
                         "Shred version: {}",
                         compute_shred_version(&genesis_config.hash(), Some(&bank.hard_forks()))

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -2047,7 +2047,19 @@ fn main() {
                         }
                     }
 
+                    let pre_capitalization = bank.capitalization();
+
                     bank.set_capitalization();
+
+                    let post_capitalization = bank.capitalization();
+                    if pre_capitalization != post_capitalization {
+                        let amount = if pre_capitalization > post_capitalization {
+                            format!("-{}", pre_capitalization - post_capitalization)
+                        } else {
+                            (post_capitalization - pre_capitalization).to_string()
+                        };
+                        warn!("Capitalization change: {amount} lamports");
+                    }
 
                     let bank = if let Some(warp_slot) = warp_slot {
                         // need to flush the write cache in order to use Storages to calculate


### PR DESCRIPTION
#### Problem
As brought up [here](https://github.com/solana-labs/solana/pull/35107#discussion_r1480148907), `solana-ledger-tool create-snapshot` operations that change the capitalization are intended for testing purposes and should be used with caution. The script silently calls `Bank::set_capitalization()` regardless of whether such operations are included. Node operators use this script on restarts on live clusters, like mainnet-beta, so it's worth taking extra care to ensure capitalization changes are intended.

#### Summary of Changes
Check capitalization before and after `Bank::set_capitalization()` and emit a warning if the value changes.
