### PR TITLE
Cleanup - `disable_bpf_loader_instructions`

### DIFF
--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -101,7 +101,9 @@ solana_rbpf = { workspace = true }
 
 [dev-dependencies]
 solana-ledger = { workspace = true }
+solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+
 
 [[bench]]
 name = "bpf_loader"

--- a/programs/sbf/Cargo.toml
+++ b/programs/sbf/Cargo.toml
@@ -104,7 +104,6 @@ solana-ledger = { workspace = true }
 solana-runtime = { workspace = true, features = ["dev-context-only-utils"] }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
 
-
 [[bench]]
 name = "bpf_loader"
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -190,12 +190,6 @@ fn bench_program_execute_noop(bencher: &mut Bencher) {
         ..
     } = create_genesis_config(50);
 
-    // deactivate `disable_bpf_loader_instructions` feature so that the program
-    // can be loaded, finalized and benched.
-    genesis_config
-        .accounts
-        .remove(&feature_set::disable_bpf_loader_instructions::id());
-
     genesis_config
         .accounts
         .remove(&feature_set::deprecate_executable_meta_update_in_bpf_loader::id());

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -23,24 +23,10 @@ use {
         ebpf::MM_INPUT_START, elf::Executable, memory_region::MemoryRegion,
         verifier::RequisiteVerifier, vm::ContextObject,
     },
-    solana_runtime::{
-        bank::Bank,
-        bank_client::BankClient,
-        genesis_utils::{create_genesis_config, GenesisConfigInfo},
-        loader_utils::{load_program, load_program_from_file},
-    },
+    solana_runtime::loader_utils::load_program_from_file,
     solana_sdk::{
-        account::AccountSharedData,
-        bpf_loader,
-        client::SyncClient,
-        entrypoint::SUCCESS,
-        feature_set::{self, FeatureSet},
-        instruction::{AccountMeta, Instruction},
-        message::Message,
-        native_loader,
-        pubkey::Pubkey,
-        signature::Signer,
-        transaction_context::InstructionAccount,
+        account::AccountSharedData, bpf_loader, entrypoint::SUCCESS, feature_set::FeatureSet,
+        native_loader, pubkey::Pubkey, transaction_context::InstructionAccount,
     },
     std::{mem, sync::Arc},
     test::Bencher,
@@ -180,46 +166,6 @@ fn bench_program_alu(bencher: &mut Bencher) {
     let mips = (instructions * (ns_per_s / summary.median as u64)) / one_million;
     println!("  {:?} MIPS", mips);
     println!("{{ \"type\": \"bench\", \"name\": \"bench_program_alu_jit_to_native_mips\", \"median\": {:?}, \"deviation\": 0 }}", mips);
-}
-
-#[bench]
-fn bench_program_execute_noop(bencher: &mut Bencher) {
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config(50);
-
-    genesis_config
-        .accounts
-        .remove(&feature_set::deprecate_executable_meta_update_in_bpf_loader::id());
-
-    let bank = Bank::new_for_benches(&genesis_config);
-    let (bank, bank_forks) = bank.wrap_with_bank_forks_for_tests();
-    let mut bank_client = BankClient::new_shared(bank.clone());
-
-    let invoke_program_id = load_program(&bank_client, &bpf_loader::id(), &mint_keypair, "noop");
-    let bank = bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
-        .expect("Failed to advance the slot");
-
-    let mint_pubkey = mint_keypair.pubkey();
-    let account_metas = vec![AccountMeta::new(mint_pubkey, true)];
-
-    let instruction =
-        Instruction::new_with_bincode(invoke_program_id, &[u8::MAX, 0, 0, 0], account_metas);
-    let message = Message::new(&[instruction], Some(&mint_pubkey));
-
-    bank_client
-        .send_and_confirm_message(&[&mint_keypair], message.clone())
-        .unwrap();
-
-    bencher.iter(|| {
-        bank.clear_signatures();
-        bank_client
-            .send_and_confirm_message(&[&mint_keypair], message.clone())
-            .unwrap();
-    });
 }
 
 #[bench]

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -6,7 +6,8 @@
 
 use {
     solana_rbpf::memory_region::MemoryState,
-    solana_sdk::feature_set::bpf_account_data_direct_mapping, std::slice,
+    solana_sdk::{feature_set::bpf_account_data_direct_mapping, signer::keypair::Keypair},
+    std::slice,
 };
 
 extern crate test;

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -28,9 +28,8 @@ use {
     solana_runtime::{
         bank::TransactionBalancesSet,
         loader_utils::{
-            create_program, load_and_finalize_program, load_program, load_program_from_file,
-            load_upgradeable_buffer, load_upgradeable_program, set_upgrade_authority,
-            upgrade_program,
+            create_program, load_program_from_file, load_upgradeable_buffer,
+            load_upgradeable_program, set_upgrade_authority, upgrade_program,
         },
     },
     solana_sbf_rust_invoke::instructions::*,
@@ -45,12 +44,11 @@ use {
         entrypoint::MAX_PERMITTED_DATA_INCREASE,
         feature_set::{self, FeatureSet},
         fee::FeeStructure,
-        loader_instruction,
         message::{v0::LoadedAddresses, SanitizedMessage},
         signature::keypair_from_seed,
         stake,
         system_instruction::{self, MAX_PERMITTED_DATA_LENGTH},
-        sysvar::{self, clock, rent},
+        sysvar::{self, clock},
         transaction::VersionedTransaction,
     },
     solana_transaction_status::{
@@ -248,22 +246,6 @@ fn execute_transactions(
     .collect()
 }
 
-fn load_program_and_advance_slot(
-    bank_client: &mut BankClient,
-    bank_forks: &RwLock<BankForks>,
-    loader_id: &Pubkey,
-    payer_keypair: &Keypair,
-    name: &str,
-) -> (Arc<Bank>, Pubkey) {
-    let pubkey = load_program(bank_client, loader_id, payer_keypair, name);
-    (
-        bank_client
-            .advance_slot(1, bank_forks, &Pubkey::default())
-            .expect("Failed to advance the slot"),
-        pubkey,
-    )
-}
-
 fn load_upgradeable_program_wrapper(
     bank_client: &BankClient,
     mint_keypair: &Keypair,
@@ -436,66 +418,6 @@ fn test_program_sbf_loader_deprecated() {
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert!(result.is_ok());
     }
-}
-
-/// This test is written with bpf_loader v2 specific instructions, which will be
-/// deprecated when `disable_bpf_loader_instructions` feature is activated.
-///
-/// The same test has been migrated to
-/// `test_sol_alloc_free_no_longer_deployable_with_upgradeable_loader`  with a new version
-/// of bpf_upgradeable_loader!
-#[test]
-#[cfg(feature = "sbf_rust")]
-fn test_sol_alloc_free_no_longer_deployable() {
-    solana_logger::setup();
-
-    let program_keypair = Keypair::new();
-    let program_address = program_keypair.pubkey();
-
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config(50);
-
-    // deactivate `disable_bpf_loader_instructions` feature so that the program
-    // can be loaded, finalized and tested.
-    genesis_config
-        .accounts
-        .remove(&feature_set::disable_bpf_loader_instructions::id());
-
-    genesis_config
-        .accounts
-        .remove(&feature_set::deprecate_executable_meta_update_in_bpf_loader::id());
-
-    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-
-    let elf = load_program_from_file("solana_sbf_rust_deprecated_loader");
-    let mut program_account = AccountSharedData::new(1, elf.len(), &bpf_loader::id());
-    program_account
-        .data_as_mut_slice()
-        .get_mut(..)
-        .unwrap()
-        .copy_from_slice(&elf);
-    bank.store_account(&program_address, &program_account);
-
-    let finalize_tx = Transaction::new(
-        &[&mint_keypair, &program_keypair],
-        Message::new(
-            &[loader_instruction::finalize(
-                &program_keypair.pubkey(),
-                &bpf_loader::id(),
-            )],
-            Some(&mint_keypair.pubkey()),
-        ),
-        bank.last_blockhash(),
-    );
-
-    // Try and deploy a program that depends on _sol_alloc_free
-    assert_eq!(
-        bank.process_transaction(&finalize_tx).unwrap_err(),
-        TransactionError::InstructionError(0, InstructionError::InvalidAccountData)
-    );
 }
 
 #[test]
@@ -1626,97 +1548,6 @@ fn test_program_sbf_instruction_introspection() {
         TransactionError::InstructionError(0, InstructionError::NotEnoughAccountKeys)
     );
     assert!(bank.get_account(&sysvar::instructions::id()).is_none());
-}
-
-/// This test is to test bpf_loader v2 `Finalize` instruction with different
-/// programs. It is going to be deprecated once we activate
-/// `disable_bpf_loader_instructions`.
-#[test]
-#[cfg(feature = "sbf_rust")]
-fn test_program_sbf_test_use_latest_executor() {
-    solana_logger::setup();
-
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config(50);
-
-    // deactivate `disable_bpf_loader_instructions` feature so that the program
-    // can be loaded, finalized and tested.
-    genesis_config
-        .accounts
-        .remove(&feature_set::disable_bpf_loader_instructions::id());
-    genesis_config
-        .accounts
-        .remove(&feature_set::deprecate_executable_meta_update_in_bpf_loader::id());
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank);
-    let panic_id = load_program(
-        &bank_client,
-        &bpf_loader::id(),
-        &mint_keypair,
-        "solana_sbf_rust_panic",
-    );
-
-    // Write the panic program into the program account
-    let (program_keypair, instruction) = load_and_finalize_program(
-        &bank_client,
-        &bpf_loader::id(),
-        None,
-        &mint_keypair,
-        "solana_sbf_rust_panic",
-    );
-
-    // Finalize the panic program, but fail the tx
-    let message = Message::new(
-        &[
-            instruction,
-            Instruction::new_with_bytes(panic_id, &[0], vec![]),
-        ],
-        Some(&mint_keypair.pubkey()),
-    );
-
-    bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
-        .expect("Failed to advance the slot");
-
-    assert!(bank_client
-        .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
-        .is_err());
-
-    // Write the noop program into the same program account
-    let (program_keypair, instruction) = load_and_finalize_program(
-        &bank_client,
-        &bpf_loader::id(),
-        Some(program_keypair),
-        &mint_keypair,
-        "solana_sbf_rust_noop",
-    );
-    bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
-        .expect("Failed to advance the slot");
-    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
-    bank_client
-        .send_and_confirm_message(&[&mint_keypair, &program_keypair], message)
-        .unwrap();
-
-    // Call the noop program, should get noop not panic
-    let message = Message::new(
-        &[Instruction::new_with_bytes(
-            program_keypair.pubkey(),
-            &[0],
-            vec![],
-        )],
-        Some(&mint_keypair.pubkey()),
-    );
-    bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
-        .expect("Failed to advance the slot");
-    assert!(bank_client
-        .send_and_confirm_message(&[&mint_keypair], message)
-        .is_ok());
 }
 
 #[test]
@@ -2885,67 +2716,6 @@ fn test_program_upgradeable_locks() {
         })
     ));
     assert_eq!(results2[1], Err(TransactionError::AccountInUse));
-}
-
-/// This test is to test bpf_loader v2 `Finalize` instruction. It is going to be
-/// deprecated once we activate `disable_bpf_loader_instructions`.
-#[test]
-#[cfg(feature = "sbf_rust")]
-fn test_program_sbf_finalize() {
-    solana_logger::setup();
-
-    let GenesisConfigInfo {
-        mut genesis_config,
-        mint_keypair,
-        ..
-    } = create_genesis_config(50);
-
-    // deactivate `disable_bpf_loader_instructions` feature so that the program
-    // can be loaded, finalized and tested.
-    genesis_config
-        .accounts
-        .remove(&feature_set::disable_bpf_loader_instructions::id());
-
-    genesis_config
-        .accounts
-        .remove(&feature_set::deprecate_executable_meta_update_in_bpf_loader::id());
-
-    let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
-    let mut bank_client = BankClient::new_shared(bank.clone());
-
-    let (_, program_pubkey) = load_program_and_advance_slot(
-        &mut bank_client,
-        bank_forks.as_ref(),
-        &bpf_loader::id(),
-        &mint_keypair,
-        "solana_sbf_rust_finalize",
-    );
-
-    // Write the noop program into the same program account
-    let (program_keypair, _instruction) = load_and_finalize_program(
-        &bank_client,
-        &bpf_loader::id(),
-        None,
-        &mint_keypair,
-        "solana_sbf_rust_noop",
-    );
-
-    bank_client
-        .advance_slot(1, bank_forks.as_ref(), &Pubkey::default())
-        .expect("Failed to advance the slot");
-
-    let account_metas = vec![
-        AccountMeta::new(program_keypair.pubkey(), true),
-        AccountMeta::new_readonly(bpf_loader::id(), false),
-        AccountMeta::new(rent::id(), false),
-    ];
-    let instruction = Instruction::new_with_bytes(program_pubkey, &[], account_metas.clone());
-    let message = Message::new(&[instruction], Some(&mint_keypair.pubkey()));
-    let result = bank_client.send_and_confirm_message(&[&mint_keypair, &program_keypair], message);
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
-    );
 }
 
 #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -2323,7 +2323,7 @@ fn test_program_sbf_disguised_as_sbf_loader() {
         let result = bank_client.send_and_confirm_instruction(&mint_keypair, instruction);
         assert_eq!(
             result.unwrap_err().unwrap(),
-            TransactionError::InstructionError(0, InstructionError::IncorrectProgramId)
+            TransactionError::InstructionError(0, InstructionError::UnsupportedProgramId)
         );
     }
 }

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -63,7 +63,6 @@ use {
     solana_runtime::{
         bank::Bank,
         bank_client::BankClient,
-        bank_forks::BankForks,
         genesis_utils::{
             bootstrap_validator_stake_lamports, create_genesis_config,
             create_genesis_config_with_leader_ex, GenesisConfigInfo,
@@ -85,12 +84,7 @@ use {
         system_program,
         transaction::{SanitizedTransaction, Transaction, TransactionError},
     },
-    std::{
-        cell::RefCell,
-        str::FromStr,
-        sync::{Arc, RwLock},
-        time::Duration,
-    },
+    std::{cell::RefCell, str::FromStr, sync::Arc, time::Duration},
 };
 
 #[cfg(feature = "sbf_rust")]

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -26,7 +26,7 @@ use {
         time::{Duration, Instant},
     },
 };
-#[cfg(feature = "dev-context-only-utils")]
+// These imports are only used for tests and benchmarks.
 use {crate::bank_forks::BankForks, solana_sdk::clock, std::sync::RwLock};
 
 pub struct BankClient {
@@ -331,7 +331,7 @@ impl BankClient {
         self.bank.set_sysvar_for_tests(sysvar);
     }
 
-    /// Only used for test and bench.
+    /// Only used for tests and benchmarks.
     pub fn advance_slot(
         &mut self,
         by: u64,

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -26,7 +26,7 @@ use {
         time::{Duration, Instant},
     },
 };
-// These imports are only used for tests and benchmarks.
+#[cfg(feature = "dev-context-only-utils")]
 use {crate::bank_forks::BankForks, solana_sdk::clock, std::sync::RwLock};
 
 pub struct BankClient {
@@ -331,7 +331,7 @@ impl BankClient {
         self.bank.set_sysvar_for_tests(sysvar);
     }
 
-    /// Only used for tests and benchmarks.
+    #[cfg(feature = "dev-context-only-utils")]
     pub fn advance_slot(
         &mut self,
         by: u64,

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -331,7 +331,7 @@ impl BankClient {
         self.bank.set_sysvar_for_tests(sysvar);
     }
 
-    #[cfg(feature = "dev-context-only-utils")]
+    /// Only used for test and bench.
     pub fn advance_slot(
         &mut self,
         by: u64,

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{bank::Bank, bank_client::BankClient},
+    crate::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     serde::Serialize,
     solana_sdk::{
         account::{AccountSharedData, WritableAccount},
@@ -13,7 +13,13 @@ use {
         signature::{Keypair, Signer},
         system_instruction,
     },
-    std::{env, fs::File, io::Read, path::PathBuf},
+    std::{
+        env,
+        fs::File,
+        io::Read,
+        path::PathBuf,
+        sync::{Arc, RwLock},
+    },
 };
 
 const CHUNK_SIZE: usize = 512; // Size of chunk just needs to fit into tx
@@ -204,6 +210,48 @@ pub fn load_upgradeable_program(
         slot: 1,
         ..Clock::default()
     });
+}
+
+pub fn load_upgradeable_program_wrapper(
+    bank_client: &BankClient,
+    mint_keypair: &Keypair,
+    authority_keypair: &Keypair,
+    name: &str,
+) -> Pubkey {
+    let buffer_keypair = Keypair::new();
+    let program_keypair = Keypair::new();
+    load_upgradeable_program(
+        bank_client,
+        mint_keypair,
+        &buffer_keypair,
+        &program_keypair,
+        authority_keypair,
+        name,
+    );
+    program_keypair.pubkey()
+}
+
+pub fn load_upgradeable_program_and_advance_slot(
+    bank_client: &mut BankClient,
+    bank_forks: &RwLock<BankForks>,
+    mint_keypair: &Keypair,
+    authority_keypair: &Keypair,
+    name: &str,
+) -> (Arc<Bank>, Pubkey) {
+    let program_id =
+        load_upgradeable_program_wrapper(bank_client, mint_keypair, authority_keypair, name);
+
+    // load_upgradeable_program sets clock sysvar to 1, which causes the program to be effective
+    // after 2 slots. They need to be called individually to create the correct fork graph in between.
+    bank_client
+        .advance_slot(1, bank_forks, &Pubkey::default())
+        .expect("Failed to advance the slot");
+
+    let bank = bank_client
+        .advance_slot(1, bank_forks, &Pubkey::default())
+        .expect("Failed to advance the slot");
+
+    (bank, program_id)
 }
 
 pub fn upgrade_program<T: Client>(

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -212,6 +212,7 @@ pub fn load_upgradeable_program(
     });
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn load_upgradeable_program_wrapper(
     bank_client: &BankClient,
     mint_keypair: &Keypair,
@@ -231,6 +232,7 @@ pub fn load_upgradeable_program_wrapper(
     program_keypair.pubkey()
 }
 
+#[cfg(feature = "dev-context-only-utils")]
 pub fn load_upgradeable_program_and_advance_slot(
     bank_client: &mut BankClient,
     bank_forks: &RwLock<BankForks>,

--- a/runtime/src/loader_utils.rs
+++ b/runtime/src/loader_utils.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "dev-context-only-utils")]
 use {
     crate::{bank::Bank, bank_client::BankClient, bank_forks::BankForks},
     serde::Serialize,
@@ -212,7 +213,6 @@ pub fn load_upgradeable_program(
     });
 }
 
-#[cfg(feature = "dev-context-only-utils")]
 pub fn load_upgradeable_program_wrapper(
     bank_client: &BankClient,
     mint_keypair: &Keypair,
@@ -232,7 +232,6 @@ pub fn load_upgradeable_program_wrapper(
     program_keypair.pubkey()
 }
 
-#[cfg(feature = "dev-context-only-utils")]
 pub fn load_upgradeable_program_and_advance_slot(
     bank_client: &mut BankClient,
     bank_forks: &RwLock<BankForks>,


### PR DESCRIPTION
#### Problem
The feature was forced in v1.17.20 on MNB.

#### Summary of Changes
Removes it from master and v1.18 as well to stay in sync.

Feature Gate Issue: #34424
