### PR TITLE
ledger-tool: Use error handling in blockstore command code

### DIFF
--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -703,9 +703,9 @@ fn do_blockstore_process_command(
                     break;
                 }
                 let shreds = source.get_data_shreds_for_slot(slot, 0)?;
-                    if target.insert_shreds(shreds, None, true).is_err() {
-                        warn!("error inserting shreds for slot {}", slot);
-                    }
+                if target.insert_shreds(shreds, None, true).is_err() {
+                    warn!("error inserting shreds for slot {}", slot);
+                }
             }
         }
         ("dead-slots", Some(arg_matches)) => {

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -777,8 +777,7 @@ fn do_blockstore_process_command(
             let start_root = value_t!(arg_matches, "start_root", Slot).unwrap_or(0);
             let num_roots = value_t_or_exit!(arg_matches, "num_roots", usize);
 
-            let iter = blockstore
-                .rooted_slot_iterator(start_root)?;
+            let iter = blockstore.rooted_slot_iterator(start_root)?;
 
             let mut output: Box<dyn Write> = if let Some(path) = arg_matches.value_of("slot_list") {
                 match File::create(path) {
@@ -789,19 +788,16 @@ fn do_blockstore_process_command(
                 Box::new(stdout())
             };
 
-            for slot in iter.take(num_roots)
+            for slot in iter
+                .take(num_roots)
                 .take_while(|slot| *slot <= max_height as u64)
                 .collect::<Vec<_>>()
                 .into_iter()
-                .rev() {
-                    let blockhash = blockstore
-                        .get_slot_entries(slot, 0)?
-                        .last()
-                        .unwrap()
-                        .hash;
-
-                    writeln!(output, "{slot}: {blockhash:?}").expect("failed to write");
-                }
+                .rev()
+            {
+                let blockhash = blockstore.get_slot_entries(slot, 0)?.last().unwrap().hash;
+                writeln!(output, "{slot}: {blockhash:?}").expect("failed to write");
+            }
         }
         ("parse_full_frozen", Some(arg_matches)) => {
             let starting_slot = value_t_or_exit!(arg_matches, "starting_slot", Slot);

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -904,13 +904,13 @@ fn do_blockstore_process_command(
                 Some(end_slot) => end_slot,
                 None => {
                     let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
-                        let slots: Vec<_> = slot_meta_iterator.map(|(slot, _)| slot).collect();
-                        if slots.is_empty() {
-                            eprintln!("Purge range is empty");
-                            std::process::exit(1);
-                        }
-                        *slots.last().unwrap()
-                },
+                    let slots: Vec<_> = slot_meta_iterator.map(|(slot, _)| slot).collect();
+                    if slots.is_empty() {
+                        eprintln!("Purge range is empty");
+                        std::process::exit(1);
+                    }
+                    *slots.last().unwrap()
+                }
             };
 
             if end_slot < start_slot {

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -619,13 +619,12 @@ fn do_blockstore_process_command(
             &crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary).db(),
         )?,
         ("bounds", Some(arg_matches)) => {
-            let blockstore =
-                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
-
-            let slot_meta_iterator = blockstore.slot_meta_iterator(0)?;
             let output_format = OutputFormat::from_matches(arg_matches, "output_format", false);
             let all = arg_matches.is_present("all");
 
+            let blockstore =
+                crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
+            let slot_meta_iterator = blockstore.slot_meta_iterator(0)?;
             let slots: Vec<_> = slot_meta_iterator.map(|(slot, _)| slot).collect();
 
             let slot_bounds = if slots.is_empty() {

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -239,10 +239,8 @@ fn get_latest_optimistic_slots(
 fn print_blockstore_file_metadata(
     blockstore: &Blockstore,
     file_name: &Option<&str>,
-) -> Result<(), String> {
-    let live_files = blockstore
-        .live_files_metadata()
-        .map_err(|err| format!("{err:?}"))?;
+) -> Result<(), Box<dyn std::error::Error>> {
+    let live_files = blockstore.live_files_metadata()?;
 
     // All files under live_files_metadata are prefixed with "/".
     let sst_file_name = file_name.as_ref().map(|name| format!("/{name}"));
@@ -267,7 +265,8 @@ fn print_blockstore_file_metadata(
     if sst_file_name.is_some() {
         return Err(format!(
             "Failed to find or load the metadata of the specified file {file_name:?}"
-        ));
+        )
+        .into());
     }
     Ok(())
 }

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -42,13 +42,13 @@ fn analyze_column<
 >(
     db: &Database,
     name: &str,
-) {
+) -> Result<(), Box<dyn std::error::Error>> {
     let mut key_len: u64 = 0;
     let mut key_tot: u64 = 0;
     let mut val_hist = histogram::Histogram::new();
     let mut val_tot: u64 = 0;
     let mut row_hist = histogram::Histogram::new();
-    for (key, val) in db.iter::<C>(blockstore_db::IteratorMode::Start).unwrap() {
+    for (key, val) in db.iter::<C>(blockstore_db::IteratorMode::Start)? {
         // Key length is fixed, only need to calculate it once
         if key_len == 0 {
             key_len = C::key(key).len() as u64;
@@ -108,31 +108,32 @@ fn analyze_column<
         })
     };
 
-    println!("{}", serde_json::to_string_pretty(&json_result).unwrap());
+    println!("{}", serde_json::to_string_pretty(&json_result)?);
+    Ok(())
 }
 
-fn analyze_storage(database: &Database) {
+fn analyze_storage(database: &Database) -> Result<(), Box<dyn std::error::Error>> {
     use solana_ledger::blockstore_db::columns::*;
-    analyze_column::<SlotMeta>(database, "SlotMeta");
-    analyze_column::<Orphans>(database, "Orphans");
-    analyze_column::<DeadSlots>(database, "DeadSlots");
-    analyze_column::<DuplicateSlots>(database, "DuplicateSlots");
-    analyze_column::<ErasureMeta>(database, "ErasureMeta");
-    analyze_column::<BankHash>(database, "BankHash");
-    analyze_column::<Root>(database, "Root");
-    analyze_column::<Index>(database, "Index");
-    analyze_column::<ShredData>(database, "ShredData");
-    analyze_column::<ShredCode>(database, "ShredCode");
-    analyze_column::<TransactionStatus>(database, "TransactionStatus");
-    analyze_column::<AddressSignatures>(database, "AddressSignatures");
-    analyze_column::<TransactionMemos>(database, "TransactionMemos");
-    analyze_column::<TransactionStatusIndex>(database, "TransactionStatusIndex");
-    analyze_column::<Rewards>(database, "Rewards");
-    analyze_column::<Blocktime>(database, "Blocktime");
-    analyze_column::<PerfSamples>(database, "PerfSamples");
-    analyze_column::<BlockHeight>(database, "BlockHeight");
-    analyze_column::<ProgramCosts>(database, "ProgramCosts");
-    analyze_column::<OptimisticSlots>(database, "OptimisticSlots");
+    analyze_column::<SlotMeta>(database, "SlotMeta")?;
+    analyze_column::<Orphans>(database, "Orphans")?;
+    analyze_column::<DeadSlots>(database, "DeadSlots")?;
+    analyze_column::<DuplicateSlots>(database, "DuplicateSlots")?;
+    analyze_column::<ErasureMeta>(database, "ErasureMeta")?;
+    analyze_column::<BankHash>(database, "BankHash")?;
+    analyze_column::<Root>(database, "Root")?;
+    analyze_column::<Index>(database, "Index")?;
+    analyze_column::<ShredData>(database, "ShredData")?;
+    analyze_column::<ShredCode>(database, "ShredCode")?;
+    analyze_column::<TransactionStatus>(database, "TransactionStatus")?;
+    analyze_column::<AddressSignatures>(database, "AddressSignatures")?;
+    analyze_column::<TransactionMemos>(database, "TransactionMemos")?;
+    analyze_column::<TransactionStatusIndex>(database, "TransactionStatusIndex")?;
+    analyze_column::<Rewards>(database, "Rewards")?;
+    analyze_column::<Blocktime>(database, "Blocktime")?;
+    analyze_column::<PerfSamples>(database, "PerfSamples")?;
+    analyze_column::<BlockHeight>(database, "BlockHeight")?;
+    analyze_column::<ProgramCosts>(database, "ProgramCosts")?;
+    analyze_column::<OptimisticSlots>(database, "OptimisticSlots")
 }
 
 fn raw_key_to_slot(key: &[u8], column_name: &str) -> Option<Slot> {
@@ -615,7 +616,7 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
         ("analyze-storage", Some(arg_matches)) => {
             analyze_storage(
                 &crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary).db(),
-            );
+            )?
         }
         ("bounds", Some(arg_matches)) => {
             let blockstore =

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -600,6 +600,14 @@ pub fn blockstore_subcommands<'a, 'b>(hidden: bool) -> Vec<App<'a, 'b>> {
 }
 
 pub fn blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) {
+    do_blockstore_process_command(ledger_path, matches).unwrap_or_else(|err| {
+        eprintln!("{err:?}");
+        std::process::exit(1);
+    });
+}
+
+
+fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -> Result<(), Box<dyn std::error::Error>> {
     let ledger_path = canonicalize_ledger_path(ledger_path);
     let verbose_level = matches.occurrences_of("verbose");
 
@@ -1084,6 +1092,7 @@ pub fn blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) 
         }
         _ => unreachable!(),
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -902,19 +902,14 @@ fn do_blockstore_process_command(
 
             let end_slot = match end_slot {
                 Some(end_slot) => end_slot,
-                None => match blockstore.slot_meta_iterator(start_slot) {
-                    Ok(metas) => {
-                        let slots: Vec<_> = metas.map(|(slot, _)| slot).collect();
+                None => {
+                    let slot_meta_iterator = blockstore.slot_meta_iterator(start_slot)?;
+                        let slots: Vec<_> = slot_meta_iterator.map(|(slot, _)| slot).collect();
                         if slots.is_empty() {
                             eprintln!("Purge range is empty");
                             std::process::exit(1);
                         }
                         *slots.last().unwrap()
-                    }
-                    Err(err) => {
-                        eprintln!("Unable to read the Ledger: {err:?}");
-                        std::process::exit(1);
-                    }
                 },
             };
 

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -698,15 +698,14 @@ fn do_blockstore_process_command(
                 ),
             );
             let target = crate::open_blockstore(&target_db, arg_matches, AccessType::Primary);
-            for (slot, _meta) in source.slot_meta_iterator(starting_slot).unwrap() {
+            for (slot, _meta) in source.slot_meta_iterator(starting_slot)? {
                 if slot > ending_slot {
                     break;
                 }
-                if let Ok(shreds) = source.get_data_shreds_for_slot(slot, 0) {
+                let shreds = source.get_data_shreds_for_slot(slot, 0)?;
                     if target.insert_shreds(shreds, None, true).is_err() {
                         warn!("error inserting shreds for slot {}", slot);
                     }
-                }
             }
         }
         ("dead-slots", Some(arg_matches)) => {

--- a/ledger-tool/src/error.rs
+++ b/ledger-tool/src/error.rs
@@ -1,0 +1,18 @@
+use {solana_ledger::blockstore::BlockstoreError, thiserror::Error};
+
+pub type Result<T> = std::result::Result<T, LedgerToolError>;
+
+#[derive(Error, Debug)]
+pub enum LedgerToolError {
+    #[error("{0}")]
+    Blockstore(#[from] BlockstoreError),
+
+    #[error("{0}")]
+    SerdeJson(#[from] serde_json::Error),
+
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("{0}")]
+    BadArgument(String),
+}

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -95,6 +95,7 @@ use {
 mod args;
 mod bigtable;
 mod blockstore;
+mod error;
 mod ledger_path;
 mod ledger_utils;
 mod output;


### PR DESCRIPTION
#### Problem
There are lots of operations that could fail, including lots of the
Blockstore calls. The old code matched on Ok(_) or did unwrap()'s
which clutter the code and increase indentation.

#### Summary of Changes
This change wraps the entire command in a function that returns a
Result. The wrapper then does a single unwrap_or_else() and prints
any error message. Everywhere else is now free to use the ? operator
