### PR TITLE
Set COPYFILE_DISABLE for mac os so it doesn't generate ._ files

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -4315,6 +4315,7 @@ pub fn create_new_ledger(
         blockstore_dir,
     ];
     let output = std::process::Command::new("tar")
+        .env("COPYFILE_DISABLE", "1")
         .args(args)
         .output()
         .unwrap();


### PR DESCRIPTION
#### Problem

Mac os creates files with ._ prefix with the tar command, and our genesis checks don't like that.

#### Summary of Changes

Set the COPYFILE_DISABLE env variable to disable this behavior.

Fixes #34176
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
