### PR TITLE
only call is_executable once

### DIFF
--- a/ledger-tool/src/program.rs
+++ b/ledger-tool/src/program.rs
@@ -545,7 +545,6 @@ pub fn program(ledger_path: &Path, matches: &ArgMatches<'_>) {
             .get_current_instruction_context()
             .unwrap(),
         true, // copy_account_data
-        &invoke_context.feature_set,
     )
     .unwrap();
 

--- a/program-runtime/src/invoke_context.rs
+++ b/program-runtime/src/invoke_context.rs
@@ -403,7 +403,7 @@ impl<'a> InvokeContext<'a> {
             })?;
         let borrowed_program_account = instruction_context
             .try_borrow_instruction_account(self.transaction_context, program_account_index)?;
-        if !borrowed_program_account.is_executable(&self.feature_set) {
+        if !borrowed_program_account.is_executable() {
             ic_msg!(self, "Account {} is not executable", callee_program_id);
             return Err(InstructionError::AccountNotExecutable);
         }
@@ -802,17 +802,17 @@ mod tests {
                     MockInstruction::NoopFail => return Err(InstructionError::GenericError),
                     MockInstruction::ModifyOwned => instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .set_data_from_slice(&[1], &invoke_context.feature_set)?,
+                        .set_data_from_slice(&[1])?,
                     MockInstruction::ModifyNotOwned => instruction_context
                         .try_borrow_instruction_account(transaction_context, 1)?
-                        .set_data_from_slice(&[1], &invoke_context.feature_set)?,
+                        .set_data_from_slice(&[1])?,
                     MockInstruction::ModifyReadonly => instruction_context
                         .try_borrow_instruction_account(transaction_context, 2)?
-                        .set_data_from_slice(&[1], &invoke_context.feature_set)?,
+                        .set_data_from_slice(&[1])?,
                     MockInstruction::UnbalancedPush => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?
-                            .checked_add_lamports(1, &invoke_context.feature_set)?;
+                            .checked_add_lamports(1)?;
                         let program_id = *transaction_context.get_key_of_account_at_index(3)?;
                         let metas = vec![
                             AccountMeta::new_readonly(
@@ -843,7 +843,7 @@ mod tests {
                     }
                     MockInstruction::UnbalancedPop => instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .checked_add_lamports(1, &invoke_context.feature_set)?,
+                        .checked_add_lamports(1)?,
                     MockInstruction::ConsumeComputeUnits {
                         compute_units_to_consume,
                         desired_result,
@@ -855,7 +855,7 @@ mod tests {
                     }
                     MockInstruction::Resize { new_len } => instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .set_data(vec![0; new_len as usize], &invoke_context.feature_set)?,
+                        .set_data(vec![0; new_len as usize])?,
                 }
             } else {
                 return Err(InstructionError::InvalidInstructionData);

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -217,16 +217,16 @@ mod tests {
                     MockSystemInstruction::TransferLamports { lamports } => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?
-                            .checked_sub_lamports(lamports, &invoke_context.feature_set)?;
+                            .checked_sub_lamports(lamports)?;
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 1)?
-                            .checked_add_lamports(lamports, &invoke_context.feature_set)?;
+                            .checked_add_lamports(lamports)?;
                         Ok(())
                     }
                     MockSystemInstruction::ChangeData { data } => {
                         instruction_context
                             .try_borrow_instruction_account(transaction_context, 1)?
-                            .set_data(vec![data], &invoke_context.feature_set)?;
+                            .set_data(vec![data])?;
                         Ok(())
                     }
                 }
@@ -443,14 +443,14 @@ mod tests {
                     MockSystemInstruction::DoWork { lamports, data } => {
                         let mut dup_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 2)?;
-                        dup_account.checked_sub_lamports(lamports, &invoke_context.feature_set)?;
-                        to_account.checked_add_lamports(lamports, &invoke_context.feature_set)?;
-                        dup_account.set_data(vec![data], &invoke_context.feature_set)?;
+                        dup_account.checked_sub_lamports(lamports)?;
+                        to_account.checked_add_lamports(lamports)?;
+                        dup_account.set_data(vec![data])?;
                         drop(dup_account);
                         let mut from_account = instruction_context
                             .try_borrow_instruction_account(transaction_context, 0)?;
-                        from_account.checked_sub_lamports(lamports, &invoke_context.feature_set)?;
-                        to_account.checked_add_lamports(lamports, &invoke_context.feature_set)?;
+                        from_account.checked_sub_lamports(lamports)?;
+                        to_account.checked_add_lamports(lamports)?;
                         Ok(())
                     }
                 }

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -133,7 +133,6 @@ pub fn invoke_builtin_function(
             .transaction_context
             .get_current_instruction_context()?,
         true, // copy_account_data // There is no VM so direct mapping can not be implemented here
-        &invoke_context.feature_set,
     )?;
 
     // Deserialize data back into instruction params
@@ -164,25 +163,18 @@ pub fn invoke_builtin_function(
         if borrowed_account.is_writable() {
             if let Some(account_info) = account_info_map.get(borrowed_account.get_key()) {
                 if borrowed_account.get_lamports() != account_info.lamports() {
-                    borrowed_account
-                        .set_lamports(account_info.lamports(), &invoke_context.feature_set)?;
+                    borrowed_account.set_lamports(account_info.lamports())?;
                 }
 
                 if borrowed_account
                     .can_data_be_resized(account_info.data_len())
                     .is_ok()
-                    && borrowed_account
-                        .can_data_be_changed(&invoke_context.feature_set)
-                        .is_ok()
+                    && borrowed_account.can_data_be_changed().is_ok()
                 {
-                    borrowed_account.set_data_from_slice(
-                        &account_info.data.borrow(),
-                        &invoke_context.feature_set,
-                    )?;
+                    borrowed_account.set_data_from_slice(&account_info.data.borrow())?;
                 }
                 if borrowed_account.get_owner() != account_info.owner {
-                    borrowed_account
-                        .set_owner(account_info.owner.as_ref(), &invoke_context.feature_set)?;
+                    borrowed_account.set_owner(account_info.owner.as_ref())?;
                 }
             }
         }
@@ -293,17 +285,17 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
                 .unwrap();
             if borrowed_account.get_lamports() != account_info.lamports() {
                 borrowed_account
-                    .set_lamports(account_info.lamports(), &invoke_context.feature_set)
+                    .set_lamports(account_info.lamports())
                     .unwrap();
             }
             let account_info_data = account_info.try_borrow_data().unwrap();
             // The redundant check helps to avoid the expensive data comparison if we can
             match borrowed_account
                 .can_data_be_resized(account_info_data.len())
-                .and_then(|_| borrowed_account.can_data_be_changed(&invoke_context.feature_set))
+                .and_then(|_| borrowed_account.can_data_be_changed())
             {
                 Ok(()) => borrowed_account
-                    .set_data_from_slice(&account_info_data, &invoke_context.feature_set)
+                    .set_data_from_slice(&account_info_data)
                     .unwrap(),
                 Err(err) if borrowed_account.get_data() != *account_info_data => {
                     panic!("{err:?}");
@@ -313,7 +305,7 @@ impl solana_sdk::program_stubs::SyscallStubs for SyscallStubs {
             // Change the owner at the end so that we are allowed to change the lamports and data before
             if borrowed_account.get_owner() != account_info.owner {
                 borrowed_account
-                    .set_owner(account_info.owner.as_ref(), &invoke_context.feature_set)
+                    .set_owner(account_info.owner.as_ref())
                     .unwrap();
             }
             if instruction_account.is_writable {

--- a/programs/address-lookup-table/src/processor.rs
+++ b/programs/address-lookup-table/src/processor.rs
@@ -162,10 +162,9 @@ impl Processor {
         let instruction_context = transaction_context.get_current_instruction_context()?;
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        lookup_table_account.set_state(
-            &ProgramState::LookupTable(LookupTableMeta::new(authority_key)),
-            &invoke_context.feature_set,
-        )?;
+        lookup_table_account.set_state(&ProgramState::LookupTable(LookupTableMeta::new(
+            authority_key,
+        )))?;
 
         Ok(())
     }
@@ -214,7 +213,7 @@ impl Processor {
         let mut lookup_table_meta = lookup_table.meta;
         lookup_table_meta.authority = None;
         AddressLookupTable::overwrite_meta_data(
-            lookup_table_account.get_data_mut(&invoke_context.feature_set)?,
+            lookup_table_account.get_data_mut()?,
             lookup_table_meta,
         )?;
 
@@ -306,12 +305,11 @@ impl Processor {
         )?;
         {
             AddressLookupTable::overwrite_meta_data(
-                lookup_table_account.get_data_mut(&invoke_context.feature_set)?,
+                lookup_table_account.get_data_mut()?,
                 lookup_table_meta,
             )?;
             for new_address in new_addresses {
-                lookup_table_account
-                    .extend_from_slice(new_address.as_ref(), &invoke_context.feature_set)?;
+                lookup_table_account.extend_from_slice(new_address.as_ref())?;
             }
         }
         drop(lookup_table_account);
@@ -383,7 +381,7 @@ impl Processor {
         lookup_table_meta.deactivation_slot = clock.slot;
 
         AddressLookupTable::overwrite_meta_data(
-            lookup_table_account.get_data_mut(&invoke_context.feature_set)?,
+            lookup_table_account.get_data_mut()?,
             lookup_table_meta,
         )?;
 
@@ -458,13 +456,13 @@ impl Processor {
 
         let mut recipient_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 2)?;
-        recipient_account.checked_add_lamports(withdrawn_lamports, &invoke_context.feature_set)?;
+        recipient_account.checked_add_lamports(withdrawn_lamports)?;
         drop(recipient_account);
 
         let mut lookup_table_account =
             instruction_context.try_borrow_instruction_account(transaction_context, 0)?;
-        lookup_table_account.set_data_length(0, &invoke_context.feature_set)?;
-        lookup_table_account.set_lamports(0, &invoke_context.feature_set)?;
+        lookup_table_account.set_data_length(0)?;
+        lookup_table_account.set_lamports(0)?;
 
         Ok(())
     }

--- a/programs/bpf_loader/benches/serialization.rs
+++ b/programs/bpf_loader/benches/serialization.rs
@@ -7,7 +7,6 @@ use {
     solana_sdk::{
         account::{Account, AccountSharedData},
         bpf_loader, bpf_loader_deprecated,
-        feature_set::FeatureSet,
         pubkey::Pubkey,
         sysvar::rent::Rent,
         transaction_context::{IndexOfAccount, InstructionAccount, TransactionContext},
@@ -127,13 +126,7 @@ fn bench_serialize_unaligned(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            false,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -144,13 +137,7 @@ fn bench_serialize_unaligned_copy_account_data(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            true,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -162,13 +149,7 @@ fn bench_serialize_aligned(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            false,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -180,13 +161,7 @@ fn bench_serialize_aligned_copy_account_data(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            true,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, true).unwrap();
     });
 }
 
@@ -197,13 +172,7 @@ fn bench_serialize_unaligned_max_accounts(bencher: &mut Bencher) {
         .get_current_instruction_context()
         .unwrap();
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            false,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }
 
@@ -215,12 +184,6 @@ fn bench_serialize_aligned_max_accounts(bencher: &mut Bencher) {
         .unwrap();
 
     bencher.iter(|| {
-        let _ = serialize_parameters(
-            &transaction_context,
-            instruction_context,
-            false,
-            &FeatureSet::all_enabled(),
-        )
-        .unwrap();
+        let _ = serialize_parameters(&transaction_context, instruction_context, false).unwrap();
     });
 }

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -938,7 +938,7 @@ mod tests {
                 assert_eq!(account.lamports(), account_info.lamports());
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
-                assert!(account_info.executable);
+                assert_eq!(account.executable(), account_info.executable);
                 assert_eq!(account.rent_epoch(), account_info.rent_epoch);
 
                 assert_eq!(
@@ -1023,7 +1023,7 @@ mod tests {
                 assert_eq!(account.lamports(), account_info.lamports());
                 assert_eq!(account.data(), &account_info.data.borrow()[..]);
                 assert_eq!(account.owner(), account_info.owner);
-                assert!(account_info.executable);
+                assert_eq!(account.executable(), account_info.executable);
                 assert_eq!(account.rent_epoch(), account_info.rent_epoch);
             }
 

--- a/programs/bpf_loader/src/serialization.rs
+++ b/programs/bpf_loader/src/serialization.rs
@@ -11,7 +11,6 @@ use {
     solana_sdk::{
         bpf_loader_deprecated,
         entrypoint::{BPF_ALIGN_OF_U128, MAX_PERMITTED_DATA_INCREASE, NON_DUP_MARKER},
-        feature_set::FeatureSet,
         instruction::InstructionError,
         pubkey::Pubkey,
         system_instruction::MAX_PERMITTED_DATA_LENGTH,
@@ -27,7 +26,7 @@ use {
 const MAX_INSTRUCTION_ACCOUNTS: u8 = NON_DUP_MARKER;
 
 enum SerializeAccount<'a> {
-    Account(IndexOfAccount, BorrowedAccount<'a>),
+    Account(BorrowedAccount<'a>),
     Duplicate(IndexOfAccount),
 }
 
@@ -94,7 +93,6 @@ impl Serializer {
     fn write_account(
         &mut self,
         account: &mut BorrowedAccount<'_>,
-        feature_set: &FeatureSet,
     ) -> Result<u64, InstructionError> {
         let vm_data_addr = if self.copy_account_data {
             let vm_data_addr = self.vaddr.saturating_add(self.buffer.len() as u64);
@@ -103,7 +101,7 @@ impl Serializer {
         } else {
             self.push_region(true);
             let vaddr = self.vaddr;
-            self.push_account_data_region(account, feature_set)?;
+            self.push_account_data_region(account)?;
             vaddr
         };
 
@@ -123,7 +121,7 @@ impl Serializer {
                     .map_err(|_| InstructionError::InvalidArgument)?;
                 self.region_start += BPF_ALIGN_OF_U128.saturating_sub(align_offset);
                 // put the realloc padding in its own region
-                self.push_region(account.can_data_be_changed(feature_set).is_ok());
+                self.push_region(account.can_data_be_changed().is_ok());
             }
         }
 
@@ -133,13 +131,12 @@ impl Serializer {
     fn push_account_data_region(
         &mut self,
         account: &mut BorrowedAccount<'_>,
-        feature_set: &FeatureSet,
     ) -> Result<(), InstructionError> {
         if !account.get_data().is_empty() {
-            let region = match account_data_region_memory_state(account, feature_set) {
+            let region = match account_data_region_memory_state(account) {
                 MemoryState::Readable => MemoryRegion::new_readonly(account.get_data(), self.vaddr),
                 MemoryState::Writable => {
-                    MemoryRegion::new_writable(account.get_data_mut(feature_set)?, self.vaddr)
+                    MemoryRegion::new_writable(account.get_data_mut()?, self.vaddr)
                 }
                 MemoryState::Cow(index_in_transaction) => {
                     MemoryRegion::new_cow(account.get_data(), self.vaddr, index_in_transaction)
@@ -194,7 +191,6 @@ pub fn serialize_parameters(
     transaction_context: &TransactionContext,
     instruction_context: &InstructionContext,
     copy_account_data: bool,
-    feature_set: &FeatureSet,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -228,7 +224,7 @@ pub fn serialize_parameters(
                 let account = instruction_context
                     .try_borrow_instruction_account(transaction_context, instruction_account_index)
                     .unwrap();
-                SerializeAccount::Account(instruction_account_index, account)
+                SerializeAccount::Account(account)
             }
         })
         // fun fact: jemalloc is good at caching tiny allocations like this one,
@@ -243,7 +239,6 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             copy_account_data,
-            feature_set,
         )
     } else {
         serialize_parameters_aligned(
@@ -251,7 +246,6 @@ pub fn serialize_parameters(
             instruction_context.get_instruction_data(),
             &program_id,
             copy_account_data,
-            feature_set,
         )
     }
 }
@@ -262,7 +256,6 @@ pub fn deserialize_parameters(
     copy_account_data: bool,
     buffer: &[u8],
     accounts_metadata: &[SerializedAccountMetadata],
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let is_loader_deprecated = *instruction_context
         .try_borrow_last_program_account(transaction_context)?
@@ -276,7 +269,6 @@ pub fn deserialize_parameters(
             copy_account_data,
             buffer,
             account_lengths,
-            feature_set,
         )
     } else {
         deserialize_parameters_aligned(
@@ -285,7 +277,6 @@ pub fn deserialize_parameters(
             copy_account_data,
             buffer,
             account_lengths,
-            feature_set,
         )
     }
 }
@@ -295,7 +286,6 @@ fn serialize_parameters_unaligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     copy_account_data: bool,
-    feature_set: &FeatureSet,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -310,7 +300,7 @@ fn serialize_parameters_unaligned(
         size += 1; // dup
         match account {
             SerializeAccount::Duplicate(_) => {}
-            SerializeAccount::Account(_, account) => {
+            SerializeAccount::Account(account) => {
                 size += size_of::<u8>() // is_signer
                 + size_of::<u8>() // is_writable
                 + size_of::<Pubkey>() // key
@@ -339,16 +329,16 @@ fn serialize_parameters_unaligned(
                 accounts_metadata.push(accounts_metadata.get(position as usize).unwrap().clone());
                 s.write(position as u8);
             }
-            SerializeAccount::Account(_, mut account) => {
+            SerializeAccount::Account(mut account) => {
                 s.write::<u8>(NON_DUP_MARKER);
                 s.write::<u8>(account.is_signer() as u8);
                 s.write::<u8>(account.is_writable() as u8);
                 let vm_key_addr = s.write_all(account.get_key().as_ref());
                 let vm_lamports_addr = s.write::<u64>(account.get_lamports().to_le());
                 s.write::<u64>((account.get_data().len() as u64).to_le());
-                let vm_data_addr = s.write_account(&mut account, feature_set)?;
+                let vm_data_addr = s.write_account(&mut account)?;
                 let vm_owner_addr = s.write_all(account.get_owner().as_ref());
-                s.write::<u8>(account.is_executable(feature_set) as u8);
+                s.write::<u8>(account.is_executable() as u8);
                 s.write::<u64>((account.get_rent_epoch()).to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
                     original_data_len: account.get_data().len(),
@@ -374,7 +364,6 @@ pub fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
     copy_account_data: bool,
     buffer: &[u8],
     account_lengths: I,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let mut start = size_of::<u64>(); // number of accounts
     for (instruction_account_index, pre_len) in (0..instruction_context
@@ -396,7 +385,7 @@ pub fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
                     .ok_or(InstructionError::InvalidArgument)?,
             );
             if borrowed_account.get_lamports() != lamports {
-                borrowed_account.set_lamports(lamports, feature_set)?;
+                borrowed_account.set_lamports(lamports)?;
             }
             start += size_of::<u64>() // lamports
                 + size_of::<u64>(); // data length
@@ -407,9 +396,9 @@ pub fn deserialize_parameters_unaligned<I: IntoIterator<Item = usize>>(
                 // The redundant check helps to avoid the expensive data comparison if we can
                 match borrowed_account
                     .can_data_be_resized(data.len())
-                    .and_then(|_| borrowed_account.can_data_be_changed(feature_set))
+                    .and_then(|_| borrowed_account.can_data_be_changed())
                 {
-                    Ok(()) => borrowed_account.set_data_from_slice(data, feature_set)?,
+                    Ok(()) => borrowed_account.set_data_from_slice(data)?,
                     Err(err) if borrowed_account.get_data() != data => return Err(err),
                     _ => {}
                 }
@@ -428,7 +417,6 @@ fn serialize_parameters_aligned(
     instruction_data: &[u8],
     program_id: &Pubkey,
     copy_account_data: bool,
-    feature_set: &FeatureSet,
 ) -> Result<
     (
         AlignedMemory<HOST_ALIGN>,
@@ -444,7 +432,7 @@ fn serialize_parameters_aligned(
         size += 1; // dup
         match account {
             SerializeAccount::Duplicate(_) => size += 7, // padding to 64-bit aligned
-            SerializeAccount::Account(_, account) => {
+            SerializeAccount::Account(account) => {
                 let data_len = account.get_data().len();
                 size += size_of::<u8>() // is_signer
                 + size_of::<u8>() // is_writable
@@ -474,17 +462,17 @@ fn serialize_parameters_aligned(
     s.write::<u64>((accounts.len() as u64).to_le());
     for account in accounts {
         match account {
-            SerializeAccount::Account(_, mut borrowed_account) => {
+            SerializeAccount::Account(mut borrowed_account) => {
                 s.write::<u8>(NON_DUP_MARKER);
                 s.write::<u8>(borrowed_account.is_signer() as u8);
                 s.write::<u8>(borrowed_account.is_writable() as u8);
-                s.write::<u8>(borrowed_account.is_executable(feature_set) as u8);
+                s.write::<u8>(borrowed_account.is_executable() as u8);
                 s.write_all(&[0u8, 0, 0, 0]);
                 let vm_key_addr = s.write_all(borrowed_account.get_key().as_ref());
                 let vm_owner_addr = s.write_all(borrowed_account.get_owner().as_ref());
                 let vm_lamports_addr = s.write::<u64>(borrowed_account.get_lamports().to_le());
                 s.write::<u64>((borrowed_account.get_data().len() as u64).to_le());
-                let vm_data_addr = s.write_account(&mut borrowed_account, feature_set)?;
+                let vm_data_addr = s.write_account(&mut borrowed_account)?;
                 s.write::<u64>((borrowed_account.get_rent_epoch()).to_le());
                 accounts_metadata.push(SerializedAccountMetadata {
                     original_data_len: borrowed_account.get_data().len(),
@@ -515,7 +503,6 @@ pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
     copy_account_data: bool,
     buffer: &[u8],
     account_lengths: I,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let mut start = size_of::<u64>(); // number of accounts
     for (instruction_account_index, pre_len) in (0..instruction_context
@@ -545,7 +532,7 @@ pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
                     .ok_or(InstructionError::InvalidArgument)?,
             );
             if borrowed_account.get_lamports() != lamports {
-                borrowed_account.set_lamports(lamports, feature_set)?;
+                borrowed_account.set_lamports(lamports)?;
             }
             start += size_of::<u64>(); // lamports
             let post_len = LittleEndian::read_u64(
@@ -567,9 +554,9 @@ pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
                     .ok_or(InstructionError::InvalidArgument)?;
                 match borrowed_account
                     .can_data_be_resized(post_len)
-                    .and_then(|_| borrowed_account.can_data_be_changed(feature_set))
+                    .and_then(|_| borrowed_account.can_data_be_changed())
                 {
-                    Ok(()) => borrowed_account.set_data_from_slice(data, feature_set)?,
+                    Ok(()) => borrowed_account.set_data_from_slice(data)?,
                     Err(err) if borrowed_account.get_data() != data => return Err(err),
                     _ => {}
                 }
@@ -583,14 +570,14 @@ pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
                     .ok_or(InstructionError::InvalidArgument)?;
                 match borrowed_account
                     .can_data_be_resized(post_len)
-                    .and_then(|_| borrowed_account.can_data_be_changed(feature_set))
+                    .and_then(|_| borrowed_account.can_data_be_changed())
                 {
                     Ok(()) => {
-                        borrowed_account.set_data_length(post_len, feature_set)?;
+                        borrowed_account.set_data_length(post_len)?;
                         let allocated_bytes = post_len.saturating_sub(pre_len);
                         if allocated_bytes > 0 {
                             borrowed_account
-                                .get_data_mut(feature_set)?
+                                .get_data_mut()?
                                 .get_mut(pre_len..pre_len.saturating_add(allocated_bytes))
                                 .ok_or(InstructionError::InvalidArgument)?
                                 .copy_from_slice(
@@ -608,18 +595,15 @@ pub fn deserialize_parameters_aligned<I: IntoIterator<Item = usize>>(
             start += size_of::<u64>(); // rent_epoch
             if borrowed_account.get_owner().to_bytes() != owner {
                 // Change the owner at the end so that we are allowed to change the lamports and data before
-                borrowed_account.set_owner(owner, feature_set)?;
+                borrowed_account.set_owner(owner)?;
             }
         }
     }
     Ok(())
 }
 
-pub(crate) fn account_data_region_memory_state(
-    account: &BorrowedAccount<'_>,
-    feature_set: &FeatureSet,
-) -> MemoryState {
-    if account.can_data_be_changed(feature_set).is_ok() {
+pub(crate) fn account_data_region_memory_state(account: &BorrowedAccount<'_>) -> MemoryState {
+    if account.can_data_be_changed().is_ok() {
         if account.is_shared() {
             MemoryState::Cow(account.get_index_in_transaction() as u64)
         } else {
@@ -744,7 +728,6 @@ mod tests {
                     invoke_context.transaction_context,
                     instruction_context,
                     copy_account_data,
-                    &invoke_context.feature_set,
                 );
                 assert_eq!(
                     serialization_result.as_ref().err(),
@@ -899,7 +882,6 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                &invoke_context.feature_set,
             )
             .unwrap();
 
@@ -961,7 +943,6 @@ mod tests {
                 copy_account_data,
                 serialized.as_slice(),
                 &accounts_metadata,
-                &invoke_context.feature_set,
             )
             .unwrap();
             for (index_in_transaction, (_key, original_account)) in
@@ -992,7 +973,6 @@ mod tests {
                 invoke_context.transaction_context,
                 instruction_context,
                 copy_account_data,
-                &invoke_context.feature_set,
             )
             .unwrap();
             let mut serialized_regions = concat_regions(&regions);
@@ -1033,7 +1013,6 @@ mod tests {
                 copy_account_data,
                 serialized.as_slice(),
                 &account_lengths,
-                &invoke_context.feature_set,
             )
             .unwrap();
             for (index_in_transaction, (_key, original_account)) in

--- a/programs/bpf_loader/src/syscalls/cpi.rs
+++ b/programs/bpf_loader/src/syscalls/cpi.rs
@@ -8,7 +8,7 @@ use {
         memory_region::{MemoryRegion, MemoryState},
     },
     solana_sdk::{
-        feature_set::{enable_bpf_loader_set_authority_checked_ix, FeatureSet},
+        feature_set::enable_bpf_loader_set_authority_checked_ix,
         stable_layout::stable_instruction::StableInstruction,
         syscalls::{
             MAX_CPI_ACCOUNT_INFOS, MAX_CPI_INSTRUCTION_ACCOUNTS, MAX_CPI_INSTRUCTION_DATA_LEN,
@@ -883,7 +883,7 @@ where
             .transaction_context
             .get_key_of_account_at_index(instruction_account.index_in_transaction)?;
 
-        if callee_account.is_executable(&invoke_context.feature_set) {
+        if callee_account.is_executable() {
             // Use the known account
             consume_compute_meter(
                 invoke_context,
@@ -1139,7 +1139,6 @@ fn cpi_common<S: SyscallInvokeSigned>(
                     caller_account,
                     &callee_account,
                     is_loader_deprecated,
-                    &invoke_context.feature_set,
                 )?;
             }
         }
@@ -1180,7 +1179,7 @@ fn update_callee_account(
     direct_mapping: bool,
 ) -> Result<(), Error> {
     if callee_account.get_lamports() != *caller_account.lamports {
-        callee_account.set_lamports(*caller_account.lamports, &invoke_context.feature_set)?;
+        callee_account.set_lamports(*caller_account.lamports)?;
     }
 
     if direct_mapping {
@@ -1188,7 +1187,7 @@ fn update_callee_account(
         let post_len = *caller_account.ref_to_len_in_vm.get()? as usize;
         match callee_account
             .can_data_be_resized(post_len)
-            .and_then(|_| callee_account.can_data_be_changed(&invoke_context.feature_set))
+            .and_then(|_| callee_account.can_data_be_changed())
         {
             Ok(()) => {
                 let realloc_bytes_used = post_len.saturating_sub(caller_account.original_data_len);
@@ -1196,7 +1195,7 @@ fn update_callee_account(
                 if is_loader_deprecated && realloc_bytes_used > 0 {
                     return Err(InstructionError::InvalidRealloc.into());
                 }
-                callee_account.set_data_length(post_len, &invoke_context.feature_set)?;
+                callee_account.set_data_length(post_len)?;
                 if realloc_bytes_used > 0 {
                     let serialized_data = translate_slice::<u8>(
                         memory_mapping,
@@ -1207,7 +1206,7 @@ fn update_callee_account(
                         invoke_context.get_check_aligned(),
                     )?;
                     callee_account
-                        .get_data_mut(&invoke_context.feature_set)?
+                        .get_data_mut()?
                         .get_mut(caller_account.original_data_len..post_len)
                         .ok_or(SyscallError::InvalidLength)?
                         .copy_from_slice(serialized_data);
@@ -1222,10 +1221,9 @@ fn update_callee_account(
         // The redundant check helps to avoid the expensive data comparison if we can
         match callee_account
             .can_data_be_resized(caller_account.serialized_data.len())
-            .and_then(|_| callee_account.can_data_be_changed(&invoke_context.feature_set))
+            .and_then(|_| callee_account.can_data_be_changed())
         {
-            Ok(()) => callee_account
-                .set_data_from_slice(caller_account.serialized_data, &invoke_context.feature_set)?,
+            Ok(()) => callee_account.set_data_from_slice(caller_account.serialized_data)?,
             Err(err) if callee_account.get_data() != caller_account.serialized_data => {
                 return Err(Box::new(err));
             }
@@ -1235,7 +1233,7 @@ fn update_callee_account(
 
     // Change the owner at the end so that we are allowed to change the lamports and data before
     if callee_account.get_owner() != caller_account.owner {
-        callee_account.set_owner(caller_account.owner.as_ref(), &invoke_context.feature_set)?;
+        callee_account.set_owner(caller_account.owner.as_ref())?;
     }
 
     Ok(())
@@ -1246,7 +1244,6 @@ fn update_caller_account_perms(
     caller_account: &CallerAccount,
     callee_account: &BorrowedAccount<'_>,
     is_loader_deprecated: bool,
-    feature_set: &FeatureSet,
 ) -> Result<(), Error> {
     let CallerAccount {
         original_data_len,
@@ -1256,10 +1253,9 @@ fn update_caller_account_perms(
 
     let data_region = account_data_region(memory_mapping, *vm_data_addr, *original_data_len)?;
     if let Some(region) = data_region {
-        region.state.set(account_data_region_memory_state(
-            callee_account,
-            feature_set,
-        ));
+        region
+            .state
+            .set(account_data_region_memory_state(callee_account));
     }
     let realloc_region = account_realloc_region(
         memory_mapping,
@@ -1270,7 +1266,7 @@ fn update_caller_account_perms(
     if let Some(region) = realloc_region {
         region
             .state
-            .set(if callee_account.can_data_be_changed(feature_set).is_ok() {
+            .set(if callee_account.can_data_be_changed().is_ok() {
                 MemoryState::Writable
             } else {
                 MemoryState::Readable
@@ -1818,11 +1814,9 @@ mod tests {
 
         let mut callee_account = borrow_instruction_account!(invoke_context, 0);
 
+        callee_account.set_lamports(42).unwrap();
         callee_account
-            .set_lamports(42, &invoke_context.feature_set)
-            .unwrap();
-        callee_account
-            .set_owner(Pubkey::new_unique().as_ref(), &invoke_context.feature_set)
+            .set_owner(Pubkey::new_unique().as_ref())
             .unwrap();
 
         update_caller_account(
@@ -1891,9 +1885,7 @@ mod tests {
             (b"foobazbad".to_vec(), MAX_PERMITTED_DATA_INCREASE - 3),
         ] {
             assert_eq!(caller_account.serialized_data, callee_account.get_data());
-            callee_account
-                .set_data_from_slice(&new_value, &invoke_context.feature_set)
-                .unwrap();
+            callee_account.set_data_from_slice(&new_value).unwrap();
 
             update_caller_account(
                 &invoke_context,
@@ -1921,10 +1913,7 @@ mod tests {
         }
 
         callee_account
-            .set_data_length(
-                original_data_len + MAX_PERMITTED_DATA_INCREASE,
-                &invoke_context.feature_set,
-            )
+            .set_data_length(original_data_len + MAX_PERMITTED_DATA_INCREASE)
             .unwrap();
         update_caller_account(
             &invoke_context,
@@ -1940,10 +1929,7 @@ mod tests {
         assert!(is_zeroed(&data_slice[data_len..]));
 
         callee_account
-            .set_data_length(
-                original_data_len + MAX_PERMITTED_DATA_INCREASE + 1,
-                &invoke_context.feature_set,
-            )
+            .set_data_length(original_data_len + MAX_PERMITTED_DATA_INCREASE + 1)
             .unwrap();
         assert_matches!(
             update_caller_account(
@@ -1958,11 +1944,9 @@ mod tests {
         );
 
         // close the account
+        callee_account.set_data_length(0).unwrap();
         callee_account
-            .set_data_length(0, &invoke_context.feature_set)
-            .unwrap();
-        callee_account
-            .set_owner(system_program::id().as_ref(), &invoke_context.feature_set)
+            .set_owner(system_program::id().as_ref())
             .unwrap();
         update_caller_account(
             &invoke_context,
@@ -2031,13 +2015,9 @@ mod tests {
                 (vec![], 0),          // check lower bound
             ] {
                 if change_ptr {
-                    callee_account
-                        .set_data(new_value, &invoke_context.feature_set)
-                        .unwrap();
+                    callee_account.set_data(new_value).unwrap();
                 } else {
-                    callee_account
-                        .set_data_from_slice(&new_value, &invoke_context.feature_set)
-                        .unwrap();
+                    callee_account.set_data_from_slice(&new_value).unwrap();
                 }
 
                 update_caller_account(
@@ -2107,10 +2087,7 @@ mod tests {
         }
 
         callee_account
-            .set_data_length(
-                original_data_len + MAX_PERMITTED_DATA_INCREASE,
-                &invoke_context.feature_set,
-            )
+            .set_data_length(original_data_len + MAX_PERMITTED_DATA_INCREASE)
             .unwrap();
         update_caller_account(
             &invoke_context,
@@ -2128,10 +2105,7 @@ mod tests {
         );
 
         callee_account
-            .set_data_length(
-                original_data_len + MAX_PERMITTED_DATA_INCREASE + 1,
-                &invoke_context.feature_set,
-            )
+            .set_data_length(original_data_len + MAX_PERMITTED_DATA_INCREASE + 1)
             .unwrap();
         assert_matches!(
             update_caller_account(
@@ -2146,11 +2120,9 @@ mod tests {
         );
 
         // close the account
+        callee_account.set_data_length(0).unwrap();
         callee_account
-            .set_data_length(0, &invoke_context.feature_set)
-            .unwrap();
-        callee_account
-            .set_owner(system_program::id().as_ref(), &invoke_context.feature_set)
+            .set_owner(system_program::id().as_ref())
             .unwrap();
         update_caller_account(
             &invoke_context,
@@ -2493,9 +2465,7 @@ mod tests {
         // this is done when a writable account is mapped, and it ensures
         // through make_data_mut() that the account is made writable and resized
         // with enough padding to hold the realloc padding
-        callee_account
-            .get_data_mut(&invoke_context.feature_set)
-            .unwrap();
+        callee_account.get_data_mut().unwrap();
 
         let serialized_data = translate_slice_mut::<u8>(
             &memory_mapping,

--- a/programs/config/src/config_processor.rs
+++ b/programs/config/src/config_processor.rs
@@ -127,7 +127,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         ic_msg!(invoke_context, "instruction data too large");
         return Err(InstructionError::InvalidInstructionData);
     }
-    config_account.get_data_mut(&invoke_context.feature_set)?[..data.len()].copy_from_slice(data);
+    config_account.get_data_mut()?[..data.len()].copy_from_slice(data);
     Ok(())
 });
 

--- a/programs/sbf/benches/bpf_loader.rs
+++ b/programs/sbf/benches/bpf_loader.rs
@@ -258,7 +258,6 @@ fn bench_create_vm(bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data,
-        &invoke_context.feature_set,
     )
     .unwrap();
 
@@ -293,7 +292,6 @@ fn bench_instruction_count_tuner(_bencher: &mut Bencher) {
             .get_current_instruction_context()
             .unwrap(),
         !direct_mapping, // copy_account_data
-        &invoke_context.feature_set,
     )
     .unwrap();
 

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -1907,7 +1907,7 @@ fn test_program_sbf_invoke_in_same_tx_as_deployment() {
             let (result, _, _) = process_transaction_and_record_inner(&bank, tx);
             assert_eq!(
                 result.unwrap_err(),
-                TransactionError::InstructionError(2, InstructionError::InvalidAccountData),
+                TransactionError::InstructionError(2, InstructionError::AccountNotExecutable),
             );
         }
     }

--- a/programs/stake/src/stake_instruction.rs
+++ b/programs/stake/src/stake_instruction.rs
@@ -73,13 +73,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         Ok(StakeInstruction::Initialize(authorized, lockup)) => {
             let mut me = get_stake_account()?;
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
-            initialize(
-                &mut me,
-                &authorized,
-                &lockup,
-                &rent,
-                &invoke_context.feature_set,
-            )
+            initialize(&mut me, &authorized, &lockup, &rent)
         }
         Ok(StakeInstruction::Authorize(authorized_pubkey, stake_authorize)) => {
             let mut me = get_stake_account()?;
@@ -96,7 +90,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 stake_authorize,
                 &clock,
                 custodian_pubkey,
-                &invoke_context.feature_set,
             )
         }
         Ok(StakeInstruction::AuthorizeWithSeed(args)) => {
@@ -118,7 +111,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 args.stake_authorize,
                 &clock,
                 custodian_pubkey,
-                &invoke_context.feature_set,
             )
         }
         Ok(StakeInstruction::DelegateStake) => {
@@ -221,7 +213,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                     None
                 },
                 new_warmup_cooldown_rate_epoch(invoke_context),
-                &invoke_context.feature_set,
             )
         }
         Ok(StakeInstruction::Deactivate) => {
@@ -233,13 +224,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
         Ok(StakeInstruction::SetLockup(lockup)) => {
             let mut me = get_stake_account()?;
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
-            set_lockup(
-                &mut me,
-                &lockup,
-                &signers,
-                &clock,
-                &invoke_context.feature_set,
-            )
+            set_lockup(&mut me, &lockup, &signers, &clock)
         }
         Ok(StakeInstruction::InitializeChecked) => {
             let mut me = get_stake_account()?;
@@ -260,13 +245,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             };
 
             let rent = get_sysvar_with_account_check::rent(invoke_context, instruction_context, 1)?;
-            initialize(
-                &mut me,
-                &authorized,
-                &Lockup::default(),
-                &rent,
-                &invoke_context.feature_set,
-            )
+            initialize(&mut me, &authorized, &Lockup::default(), &rent)
         }
         Ok(StakeInstruction::AuthorizeChecked(stake_authorize)) => {
             let mut me = get_stake_account()?;
@@ -289,7 +268,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 stake_authorize,
                 &clock,
                 custodian_pubkey,
-                &invoke_context.feature_set,
             )
         }
         Ok(StakeInstruction::AuthorizeCheckedWithSeed(args)) => {
@@ -318,7 +296,6 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 args.stake_authorize,
                 &clock,
                 custodian_pubkey,
-                &invoke_context.feature_set,
             )
         }
         Ok(StakeInstruction::SetLockupChecked(lockup_checked)) => {
@@ -332,13 +309,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
                 custodian: custodian_pubkey.cloned(),
             };
             let clock = invoke_context.get_sysvar_cache().get_clock()?;
-            set_lockup(
-                &mut me,
-                &lockup,
-                &signers,
-                &clock,
-                &invoke_context.feature_set,
-            )
+            set_lockup(&mut me, &lockup, &signers, &clock)
         }
         Ok(StakeInstruction::GetMinimumDelegation) => {
             let feature_set = invoke_context.feature_set.as_ref();

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -478,7 +478,6 @@ pub fn initialize(
     authorized: &Authorized,
     lockup: &Lockup,
     rent: &Rent,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     if stake_account.get_data().len() != StakeStateV2::size_of() {
         return Err(InstructionError::InvalidAccountData);
@@ -487,14 +486,11 @@ pub fn initialize(
     if let StakeStateV2::Uninitialized = stake_account.get_state()? {
         let rent_exempt_reserve = rent.minimum_balance(stake_account.get_data().len());
         if stake_account.get_lamports() >= rent_exempt_reserve {
-            stake_account.set_state(
-                &StakeStateV2::Initialized(Meta {
-                    rent_exempt_reserve,
-                    authorized: *authorized,
-                    lockup: *lockup,
-                }),
-                feature_set,
-            )
+            stake_account.set_state(&StakeStateV2::Initialized(Meta {
+                rent_exempt_reserve,
+                authorized: *authorized,
+                lockup: *lockup,
+            }))
         } else {
             Err(InstructionError::InsufficientFunds)
         }
@@ -513,7 +509,6 @@ pub fn authorize(
     stake_authorize: StakeAuthorize,
     clock: &Clock,
     custodian: Option<&Pubkey>,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     match stake_account.get_state()? {
         StakeStateV2::Stake(mut meta, stake, stake_flags) => {
@@ -523,7 +518,7 @@ pub fn authorize(
                 stake_authorize,
                 Some((&meta.lockup, clock, custodian)),
             )?;
-            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags), feature_set)
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
         }
         StakeStateV2::Initialized(mut meta) => {
             meta.authorized.authorize(
@@ -532,7 +527,7 @@ pub fn authorize(
                 stake_authorize,
                 Some((&meta.lockup, clock, custodian)),
             )?;
-            stake_account.set_state(&StakeStateV2::Initialized(meta), feature_set)
+            stake_account.set_state(&StakeStateV2::Initialized(meta))
         }
         _ => Err(InstructionError::InvalidAccountData),
     }
@@ -550,7 +545,6 @@ pub fn authorize_with_seed(
     stake_authorize: StakeAuthorize,
     clock: &Clock,
     custodian: Option<&Pubkey>,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let mut signers = HashSet::default();
     if instruction_context.is_instruction_account_signer(authority_base_index)? {
@@ -571,7 +565,6 @@ pub fn authorize_with_seed(
         stake_authorize,
         clock,
         custodian,
-        feature_set,
     )
 }
 
@@ -609,10 +602,7 @@ pub fn delegate(
                 &vote_state?.convert_to_current(),
                 clock.epoch,
             );
-            stake_account.set_state(
-                &StakeStateV2::Stake(meta, stake, StakeFlags::empty()),
-                feature_set,
-            )
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, StakeFlags::empty()))
         }
         StakeStateV2::Stake(meta, mut stake, stake_flags) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
@@ -627,7 +617,7 @@ pub fn delegate(
                 clock,
                 stake_history,
             )?;
-            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags), feature_set)
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
         }
         _ => Err(InstructionError::InvalidAccountData),
     }
@@ -683,10 +673,7 @@ pub fn deactivate(
     if let StakeStateV2::Stake(meta, mut stake, mut stake_flags) = stake_account.get_state()? {
         meta.authorized.check(signers, StakeAuthorize::Staker)?;
         deactivate_stake(invoke_context, &mut stake, &mut stake_flags, clock.epoch)?;
-        stake_account.set_state(
-            &StakeStateV2::Stake(meta, stake, stake_flags),
-            &invoke_context.feature_set,
-        )
+        stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
     } else {
         Err(InstructionError::InvalidAccountData)
     }
@@ -697,16 +684,15 @@ pub fn set_lockup(
     lockup: &LockupArgs,
     signers: &HashSet<Pubkey>,
     clock: &Clock,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     match stake_account.get_state()? {
         StakeStateV2::Initialized(mut meta) => {
             meta.set_lockup(lockup, signers, clock)?;
-            stake_account.set_state(&StakeStateV2::Initialized(meta), feature_set)
+            stake_account.set_state(&StakeStateV2::Initialized(meta))
         }
         StakeStateV2::Stake(mut meta, stake, stake_flags) => {
             meta.set_lockup(lockup, signers, clock)?;
-            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags), feature_set)
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
         }
         _ => Err(InstructionError::InvalidAccountData),
     }
@@ -815,17 +801,11 @@ pub fn split(
 
             let mut stake_account = instruction_context
                 .try_borrow_instruction_account(transaction_context, stake_account_index)?;
-            stake_account.set_state(
-                &StakeStateV2::Stake(meta, stake, stake_flags),
-                &invoke_context.feature_set,
-            )?;
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))?;
             drop(stake_account);
             let mut split = instruction_context
                 .try_borrow_instruction_account(transaction_context, split_index)?;
-            split.set_state(
-                &StakeStateV2::Stake(split_meta, split_stake, stake_flags),
-                &invoke_context.feature_set,
-            )?;
+            split.set_state(&StakeStateV2::Stake(split_meta, split_stake, stake_flags))?;
         }
         StakeStateV2::Initialized(meta) => {
             meta.authorized.check(signers, StakeAuthorize::Staker)?;
@@ -844,10 +824,7 @@ pub fn split(
             split_meta.rent_exempt_reserve = validated_split_info.destination_rent_exempt_reserve;
             let mut split = instruction_context
                 .try_borrow_instruction_account(transaction_context, split_index)?;
-            split.set_state(
-                &StakeStateV2::Initialized(split_meta),
-                &invoke_context.feature_set,
-            )?;
+            split.set_state(&StakeStateV2::Initialized(split_meta))?;
         }
         StakeStateV2::Uninitialized => {
             let stake_pubkey = transaction_context.get_key_of_account_at_index(
@@ -865,17 +842,17 @@ pub fn split(
     let mut stake_account = instruction_context
         .try_borrow_instruction_account(transaction_context, stake_account_index)?;
     if lamports == stake_account.get_lamports() {
-        stake_account.set_state(&StakeStateV2::Uninitialized, &invoke_context.feature_set)?;
+        stake_account.set_state(&StakeStateV2::Uninitialized)?;
     }
     drop(stake_account);
 
     let mut split =
         instruction_context.try_borrow_instruction_account(transaction_context, split_index)?;
-    split.checked_add_lamports(lamports, &invoke_context.feature_set)?;
+    split.checked_add_lamports(lamports)?;
     drop(split);
     let mut stake_account = instruction_context
         .try_borrow_instruction_account(transaction_context, stake_account_index)?;
-    stake_account.checked_sub_lamports(lamports, &invoke_context.feature_set)?;
+    stake_account.checked_sub_lamports(lamports)?;
     Ok(())
 }
 
@@ -931,16 +908,16 @@ pub fn merge(
 
     ic_msg!(invoke_context, "Merging stake accounts");
     if let Some(merged_state) = stake_merge_kind.merge(invoke_context, source_merge_kind, clock)? {
-        stake_account.set_state(&merged_state, &invoke_context.feature_set)?;
+        stake_account.set_state(&merged_state)?;
     }
 
     // Source is about to be drained, deinitialize its state
-    source_account.set_state(&StakeStateV2::Uninitialized, &invoke_context.feature_set)?;
+    source_account.set_state(&StakeStateV2::Uninitialized)?;
 
     // Drain the source stake account
     let lamports = source_account.get_lamports();
-    source_account.checked_sub_lamports(lamports, &invoke_context.feature_set)?;
-    stake_account.checked_add_lamports(lamports, &invoke_context.feature_set)?;
+    source_account.checked_sub_lamports(lamports)?;
+    stake_account.checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -1032,9 +1009,8 @@ pub fn redelegate(
     deactivate(invoke_context, stake_account, &clock, signers)?;
 
     // transfer the effective stake to the uninitialized stake account
-    stake_account.checked_sub_lamports(effective_stake, &invoke_context.feature_set)?;
-    uninitialized_stake_account
-        .checked_add_lamports(effective_stake, &invoke_context.feature_set)?;
+    stake_account.checked_sub_lamports(effective_stake)?;
+    uninitialized_stake_account.checked_add_lamports(effective_stake)?;
 
     // initialize and schedule `uninitialized_stake_account` for activation
     let sysvar_cache = invoke_context.get_sysvar_cache();
@@ -1048,19 +1024,16 @@ pub fn redelegate(
         &uninitialized_stake_meta,
         &invoke_context.feature_set,
     )?;
-    uninitialized_stake_account.set_state(
-        &StakeStateV2::Stake(
-            uninitialized_stake_meta,
-            new_stake(
-                stake_amount,
-                &vote_pubkey,
-                &vote_state.convert_to_current(),
-                clock.epoch,
-            ),
-            StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED,
+    uninitialized_stake_account.set_state(&StakeStateV2::Stake(
+        uninitialized_stake_meta,
+        new_stake(
+            stake_amount,
+            &vote_pubkey,
+            &vote_state.convert_to_current(),
+            clock.epoch,
         ),
-        &invoke_context.feature_set,
-    )?;
+        StakeFlags::MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED,
+    ))?;
 
     Ok(())
 }
@@ -1077,7 +1050,6 @@ pub fn withdraw(
     withdraw_authority_index: IndexOfAccount,
     custodian_index: Option<IndexOfAccount>,
     new_rate_activation_epoch: Option<Epoch>,
-    feature_set: &FeatureSet,
 ) -> Result<(), InstructionError> {
     let withdraw_authority_pubkey = transaction_context.get_key_of_account_at_index(
         instruction_context
@@ -1162,14 +1134,14 @@ pub fn withdraw(
 
     // Deinitialize state upon zero balance
     if lamports == stake_account.get_lamports() {
-        stake_account.set_state(&StakeStateV2::Uninitialized, feature_set)?;
+        stake_account.set_state(&StakeStateV2::Uninitialized)?;
     }
 
-    stake_account.checked_sub_lamports(lamports, feature_set)?;
+    stake_account.checked_sub_lamports(lamports)?;
     drop(stake_account);
     let mut to =
         instruction_context.try_borrow_instruction_account(transaction_context, to_index)?;
-    to.checked_add_lamports(lamports, feature_set)?;
+    to.checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -1217,10 +1189,7 @@ pub(crate) fn deactivate_delinquent(
         // voted in the last `MINIMUM_DELINQUENT_EPOCHS_FOR_DEACTIVATION`
         if eligible_for_deactivate_delinquent(&delinquent_vote_state.epoch_credits, current_epoch) {
             deactivate_stake(invoke_context, &mut stake, &mut stake_flags, current_epoch)?;
-            stake_account.set_state(
-                &StakeStateV2::Stake(meta, stake, stake_flags),
-                &invoke_context.feature_set,
-            )
+            stake_account.set_state(&StakeStateV2::Stake(meta, stake, stake_flags))
         } else {
             Err(StakeError::MinimumDelinquentEpochsForDeactivationNotMet.into())
         }

--- a/programs/system/src/system_processor.rs
+++ b/programs/system/src/system_processor.rs
@@ -104,7 +104,7 @@ fn allocate(
         return Err(SystemError::InvalidAccountDataLength.into());
     }
 
-    account.set_data_length(space as usize, &invoke_context.feature_set)?;
+    account.set_data_length(space as usize)?;
 
     Ok(())
 }
@@ -126,7 +126,7 @@ fn assign(
         return Err(InstructionError::MissingRequiredSignature);
     }
 
-    account.set_owner(&owner.to_bytes(), &invoke_context.feature_set)
+    account.set_owner(&owner.to_bytes())
 }
 
 fn allocate_and_assign(
@@ -203,11 +203,11 @@ fn transfer_verified(
         return Err(SystemError::ResultWithNegativeLamports.into());
     }
 
-    from.checked_sub_lamports(lamports, &invoke_context.feature_set)?;
+    from.checked_sub_lamports(lamports)?;
     drop(from);
     let mut to = instruction_context
         .try_borrow_instruction_account(transaction_context, to_account_index)?;
-    to.checked_add_lamports(lamports, &invoke_context.feature_set)?;
+    to.checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -481,9 +481,7 @@ declare_process_instruction!(Entrypoint, DEFAULT_COMPUTE_UNITS, |invoke_context|
             let nonce_versions: nonce::state::Versions = nonce_account.get_state()?;
             match nonce_versions.upgrade() {
                 None => Err(InstructionError::InvalidArgument),
-                Some(nonce_versions) => {
-                    nonce_account.set_state(&nonce_versions, &invoke_context.feature_set)
-                }
+                Some(nonce_versions) => nonce_account.set_state(&nonce_versions),
             }
         }
         SystemInstruction::Allocate { space } => {

--- a/programs/vote/src/vote_state/mod.rs
+++ b/programs/vote/src/vote_state/mod.rs
@@ -156,24 +156,22 @@ fn set_vote_account_state(
             && (!vote_account
                 .is_rent_exempt_at_data_length(VoteStateVersions::vote_state_size_of(true))
                 || vote_account
-                    .set_data_length(VoteStateVersions::vote_state_size_of(true), feature_set)
+                    .set_data_length(VoteStateVersions::vote_state_size_of(true))
                     .is_err())
         {
             // Account cannot be resized to the size of a vote state as it will not be rent exempt, or failed to be
             // resized for other reasons.  So store the V1_14_11 version.
-            return vote_account.set_state(
-                &VoteStateVersions::V1_14_11(Box::new(VoteState1_14_11::from(vote_state))),
-                feature_set,
-            );
+            return vote_account.set_state(&VoteStateVersions::V1_14_11(Box::new(
+                VoteState1_14_11::from(vote_state),
+            )));
         }
         // Vote account is large enough to store the newest version of vote state
-        vote_account.set_state(&VoteStateVersions::new_current(vote_state), feature_set)
+        vote_account.set_state(&VoteStateVersions::new_current(vote_state))
     // Else when the vote_state_add_vote_latency feature is not enabled, then the V1_14_11 version is stored
     } else {
-        vote_account.set_state(
-            &VoteStateVersions::V1_14_11(Box::new(VoteState1_14_11::from(vote_state))),
-            feature_set,
-        )
+        vote_account.set_state(&VoteStateVersions::V1_14_11(Box::new(
+            VoteState1_14_11::from(vote_state),
+        )))
     }
 }
 
@@ -1002,11 +1000,11 @@ pub fn withdraw<S: std::hash::BuildHasher>(
         }
     }
 
-    vote_account.checked_sub_lamports(lamports, feature_set)?;
+    vote_account.checked_sub_lamports(lamports)?;
     drop(vote_account);
     let mut to_account = instruction_context
         .try_borrow_instruction_account(transaction_context, to_account_index)?;
-    to_account.checked_add_lamports(lamports, feature_set)?;
+    to_account.checked_add_lamports(lamports)?;
     Ok(())
 }
 
@@ -1341,7 +1339,7 @@ mod tests {
         // Test that when the feature is enabled, if the vote account does have sufficient lamports, the
         // new vote state is written out
         assert_eq!(
-            borrowed_account.set_lamports(rent.minimum_balance(VoteState::size_of()), &feature_set),
+            borrowed_account.set_lamports(rent.minimum_balance(VoteState::size_of())),
             Ok(())
         );
         assert_eq!(

--- a/programs/zk-token-proof/src/lib.rs
+++ b/programs/zk-token-proof/src/lib.rs
@@ -130,8 +130,7 @@ where
             return Err(InstructionError::InvalidAccountData);
         }
 
-        proof_context_account
-            .set_data_from_slice(&context_state_data, &invoke_context.feature_set)?;
+        proof_context_account.set_data_from_slice(&context_state_data)?;
     }
 
     Ok(())
@@ -173,13 +172,10 @@ fn process_close_proof_context(invoke_context: &mut InvokeContext) -> Result<(),
 
     let mut destination_account =
         instruction_context.try_borrow_instruction_account(transaction_context, 1)?;
-    destination_account.checked_add_lamports(
-        proof_context_account.get_lamports(),
-        &invoke_context.feature_set,
-    )?;
-    proof_context_account.set_lamports(0, &invoke_context.feature_set)?;
-    proof_context_account.set_data_length(0, &invoke_context.feature_set)?;
-    proof_context_account.set_owner(system_program::id().as_ref(), &invoke_context.feature_set)?;
+    destination_account.checked_add_lamports(proof_context_account.get_lamports())?;
+    proof_context_account.set_lamports(0)?;
+    proof_context_account.set_data_length(0)?;
+    proof_context_account.set_owner(system_program::id().as_ref())?;
 
     Ok(())
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1085,10 +1085,10 @@ fn test_rent_complex() {
                 MockInstruction::Deduction => {
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 1)?
-                        .checked_add_lamports(1, &invoke_context.feature_set)?;
+                        .checked_add_lamports(1)?;
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 2)?
-                        .checked_sub_lamports(1, &invoke_context.feature_set)?;
+                        .checked_sub_lamports(1)?;
                     Ok(())
                 }
             }
@@ -6015,16 +6015,16 @@ fn test_transaction_with_duplicate_accounts_in_instruction() {
         let lamports = u64::from_le_bytes(instruction_data.try_into().unwrap());
         instruction_context
             .try_borrow_instruction_account(transaction_context, 2)?
-            .checked_sub_lamports(lamports, &invoke_context.feature_set)?;
+            .checked_sub_lamports(lamports)?;
         instruction_context
             .try_borrow_instruction_account(transaction_context, 1)?
-            .checked_add_lamports(lamports, &invoke_context.feature_set)?;
+            .checked_add_lamports(lamports)?;
         instruction_context
             .try_borrow_instruction_account(transaction_context, 0)?
-            .checked_sub_lamports(lamports, &invoke_context.feature_set)?;
+            .checked_sub_lamports(lamports)?;
         instruction_context
             .try_borrow_instruction_account(transaction_context, 1)?
-            .checked_add_lamports(lamports, &invoke_context.feature_set)?;
+            .checked_add_lamports(lamports)?;
         Ok(())
     });
 
@@ -6528,7 +6528,7 @@ fn test_same_program_id_uses_unique_executable_accounts() {
         let instruction_context = transaction_context.get_current_instruction_context()?;
         instruction_context
             .try_borrow_program_account(transaction_context, 0)?
-            .set_data_length(2, &invoke_context.feature_set)
+            .set_data_length(2)
     });
 
     let (genesis_config, mint_keypair) = create_genesis_config(50000);
@@ -9495,7 +9495,7 @@ fn test_transfer_sysvar() {
         let instruction_context = transaction_context.get_current_instruction_context()?;
         instruction_context
             .try_borrow_instruction_account(transaction_context, 1)?
-            .set_data(vec![0; 40], &invoke_context.feature_set)?;
+            .set_data(vec![0; 40])?;
         Ok(())
     });
 
@@ -10346,10 +10346,10 @@ declare_process_instruction!(MockTransferBuiltin, 1, |invoke_context| {
             MockTransferInstruction::Transfer(amount) => {
                 instruction_context
                     .try_borrow_instruction_account(transaction_context, 1)?
-                    .checked_sub_lamports(amount, &invoke_context.feature_set)?;
+                    .checked_sub_lamports(amount)?;
                 instruction_context
                     .try_borrow_instruction_account(transaction_context, 2)?
-                    .checked_add_lamports(amount, &invoke_context.feature_set)?;
+                    .checked_add_lamports(amount)?;
                 Ok(())
             }
         }
@@ -11060,7 +11060,7 @@ declare_process_instruction!(MockReallocBuiltin, 1, |invoke_context| {
                 // Set data length
                 instruction_context
                     .try_borrow_instruction_account(transaction_context, 1)?
-                    .set_data_length(new_size, &invoke_context.feature_set)?;
+                    .set_data_length(new_size)?;
 
                 // set balance
                 let current_balance = instruction_context
@@ -11071,17 +11071,17 @@ declare_process_instruction!(MockReallocBuiltin, 1, |invoke_context| {
                 if diff_balance.is_positive() {
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .checked_sub_lamports(amount, &invoke_context.feature_set)?;
+                        .checked_sub_lamports(amount)?;
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 1)?
-                        .set_lamports(new_balance, &invoke_context.feature_set)?;
+                        .set_lamports(new_balance)?;
                 } else {
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 0)?
-                        .checked_add_lamports(amount, &invoke_context.feature_set)?;
+                        .checked_add_lamports(amount)?;
                     instruction_context
                         .try_borrow_instruction_account(transaction_context, 1)?
-                        .set_lamports(new_balance, &invoke_context.feature_set)?;
+                        .set_lamports(new_balance)?;
                 }
                 Ok(())
             }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7287,7 +7287,8 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
     );
     assert_eq!(bank.get_balance(&buffer_address), 0);
     assert_eq!(None, bank.get_account(&buffer_address));
-    let post_program_account = bank.get_account(&program_keypair.pubkey()).unwrap();
+    let mut post_program_account = bank.get_account(&program_keypair.pubkey()).unwrap();
+    post_program_account.set_executable(true);
     assert_eq!(post_program_account.lamports(), min_program_balance);
     assert_eq!(post_program_account.owner(), &bpf_loader_upgradeable::id());
     assert_eq!(

--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -40,9 +40,6 @@ pub struct Account {
     /// the program that owns this account. If executable, the program that loads this account.
     pub owner: Pubkey,
     /// this account's data contains a loaded program (and is now read-only)
-    ///
-    /// When feature `deprecate_executable_meta_update_in_bpf_loader` is active,
-    /// `executable` is deprecated, please use `fn is_executable(&account)` instead.
     pub executable: bool,
     /// the epoch at which this account will next owe rent
     pub rent_epoch: Epoch,

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -17,7 +17,7 @@ use {
 };
 use {
     crate::{
-        account::{is_builtin, is_executable, AccountSharedData, ReadableAccount},
+        account::{AccountSharedData, ReadableAccount},
         feature_set::FeatureSet,
         instruction::InstructionError,
         pubkey::Pubkey,
@@ -1040,8 +1040,8 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns whether this account is executable (transaction wide)
     #[inline]
-    pub fn is_executable(&self, feature_set: &FeatureSet) -> bool {
-        is_builtin(&*self.account) || is_executable(&*self.account, feature_set)
+    pub fn is_executable(&self, _feature_set: &FeatureSet) -> bool {
+        self.account.executable()
     }
 
     /// Configures whether this account is executable (transaction wide)

--- a/sdk/src/transaction_context.rs
+++ b/sdk/src/transaction_context.rs
@@ -18,7 +18,6 @@ use {
 use {
     crate::{
         account::{AccountSharedData, ReadableAccount},
-        feature_set::FeatureSet,
         instruction::InstructionError,
         pubkey::Pubkey,
     },
@@ -740,11 +739,7 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Assignes the owner of this account (transaction wide)
     #[cfg(not(target_os = "solana"))]
-    pub fn set_owner(
-        &mut self,
-        pubkey: &[u8],
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn set_owner(&mut self, pubkey: &[u8]) -> Result<(), InstructionError> {
         // Only the owner can assign a new owner
         if !self.is_owned_by_current_program() {
             return Err(InstructionError::ModifiedProgramId);
@@ -754,7 +749,7 @@ impl<'a> BorrowedAccount<'a> {
             return Err(InstructionError::ModifiedProgramId);
         }
         // and only if the account is not executable
-        if self.is_executable(feature_set) {
+        if self.is_executable() {
             return Err(InstructionError::ModifiedProgramId);
         }
         // and only if the data is zero-initialized or empty
@@ -778,11 +773,7 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Overwrites the number of lamports of this account (transaction wide)
     #[cfg(not(target_os = "solana"))]
-    pub fn set_lamports(
-        &mut self,
-        lamports: u64,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn set_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
         // An account not owned by the program cannot have its balance decrease
         if !self.is_owned_by_current_program() && lamports < self.get_lamports() {
             return Err(InstructionError::ExternalAccountLamportSpend);
@@ -792,7 +783,7 @@ impl<'a> BorrowedAccount<'a> {
             return Err(InstructionError::ReadonlyLamportChange);
         }
         // The balance of executable accounts may not change
-        if self.is_executable(feature_set) {
+        if self.is_executable() {
             return Err(InstructionError::ExecutableLamportChange);
         }
         // don't touch the account if the lamports do not change
@@ -806,31 +797,21 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Adds lamports to this account (transaction wide)
     #[cfg(not(target_os = "solana"))]
-    pub fn checked_add_lamports(
-        &mut self,
-        lamports: u64,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn checked_add_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
         self.set_lamports(
             self.get_lamports()
                 .checked_add(lamports)
                 .ok_or(InstructionError::ArithmeticOverflow)?,
-            feature_set,
         )
     }
 
     /// Subtracts lamports from this account (transaction wide)
     #[cfg(not(target_os = "solana"))]
-    pub fn checked_sub_lamports(
-        &mut self,
-        lamports: u64,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn checked_sub_lamports(&mut self, lamports: u64) -> Result<(), InstructionError> {
         self.set_lamports(
             self.get_lamports()
                 .checked_sub(lamports)
                 .ok_or(InstructionError::ArithmeticOverflow)?,
-            feature_set,
         )
     }
 
@@ -842,11 +823,8 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns a writable slice of the account data (transaction wide)
     #[cfg(not(target_os = "solana"))]
-    pub fn get_data_mut(
-        &mut self,
-        feature_set: &FeatureSet,
-    ) -> Result<&mut [u8], InstructionError> {
-        self.can_data_be_changed(feature_set)?;
+    pub fn get_data_mut(&mut self) -> Result<&mut [u8], InstructionError> {
+        self.can_data_be_changed()?;
         self.touch()?;
         self.make_data_mut();
         Ok(self.account.data_as_mut_slice())
@@ -871,13 +849,9 @@ impl<'a> BorrowedAccount<'a> {
         not(target_os = "solana"),
         any(test, feature = "dev-context-only-utils")
     ))]
-    pub fn set_data(
-        &mut self,
-        data: Vec<u8>,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn set_data(&mut self, data: Vec<u8>) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;
-        self.can_data_be_changed(feature_set)?;
+        self.can_data_be_changed()?;
         self.touch()?;
 
         self.update_accounts_resize_delta(data.len())?;
@@ -890,13 +864,9 @@ impl<'a> BorrowedAccount<'a> {
     /// Call this when you have a slice of data you do not own and want to
     /// replace the account data with it.
     #[cfg(not(target_os = "solana"))]
-    pub fn set_data_from_slice(
-        &mut self,
-        data: &[u8],
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn set_data_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         self.can_data_be_resized(data.len())?;
-        self.can_data_be_changed(feature_set)?;
+        self.can_data_be_changed()?;
         self.touch()?;
         self.update_accounts_resize_delta(data.len())?;
         // Calling make_data_mut() here guarantees that set_data_from_slice()
@@ -915,13 +885,9 @@ impl<'a> BorrowedAccount<'a> {
     ///
     /// Fills it with zeros at the end if is extended or truncates at the end otherwise.
     #[cfg(not(target_os = "solana"))]
-    pub fn set_data_length(
-        &mut self,
-        new_length: usize,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn set_data_length(&mut self, new_length: usize) -> Result<(), InstructionError> {
         self.can_data_be_resized(new_length)?;
-        self.can_data_be_changed(feature_set)?;
+        self.can_data_be_changed()?;
         // don't touch the account if the length does not change
         if self.get_data().len() == new_length {
             return Ok(());
@@ -934,14 +900,10 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Appends all elements in a slice to the account
     #[cfg(not(target_os = "solana"))]
-    pub fn extend_from_slice(
-        &mut self,
-        data: &[u8],
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
+    pub fn extend_from_slice(&mut self, data: &[u8]) -> Result<(), InstructionError> {
         let new_len = self.get_data().len().saturating_add(data.len());
         self.can_data_be_resized(new_len)?;
-        self.can_data_be_changed(feature_set)?;
+        self.can_data_be_changed()?;
 
         if data.is_empty() {
             return Ok(());
@@ -1014,12 +976,8 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Serializes a state into the account data
     #[cfg(not(target_os = "solana"))]
-    pub fn set_state<T: serde::Serialize>(
-        &mut self,
-        state: &T,
-        feature_set: &FeatureSet,
-    ) -> Result<(), InstructionError> {
-        let data = self.get_data_mut(feature_set)?;
+    pub fn set_state<T: serde::Serialize>(&mut self, state: &T) -> Result<(), InstructionError> {
+        let data = self.get_data_mut()?;
         let serialized_size =
             bincode::serialized_size(state).map_err(|_| InstructionError::GenericError)?;
         if serialized_size > data.len() as u64 {
@@ -1040,7 +998,7 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns whether this account is executable (transaction wide)
     #[inline]
-    pub fn is_executable(&self, _feature_set: &FeatureSet) -> bool {
+    pub fn is_executable(&self) -> bool {
         self.account.executable()
     }
 
@@ -1119,9 +1077,9 @@ impl<'a> BorrowedAccount<'a> {
 
     /// Returns an error if the account data can not be mutated by the current program
     #[cfg(not(target_os = "solana"))]
-    pub fn can_data_be_changed(&self, feature_set: &FeatureSet) -> Result<(), InstructionError> {
+    pub fn can_data_be_changed(&self) -> Result<(), InstructionError> {
         // Only non-executable accounts data can be changed
-        if self.is_executable(feature_set) {
+        if self.is_executable() {
             return Err(InstructionError::ExecutableDataModified);
         }
         // and only if the account is writable

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -250,6 +250,9 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 rent_debits.insert(key, rent, account.lamports());
 
                 account
+                    .set_executable(is_builtin(&account) || is_executable(&account, &feature_set));
+
+                account
             };
 
             accounts_found.push(account_found);
@@ -289,7 +292,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 return Err(TransactionError::ProgramAccountNotFound);
             }
 
-            if !(is_builtin(program_account) || is_executable(program_account, &feature_set)) {
+            if !program_account.executable() {
                 error_counters.invalid_program_for_execution += 1;
                 return Err(TransactionError::InvalidProgramForExecution);
             }
@@ -309,8 +312,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                 let owner_index = accounts.len();
                 if let Some(owner_account) = callbacks.get_account_shared_data(owner_id) {
                     if !native_loader::check_id(owner_account.owner())
-                        || !(is_builtin(&owner_account)
-                            || is_executable(&owner_account, &feature_set))
+                        || !owner_account.executable()
                     {
                         error_counters.invalid_program_for_execution += 1;
                         return Err(TransactionError::InvalidProgramForExecution);


### PR DESCRIPTION
#### Problem

We can avoid some runtime cost by calling is_executable() once during account loading.  This also means we don't have to pass the feature_set to is_executable().

#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
