### PR TITLE
v1.17 Ignore flaky test_optimistic_confirmation_violation_with_tower and fix bpf benches

### DIFF
--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -3059,6 +3059,7 @@ fn run_test_load_program_accounts(scan_commitment: CommitmentConfig) {
 }
 
 #[test]
+#[ignore]
 #[serial]
 fn test_no_optimistic_confirmation_violation_with_tower() {
     do_test_optimistic_confirmation_violation_with_or_without_tower(true);

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -101,6 +101,7 @@ fn bench_program_create_executable(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn bench_program_alu(bencher: &mut Bencher) {
     let ns_per_s = 1000000000;
     let one_million = 1000000;
@@ -118,13 +119,18 @@ fn bench_program_alu(bencher: &mut Bencher) {
         true,
         false,
     );
+    #[allow(unused_mut)]
     let mut executable =
         Executable::<InvokeContext>::from_elf(&elf, Arc::new(program_runtime_environment.unwrap()))
             .unwrap();
 
     executable.verify::<RequisiteVerifier>().unwrap();
 
-    executable.jit_compile().unwrap();
+    #[cfg(all(not(target_os = "windows"), target_arch = "x86_64"))]
+    {
+        executable.jit_compile().unwrap();
+    }
+
     create_vm!(
         vm,
         &executable,
@@ -181,6 +187,7 @@ fn bench_program_alu(bencher: &mut Bencher) {
 }
 
 #[bench]
+#[ignore]
 fn bench_program_execute_noop(bencher: &mut Bencher) {
     let GenesisConfigInfo {
         mut genesis_config,


### PR DESCRIPTION
#### Problem

test_optimistic_confirmation_violation_with_tower is flaky, and some sbf benches are failling from the disabled loader

#### Summary of Changes

Ignore them and fix compilation errors

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
