### PR TITLE
Replaces ReadAccountMapEntry in do_scan_secondary_index()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1113,15 +1113,14 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
             if config.is_aborted() {
                 break;
             }
-            let Some(entry) = self.get_cloned(&pubkey) else {
-                continue;
+            if let Some(entry) = self.get_cloned(&pubkey) {
+                self.get_account_info_with_and_then(
+                    &entry,
+                    Some(ancestors),
+                    max_root,
+                    |(slot, account_info)| func(&pubkey, (&account_info, slot)),
+                );
             };
-            let slot_list = entry.slot_list.read().unwrap();
-            let Some(found_index) = self.latest_slot(Some(ancestors), &slot_list, max_root) else {
-                continue;
-            };
-            let (slot, account_info) = slot_list[found_index];
-            func(&pubkey, (&account_info, slot));
         }
     }
 


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

When scanning a secondary index, we look up each pubkey in the index and then apply a callback function to the entry if found. Currently this uses `ReadAccountMapEntry` via `AccountsIndex::get()`, but we can do it other ways without `ReadAccountMapEntry`.


#### Summary of Changes

Reimplements `do_scan_secondary_index()` without `ReadAccountMapEntry`.