### PR TITLE
[TieredStorage] Reorder the checks in Footer

### DIFF
--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -202,26 +202,28 @@ impl TieredStorageFooter {
         file.seek_from_end(-(FOOTER_TAIL_SIZE as i64))?;
 
         let mut footer_version: u64 = 0;
-        file.read_pod(&mut footer_version)?;
-        if footer_version != FOOTER_FORMAT_VERSION {
-            return Err(TieredStorageError::InvalidFooterVersion(footer_version));
-        }
-
         let mut footer_size: u64 = 0;
-        file.read_pod(&mut footer_size)?;
-        if footer_size != FOOTER_SIZE as u64 {
-            return Err(TieredStorageError::InvalidFooterSize(
-                footer_size,
-                FOOTER_SIZE as u64,
-            ));
-        }
-
         let mut magic_number = TieredStorageMagicNumber::zeroed();
+
+        file.read_pod(&mut footer_version)?;
+        file.read_pod(&mut footer_size)?;
         file.read_pod(&mut magic_number)?;
+
         if magic_number != TieredStorageMagicNumber::default() {
             return Err(TieredStorageError::MagicNumberMismatch(
                 TieredStorageMagicNumber::default().0,
                 magic_number.0,
+            ));
+        }
+
+        if footer_version != FOOTER_FORMAT_VERSION {
+            return Err(TieredStorageError::InvalidFooterVersion(footer_version));
+        }
+
+        if footer_size != FOOTER_SIZE as u64 {
+            return Err(TieredStorageError::InvalidFooterSize(
+                footer_size,
+                FOOTER_SIZE as u64,
             ));
         }
 

--- a/accounts-db/src/tiered_storage/footer.rs
+++ b/accounts-db/src/tiered_storage/footer.rs
@@ -236,7 +236,12 @@ impl TieredStorageFooter {
 
         let mut magic_number = TieredStorageMagicNumber::zeroed();
         file.read_pod(&mut magic_number)?;
-        assert_eq!(magic_number, TieredStorageMagicNumber::default());
+        if magic_number != TieredStorageMagicNumber::default() {
+            return Err(TieredStorageError::MagicNumberMismatch(
+                TieredStorageMagicNumber::default().0,
+                magic_number.0,
+            ));
+        }
 
         let mut footer = Self::default();
         file.seek_from_end(-(footer_size as i64))?;


### PR DESCRIPTION
#### Problem
Footer's magic number at the end of the file is a way to quickly determine
whether a file is a tiered-storage file.  However, the constructor function
for TieredStorageFooter checks the footer version first before checking
the magic number.  This makes the AccountsFile code difficult to determine
whether a file is an AppendVec or a TieredStorage file.

#### Summary of Changes
TieredStorageFooter::new_from_path() will now check the magic number first
before invoking new_from_footer_block().

#### Test Plan
Add a new unit-test.