### PR TITLE
Fix: add missing required attribute to LOOKUP_TABLE_ADDRESS arg for get subcommand

### DIFF
--- a/cli/src/address_lookup_table.rs
+++ b/cli/src/address_lookup_table.rs
@@ -257,6 +257,7 @@ impl AddressLookupTableSubCommands for App<'_, '_> {
                                 .index(1)
                                 .value_name("LOOKUP_TABLE_ADDRESS")
                                 .takes_value(true)
+                                .required(true)
                                 .help("Address of the lookup table to show"),
                         ),
                 ),


### PR DESCRIPTION
#### Problem

`address-lookup-table get` subcommand in solana cli panics if `LOOKUP_TABLE_ADDRESS` argument is not given, yet the argument isn't marked as required.

#### Summary of Changes

made it required.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
