### PR TITLE
Report lost_insertions metrics correctly

### DIFF
--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -180,7 +180,7 @@ impl Stats {
         let evictions: u64 = self.evictions.values().sum();
         let reloads = self.reloads.load(Ordering::Relaxed);
         let insertions = self.insertions.load(Ordering::Relaxed);
-        let lost_insertions = self.insertions.load(Ordering::Relaxed);
+        let lost_insertions = self.lost_insertions.load(Ordering::Relaxed);
         let replacements = self.replacements.load(Ordering::Relaxed);
         let one_hit_wonders = self.one_hit_wonders.load(Ordering::Relaxed);
         let prunes_orphan = self.prunes_orphan.load(Ordering::Relaxed);


### PR DESCRIPTION
#### Problem

`loaded-programs-cache-stats.lost_insertions` is wrongly reporting its value using `insertions`, introduced at https://github.com/solana-labs/solana/pull/35026#discussion_r1488763316.
#### Summary of Changes

Use correct `lost_insertions` instead.

Maybe worth to bp to v1.18 and v1.17?