### PR TITLE
feature/sysvar rent epoch

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7252,6 +7252,13 @@ impl Bank {
             self.get_minimum_balance_for_rent_exemption(account.data().len())
                 .max(account.lamports()),
         );
+
+        if self
+            .feature_set
+            .is_active(&feature_set::set_sysvar_rent_epoch_max::id())
+        {
+            account.set_rent_epoch(RENT_EXEMPT_RENT_EPOCH);
+        }
     }
 
     /// Compute the active feature set based on the current bank state,

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -3796,7 +3796,6 @@ fn test_bank_update_sysvar_account() {
         use sysvar::clock::Clock;
 
         let dummy_clock_id = solana_sdk::pubkey::new_rand();
-        let dummy_rent_epoch = 44;
         let (mut genesis_config, _mint_keypair) = create_genesis_config(500);
 
         let expected_previous_slot = 3;
@@ -3819,14 +3818,13 @@ fn test_bank_update_sysvar_account() {
                 bank1.update_sysvar_account(&dummy_clock_id, |optional_account| {
                     assert!(optional_account.is_none());
 
-                    let mut account = create_account(
+                    let account = create_account(
                         &Clock {
                             slot: expected_previous_slot,
                             ..Clock::default()
                         },
                         bank1.inherit_specially_retained_account_fields(optional_account),
                     );
-                    account.set_rent_epoch(dummy_rent_epoch);
                     account
                 });
                 let current_account = bank1.get_account(&dummy_clock_id).unwrap();
@@ -3834,7 +3832,7 @@ fn test_bank_update_sysvar_account() {
                     expected_previous_slot,
                     from_account::<Clock, _>(&current_account).unwrap().slot
                 );
-                assert_eq!(dummy_rent_epoch, current_account.rent_epoch());
+                assert_eq!(RENT_EXEMPT_RENT_EPOCH, current_account.rent_epoch());
             },
             |old, new| {
                 assert_eq!(
@@ -3898,7 +3896,7 @@ fn test_bank_update_sysvar_account() {
                     expected_next_slot,
                     from_account::<Clock, _>(&current_account).unwrap().slot
                 );
-                assert_eq!(dummy_rent_epoch, current_account.rent_epoch());
+                assert_eq!(RENT_EXEMPT_RENT_EPOCH, current_account.rent_epoch());
             },
             |old, new| {
                 // if existing, capitalization shouldn't change

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -974,7 +974,7 @@ lazy_static! {
         (cost_model_requested_write_lock_cost::id(), "cost model uses number of requested write locks #34819"),
         (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
-        (set_sysvar_rent_epoch_max::id(), "Set rent epoch to MAX for sysvar #"),
+        (set_sysvar_rent_epoch_max::id(), "Set rent epoch to MAX for sysvar #35193"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -780,6 +780,10 @@ pub mod enable_chained_merkle_shreds {
     solana_sdk::declare_id!("7uZBkJXJ1HkuP6R3MJfZs7mLwymBcDbKdqbF51ZWLier");
 }
 
+pub mod set_sysvar_rent_epoch_max {
+    solana_sdk::declare_id!("GuKAKhhCz7FAMH6dgmcucNPkBe9cbySEAM3wvN6rdGUq");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -970,6 +974,7 @@ lazy_static! {
         (cost_model_requested_write_lock_cost::id(), "cost model uses number of requested write locks #34819"),
         (enable_gossip_duplicate_proof_ingestion::id(), "enable gossip duplicate proof ingestion #32963"),
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
+        (set_sysvar_rent_epoch_max::id(), "Set rent epoch to MAX for sysvar #"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
#### Problem

Since we have activated `set_rent_epoch_max` feature (https://github.com/solana-labs/solana/issues/28683), all rent_exempt accounts should have their rent_epoch set to u64::max. However, when we create sysvar (which must be rent_exempt), its rent_epoch is still set to zero. 


#### Summary of Changes

set rent_epoch to u64::max for all sysvar 


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
