### PR TITLE
Remove channel that sends roots to BlockstoreCleanupService

### DIFF
--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -281,7 +281,6 @@ pub struct ReplayStageConfig {
     pub exit: Arc<AtomicBool>,
     pub rpc_subscriptions: Arc<RpcSubscriptions>,
     pub leader_schedule_cache: Arc<LeaderScheduleCache>,
-    pub latest_root_senders: Vec<Sender<Slot>>,
     pub accounts_background_request_sender: AbsRequestSender,
     pub block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     pub transaction_status_sender: Option<TransactionStatusSender>,
@@ -551,7 +550,6 @@ impl ReplayStage {
             exit,
             rpc_subscriptions,
             leader_schedule_cache,
-            latest_root_senders,
             accounts_background_request_sender,
             block_commitment_cache,
             transaction_status_sender,
@@ -934,7 +932,6 @@ impl ReplayStage {
                         &leader_schedule_cache,
                         &lockouts_sender,
                         &accounts_background_request_sender,
-                        &latest_root_senders,
                         &rpc_subscriptions,
                         &block_commitment_cache,
                         &mut heaviest_subtree_fork_choice,
@@ -2203,7 +2200,6 @@ impl ReplayStage {
         leader_schedule_cache: &Arc<LeaderScheduleCache>,
         lockouts_sender: &Sender<CommitmentAggregationData>,
         accounts_background_request_sender: &AbsRequestSender,
-        latest_root_senders: &[Sender<Slot>],
         rpc_subscriptions: &Arc<RpcSubscriptions>,
         block_commitment_cache: &Arc<RwLock<BlockCommitmentCache>>,
         heaviest_subtree_fork_choice: &mut HeaviestSubtreeForkChoice,
@@ -2292,11 +2288,6 @@ impl ReplayStage {
                         .unwrap_or_else(|err| warn!("bank_notification_sender failed: {:?}", err));
                 }
             }
-            latest_root_senders.iter().for_each(|s| {
-                if let Err(e) = s.send(new_root) {
-                    trace!("latest root send failed: {:?}", e);
-                }
-            });
             info!("new root {}", new_root);
         }
 

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -246,14 +246,12 @@ impl Tvu {
             exit.clone(),
         );
 
-        let (blockstore_cleanup_slot_sender, _blockstore_cleanup_slot_receiver) = unbounded();
         let replay_stage_config = ReplayStageConfig {
             vote_account: *vote_account,
             authorized_voter_keypairs,
             exit: exit.clone(),
             rpc_subscriptions: rpc_subscriptions.clone(),
             leader_schedule_cache: leader_schedule_cache.clone(),
-            latest_root_senders: vec![blockstore_cleanup_slot_sender],
             accounts_background_request_sender,
             block_commitment_cache,
             transaction_status_sender,

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -246,7 +246,7 @@ impl Tvu {
             exit.clone(),
         );
 
-        let (blockstore_cleanup_slot_sender, blockstore_cleanup_slot_receiver) = unbounded();
+        let (blockstore_cleanup_slot_sender, _blockstore_cleanup_slot_receiver) = unbounded();
         let replay_stage_config = ReplayStageConfig {
             vote_account: *vote_account,
             authorized_voter_keypairs,
@@ -323,7 +323,6 @@ impl Tvu {
 
         let blockstore_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {
             BlockstoreCleanupService::new(
-                blockstore_cleanup_slot_receiver,
                 blockstore.clone(),
                 max_ledger_shreds,
                 exit.clone(),

--- a/core/src/tvu.rs
+++ b/core/src/tvu.rs
@@ -320,11 +320,7 @@ impl Tvu {
         )?;
 
         let blockstore_cleanup_service = tvu_config.max_ledger_shreds.map(|max_ledger_shreds| {
-            BlockstoreCleanupService::new(
-                blockstore.clone(),
-                max_ledger_shreds,
-                exit.clone(),
-            )
+            BlockstoreCleanupService::new(blockstore.clone(), max_ledger_shreds, exit.clone())
         });
 
         let duplicate_shred_listener = DuplicateShredListener::new(

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -52,14 +52,14 @@ impl BlockstoreCleanupService {
         let mut last_purge_slot = 0;
         let mut last_check_time = Instant::now();
 
-        info!(
-            "BlockstoreCleanupService active. max ledger shreds={}",
-            max_ledger_shreds
-        );
-
         let t_cleanup = Builder::new()
             .name("solBstoreClean".to_string())
-            .spawn(move || loop {
+            .spawn(move || {
+                info!(
+                    "BlockstoreCleanupService has started with max \
+                    ledger shreds={max_ledger_shreds}",
+                );
+                loop {
                 if exit.load(Ordering::Relaxed) {
                     break;
                 }
@@ -76,7 +76,10 @@ impl BlockstoreCleanupService {
                 // Only sleep for 1 second instead of LOOP_LIMITER so that this
                 // thread can respond to the exit flag in a timely manner
                 thread::sleep(Duration::from_secs(1));
-            })
+            }
+            info!("BlockstoreCleanupService has stopped");
+        }
+            )
             .unwrap();
 
         Self { t_cleanup }

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -60,26 +60,25 @@ impl BlockstoreCleanupService {
                     ledger shreds={max_ledger_shreds}",
                 );
                 loop {
-                if exit.load(Ordering::Relaxed) {
-                    break;
-                }
-                if last_check_time.elapsed() > LOOP_LIMITER {
-                    Self::cleanup_ledger(
-                        &blockstore,
-                        max_ledger_shreds,
-                        &mut last_purge_slot,
-                        DEFAULT_PURGE_SLOT_INTERVAL,
-                    );
+                    if exit.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    if last_check_time.elapsed() > LOOP_LIMITER {
+                        Self::cleanup_ledger(
+                            &blockstore,
+                            max_ledger_shreds,
+                            &mut last_purge_slot,
+                            DEFAULT_PURGE_SLOT_INTERVAL,
+                        );
 
-                    last_check_time = Instant::now();
+                        last_check_time = Instant::now();
+                    }
+                    // Only sleep for 1 second instead of LOOP_LIMITER so that this
+                    // thread can respond to the exit flag in a timely manner
+                    thread::sleep(Duration::from_secs(1));
                 }
-                // Only sleep for 1 second instead of LOOP_LIMITER so that this
-                // thread can respond to the exit flag in a timely manner
-                thread::sleep(Duration::from_secs(1));
-            }
-            info!("BlockstoreCleanupService has stopped");
-        }
-            )
+                info!("BlockstoreCleanupService has stopped");
+            })
             .unwrap();
 
         Self { t_cleanup }

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_MIN_MAX_LEDGER_SHREDS: u64 = 50_000_000;
 // Cleanup will be considered after the latest root has advanced by this value
 const DEFAULT_CLEANUP_SLOT_INTERVAL: u64 = 512;
 // The above slot interval can be roughly equated to a time interval. So, scale
-// how often we check for cleanup with the interval. Doing so will avoid easted
+// how often we check for cleanup with the interval. Doing so will avoid wasted
 // checks when we know that the latest root could not have advanced far enough
 //
 // Given that the timing of new slots/roots is not exact, divide by 10 to avoid
@@ -142,8 +142,8 @@ impl BlockstoreCleanupService {
             .unwrap_or(lowest_slot);
         if highest_slot < lowest_slot {
             error!(
-                "Skipping cleanup: Blockstore highest slot {} < lowest slot {}",
-                highest_slot, lowest_slot
+                "Skipping Blockstore cleanup: \
+                highest slot {highest_slot} < lowest slot {lowest_slot}",
             );
             return (false, 0, num_shreds);
         }
@@ -152,8 +152,8 @@ impl BlockstoreCleanupService {
         let num_slots = highest_slot - lowest_slot + 1;
         let mean_shreds_per_slot = num_shreds / num_slots;
         info!(
-            "{} alive shreds in slots [{}, {}], mean of {} shreds per slot",
-            num_shreds, lowest_slot, highest_slot, mean_shreds_per_slot
+            "Blockstore has {num_shreds} alive shreds in slots [{lowest_slot}, {highest_slot}], \
+            mean of {mean_shreds_per_slot} shreds per slot",
         );
 
         if num_shreds <= max_ledger_shreds {
@@ -170,7 +170,7 @@ impl BlockstoreCleanupService {
             let lowest_cleanup_slot = std::cmp::min(lowest_slot + num_slots_to_clean - 1, root);
             (true, lowest_cleanup_slot, num_shreds)
         } else {
-            error!("Skipping cleanup: calculated mean of 0 shreds per slot");
+            error!("Skipping Blockstore cleanup: calculated mean of 0 shreds per slot");
             (false, 0, num_shreds)
         }
     }
@@ -206,6 +206,7 @@ impl BlockstoreCleanupService {
             return;
         }
         *last_purge_slot = root;
+        info!("Looking for Blockstore data to cleanup, latest root: {root}");
 
         let disk_utilization_pre = blockstore.storage_size();
         let (slots_to_clean, lowest_cleanup_slot, total_shreds) =

--- a/ledger/src/blockstore_cleanup_service.rs
+++ b/ledger/src/blockstore_cleanup_service.rs
@@ -370,7 +370,7 @@ mod tests {
 
         // Mark 50 as a root to kill all but 5 shreds, which will be in the newest slots
         let mut last_purge_slot = 0;
-        blockstore.set_roots(vec![50].iter()).unwrap();
+        blockstore.set_roots([50].iter()).unwrap();
         BlockstoreCleanupService::cleanup_ledger(&blockstore, 5, &mut last_purge_slot, 10);
         assert_eq!(last_purge_slot, 50);
 
@@ -412,7 +412,7 @@ mod tests {
             insert_time.stop();
 
             let mut time = Measure::start("purge time");
-            blockstore.set_roots(vec![slot + num_slots].iter()).unwrap();
+            blockstore.set_roots([slot + num_slots].iter()).unwrap();
             BlockstoreCleanupService::cleanup_ledger(
                 &blockstore,
                 initial_slots,


### PR DESCRIPTION
#### Problem
Currently, ReplayStage sends new roots to BlockstoreCleanupService, and
BlockstoreCleanupService decides when to clean based on the advancement
of the latest root. This is totally unnecessary as the latest root is
cached by the Blockstore, and this value can simply be fetched.

#### Summary of Changes
- Rip out the channel, and instead query latest root from Blockstore directly
- Eliminate separate thread that was spawned to do the cleanup while the channel was drained
- Remove `latest_root_senders` from `ReplayStage` as the only receiver of these roots was `BlockstoreCleanupService`

#### Impact
Prior to this change, we were sending / receiving up to 150 roots/min (assuming 0% skip rate) across the channel. With the change, we are now reading an atomic every (512 * 0.4 / 10) ~20 seconds instead of using the channel.

Arguably, we could possibly increase the ~20s value to a larger interval (ie read less frequently) with the tradeoff that we may not clean as quickly as we could. However, I think there is minimal benefit to further tuning this value; the use of `LOOP_LIMITER` already makes us read the atomic 1/20 as often as we would if the `LOOP_LIMITER` if-statement didn't exist, and we just checked after every `1s` sleep