### PR TITLE
Add --unified-scheduler-handler-threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7547,6 +7547,7 @@ dependencies = [
  "solana-svm",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote-program",
  "spl-token-2022",

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -818,7 +818,7 @@ impl Validator {
                 if let Some(count) = config.unified_scheduler_handler_threads {
                     warn!(
                         "--unified-scheduler-handler-threads={count} is ignored because unified \
-                         scheduler is disabled"
+                         scheduler isn't enabled"
                     );
                 }
             }

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -815,6 +815,12 @@ impl Validator {
         match &config.block_verification_method {
             BlockVerificationMethod::BlockstoreProcessor => {
                 info!("no scheduler pool is installed for block verification...");
+                if let Some(count) = config.unified_scheduler_handler_threads {
+                    warn!(
+                        "--unified-scheduler-handler-threads={count} is ignored because unified \
+                         scheduler is disabled"
+                    );
+                }
             }
             BlockVerificationMethod::UnifiedScheduler => {
                 let scheduler_pool = DefaultSchedulerPool::new_dyn(

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -262,6 +262,7 @@ pub struct ValidatorConfig {
     pub generator_config: Option<GeneratorConfig>,
     pub use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup,
     pub wen_restart_proto_path: Option<PathBuf>,
+    pub unified_scheduler_handler_threads: Option<usize>,
 }
 
 impl Default for ValidatorConfig {
@@ -329,6 +330,7 @@ impl Default for ValidatorConfig {
             generator_config: None,
             use_snapshot_archives_at_startup: UseSnapshotArchivesAtStartup::default(),
             wen_restart_proto_path: None,
+            unified_scheduler_handler_threads: None,
         }
     }
 }
@@ -816,6 +818,7 @@ impl Validator {
             }
             BlockVerificationMethod::UnifiedScheduler => {
                 let scheduler_pool = DefaultSchedulerPool::new_dyn(
+                    config.unified_scheduler_handler_threads,
                     config.runtime_config.log_messages_bytes_limit,
                     transaction_status_sender.clone(),
                     Some(replay_vote_sender.clone()),

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -291,13 +291,19 @@ pub fn load_and_process_ledger(
         "Using: block-verification-method: {}",
         block_verification_method,
     );
+    let unified_scheduler_handler_threads =
+        value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
     match block_verification_method {
         BlockVerificationMethod::BlockstoreProcessor => {
             info!("no scheduler pool is installed for block verification...");
+            if let Some(count) = unified_scheduler_handler_threads {
+                warn!(
+                    "--unified-scheduler-handler-threads={count} is ignored because unified \
+                     scheduler is disabled"
+                );
+            }
         }
         BlockVerificationMethod::UnifiedScheduler => {
-            let unified_scheduler_handler_threads =
-                value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
             let no_transaction_status_sender = None;
             let no_replay_vote_sender = None;
             let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -299,7 +299,7 @@ pub fn load_and_process_ledger(
             if let Some(count) = unified_scheduler_handler_threads {
                 warn!(
                     "--unified-scheduler-handler-threads={count} is ignored because unified \
-                     scheduler is disabled"
+                     scheduler isn't enabled"
                 );
             }
         }

--- a/ledger-tool/src/ledger_utils.rs
+++ b/ledger-tool/src/ledger_utils.rs
@@ -296,6 +296,8 @@ pub fn load_and_process_ledger(
             info!("no scheduler pool is installed for block verification...");
         }
         BlockVerificationMethod::UnifiedScheduler => {
+            let unified_scheduler_handler_threads =
+                value_t!(arg_matches, "unified_scheduler_handler_threads", usize).ok();
             let no_transaction_status_sender = None;
             let no_replay_vote_sender = None;
             let ignored_prioritization_fee_cache = Arc::new(PrioritizationFeeCache::new(0u64));
@@ -303,6 +305,7 @@ pub fn load_and_process_ledger(
                 .write()
                 .unwrap()
                 .install_scheduler_pool(DefaultSchedulerPool::new_dyn(
+                    unified_scheduler_handler_threads,
                     process_options.runtime_config.log_messages_bytes_limit,
                     no_transaction_status_sender,
                     no_replay_vote_sender,

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -851,7 +851,7 @@ fn main() {
         .arg(
             Arg::with_name("unified_scheduler_handler_threads")
                 .long("unified-scheduler-handler-threads")
-                .value_name("THREADS")
+                .value_name("COUNT")
                 .takes_value(true)
                 .validator(|s| is_within_range(s, 1..))
                 .global(true)

--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -28,7 +28,7 @@ use {
         input_parsers::{cluster_type_of, pubkey_of, pubkeys_of},
         input_validators::{
             is_parsable, is_pow2, is_pubkey, is_pubkey_or_keypair, is_slot, is_valid_percentage,
-            validate_maximum_full_snapshot_archives_to_retain,
+            is_within_range, validate_maximum_full_snapshot_archives_to_retain,
             validate_maximum_incremental_snapshot_archives_to_retain,
         },
     },
@@ -72,6 +72,7 @@ use {
         transaction::{MessageHash, SanitizedTransaction, SimpleAddressLoader},
     },
     solana_stake_program::stake_state::{self, PointValue},
+    solana_unified_scheduler_pool::DefaultSchedulerPool,
     solana_vote_program::{
         self,
         vote_state::{self, VoteState},
@@ -846,6 +847,16 @@ fn main() {
                 .global(true)
                 .hidden(hidden_unless_forced())
                 .help(BlockVerificationMethod::cli_message()),
+        )
+        .arg(
+            Arg::with_name("unified_scheduler_handler_threads")
+                .long("unified-scheduler-handler-threads")
+                .value_name("THREADS")
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 1..))
+                .global(true)
+                .hidden(hidden_unless_forced())
+                .help(DefaultSchedulerPool::cli_message()),
         )
         .arg(
             Arg::with_name("output_format")

--- a/local-cluster/src/validator_configs.rs
+++ b/local-cluster/src/validator_configs.rs
@@ -68,6 +68,7 @@ pub fn safe_clone_config(config: &ValidatorConfig) -> ValidatorConfig {
         generator_config: config.generator_config.clone(),
         use_snapshot_archives_at_startup: config.use_snapshot_archives_at_startup,
         wen_restart_proto_path: config.wen_restart_proto_path.clone(),
+        unified_scheduler_handler_threads: config.unified_scheduler_handler_threads,
     }
 }
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6545,6 +6545,7 @@ dependencies = [
  "solana-svm",
  "solana-test-validator",
  "solana-tpu-client",
+ "solana-unified-scheduler-pool",
  "solana-version",
  "solana-vote-program",
  "symlink",

--- a/validator/Cargo.toml
+++ b/validator/Cargo.toml
@@ -61,6 +61,7 @@ solana-streamer = { workspace = true }
 solana-svm = { workspace = true }
 solana-test-validator = { workspace = true }
 solana-tpu-client = { workspace = true }
+solana-unified-scheduler-pool = { workspace = true }
 solana-version = { workspace = true }
 solana-vote-program = { workspace = true }
 symlink = { workspace = true }

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1394,7 +1394,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
             Arg::with_name("unified_scheduler_handler_threads")
                 .long("unified-scheduler-handler-threads")
                 .hidden(hidden_unless_forced())
-                .value_name("THREADS")
+                .value_name("COUNT")
                 .takes_value(true)
                 .validator(|s| is_within_range(s, 1..))
                 .help(DefaultSchedulerPool::cli_message()),

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -47,6 +47,7 @@ use {
         self, MAX_BATCH_SEND_RATE_MS, MAX_TRANSACTION_BATCH_SIZE,
     },
     solana_tpu_client::tpu_client::DEFAULT_TPU_CONNECTION_POOL_SIZE,
+    solana_unified_scheduler_pool::DefaultSchedulerPool,
     std::{path::PathBuf, str::FromStr},
 };
 
@@ -1388,6 +1389,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .takes_value(true)
                 .possible_values(BlockProductionMethod::cli_names())
                 .help(BlockProductionMethod::cli_message())
+        )
+        .arg(
+            Arg::with_name("unified_scheduler_handler_threads")
+                .long("unified-scheduler-handler-threads")
+                .hidden(hidden_unless_forced())
+                .value_name("THREADS")
+                .takes_value(true)
+                .validator(|s| is_within_range(s, 1..))
+                .help(DefaultSchedulerPool::cli_message()),
         )
         .arg(
             Arg::with_name("wen_restart")

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1652,6 +1652,8 @@ pub fn main() {
         BlockProductionMethod
     )
     .unwrap_or_default();
+    validator_config.unified_scheduler_handler_threads =
+        value_t!(matches, "unified_scheduler_handler_threads", usize).ok();
 
     validator_config.ledger_column_options = LedgerColumnOptions {
         compression_type: match matches.value_of("rocksdb_ledger_compression") {


### PR DESCRIPTION
#### Problem

There's no way to adjust the number of threads via cli for unified scheduler because it's still single-threaded. However, this won't hold eternally. :)

#### Summary of Changes

Provide such a way in advance for upcoming pr, which makes the unified scheduler multi-threaded with actual scheduler logic.

#### `--help`

(note: both output is identical)

```
$ SOLANA_NO_HIDDEN_CLI_ARGS="" solana-validator --help
...
        --unified-scheduler-handler-threads <COUNT>
            Change the number of the unified scheduler's transaction execution threads dedicated to each block,
            otherwise calculated as cpu_cores/4 [default: 12]
...

$ SOLANA_NO_HIDDEN_CLI_ARGS="" solana-ledger-tool --help
...
        --unified-scheduler-handler-threads <COUNT>
            Change the number of the unified scheduler's transaction execution threads dedicated to each block,
            otherwise calculated as cpu_cores/4 [default: 12]
...
```

#### context

extracted from #33070 