### PR TITLE
chore: bump toml for programs/sbf from 0.5.8 to 0.5.11

### DIFF
--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -7449,9 +7449,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
#### Problem

context: https://github.com/solana-labs/solana/pull/35126

#### Summary of Changes

bump `toml` for `programs/sbf` from 0.5.8 to 0.5.11 (0.5.11 is the latest version of toml 0.5.x atm)