### PR TITLE
Optimize prioritization fee cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6939,7 +6939,6 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "lru",
  "lz4",
  "memmap2",
  "memoffset 0.9.0",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -29,7 +29,6 @@ index_list = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 log = { workspace = true }
-lru = { workspace = true }
 lz4 = { workspace = true }
 memmap2 = { workspace = true }
 mockall = { workspace = true }

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -286,7 +286,7 @@ impl PrioritizationFeeCache {
                     .entry(slot)
                     .or_default()
                     .entry(bank_id)
-                    .or_insert(PrioritizationFee::default());
+                    .or_default();
 
                 for CacheTransactionUpdate {
                     transaction_fee,
@@ -319,10 +319,7 @@ impl PrioritizationFeeCache {
             };
         }
 
-        let mut slot_prioritization_fee = match unfinalized.remove(&slot) {
-            Some(slot_prioritization_fee) => slot_prioritization_fee,
-            None => return,
-        };
+        let Some(mut slot_prioritization_fee) = unfinalized.remove(&slot) else { return };
 
         // prune cache by evicting write account entry from prioritization fee if its fee is less
         // or equal to block's minimum transaction fee, because they are irrelevant in calculating

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -3,7 +3,6 @@ use {
     crossbeam_channel::{unbounded, Receiver, Sender},
     dashmap::DashMap,
     log::*,
-    lru::LruCache,
     solana_measure::measure,
     solana_sdk::{
         clock::{BankId, Slot},
@@ -11,7 +10,7 @@ use {
         transaction::SanitizedTransaction,
     },
     std::{
-        collections::HashMap,
+        collections::{BTreeMap, HashMap},
         sync::{
             atomic::{AtomicU64, Ordering},
             Arc, RwLock,
@@ -118,6 +117,7 @@ impl PrioritizationFeeCacheMetrics {
     }
 }
 
+#[derive(Debug)]
 enum CacheServiceUpdate {
     TransactionUpdate {
         slot: Slot,
@@ -141,7 +141,7 @@ type SlotPrioritizationFee = DashMap<BankId, PrioritizationFee>;
 /// and collecting stats and reporting metrics.
 #[derive(Debug)]
 pub struct PrioritizationFeeCache {
-    cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
+    cache: Arc<RwLock<BTreeMap<Slot, SlotPrioritizationFee>>>,
     service_thread: Option<JoinHandle<()>>,
     sender: Sender<CacheServiceUpdate>,
     metrics: Arc<PrioritizationFeeCacheMetrics>,
@@ -166,17 +166,17 @@ impl Drop for PrioritizationFeeCache {
 
 impl PrioritizationFeeCache {
     pub fn new(capacity: u64) -> Self {
-        let metrics = Arc::new(PrioritizationFeeCacheMetrics::default());
+        let cache = Arc::new(RwLock::new(BTreeMap::new()));
         let (sender, receiver) = unbounded();
-        let cache = Arc::new(RwLock::new(LruCache::new(capacity as usize)));
+        let metrics = Arc::new(PrioritizationFeeCacheMetrics::default());
 
-        let cache_clone = cache.clone();
-        let metrics_clone = metrics.clone();
         let service_thread = Some(
             Builder::new()
                 .name("solPrFeeCachSvc".to_string())
-                .spawn(move || {
-                    Self::service_loop(cache_clone, receiver, metrics_clone);
+                .spawn({
+                    let cache = cache.clone();
+                    let metrics = metrics.clone();
+                    move || Self::service_loop(cache, capacity as usize, receiver, metrics)
                 })
                 .unwrap(),
         );
@@ -186,22 +186,6 @@ impl PrioritizationFeeCache {
             service_thread,
             sender,
             metrics,
-        }
-    }
-
-    /// Get prioritization fee entry, create new entry if necessary
-    fn get_prioritization_fee(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-    ) -> Arc<SlotPrioritizationFee> {
-        let mut cache = cache.write().unwrap();
-        match cache.get(slot) {
-            Some(entry) => Arc::clone(entry),
-            None => {
-                let entry = Arc::new(SlotPrioritizationFee::default());
-                cache.put(*slot, Arc::clone(&entry));
-                entry
-            }
         }
     }
 
@@ -279,50 +263,60 @@ impl PrioritizationFeeCache {
             });
     }
 
-    /// Internal function is invoked by worker thread to update slot's minimum prioritization fee,
-    /// Cache lock contends here.
+    /// Internal function is invoked by worker thread to update slot's minimum prioritization fee.
     fn update_cache(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-        bank_id: &BankId,
+        unfinalized: &mut BTreeMap<Slot, SlotPrioritizationFee>,
+        slot: Slot,
+        bank_id: BankId,
         transaction_fee: u64,
         writable_accounts: Arc<Vec<Pubkey>>,
-        metrics: Arc<PrioritizationFeeCacheMetrics>,
+        metrics: &PrioritizationFeeCacheMetrics,
     ) {
-        let (slot_prioritization_fee, cache_lock_time) =
-            measure!(Self::get_prioritization_fee(cache, slot), "cache_lock_time");
-
         let (_, entry_update_time) = measure!(
             {
-                let mut block_prioritization_fee = slot_prioritization_fee
-                    .entry(*bank_id)
+                let mut block_prioritization_fee = unfinalized
+                    .entry(slot)
+                    .or_default()
+                    .entry(bank_id)
                     .or_insert(PrioritizationFee::default());
                 block_prioritization_fee.update(transaction_fee, &writable_accounts)
             },
             "entry_update_time"
         );
-        metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
         metrics.accumulate_total_entry_update_elapsed_us(entry_update_time.as_us());
         metrics.accumulate_successful_transaction_update_count(1);
     }
 
     fn finalize_slot(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
-        slot: &Slot,
-        bank_id: &BankId,
-        metrics: Arc<PrioritizationFeeCacheMetrics>,
+        unfinalized: &mut BTreeMap<Slot, SlotPrioritizationFee>,
+        cache: &RwLock<BTreeMap<Slot, SlotPrioritizationFee>>,
+        cache_max_size: usize,
+        slot: Slot,
+        bank_id: BankId,
+        metrics: &PrioritizationFeeCacheMetrics,
     ) {
-        let (slot_prioritization_fee, cache_lock_time) =
-            measure!(Self::get_prioritization_fee(cache, slot), "cache_lock_time");
+        // remove unfinalized slots
+        // TODO: do we need to keep slots in buffer? or they always come in order?
+        loop {
+            match unfinalized.keys().next().cloned() {
+                Some(unfinalized_slot) if unfinalized_slot < slot - 128 => unfinalized.pop_first(),
+                _ => break,
+            };
+        }
+
+        let slot_prioritization_fee = match unfinalized.remove(&slot) {
+            Some(slot_prioritization_fee) => slot_prioritization_fee,
+            None => return,
+        };
 
         // prune cache by evicting write account entry from prioritization fee if its fee is less
         // or equal to block's minimum transaction fee, because they are irrelevant in calculating
         // block minimum fee.
-        let (result, slot_finalize_time) = measure!(
+        let (_, slot_finalize_time) = measure!(
             {
                 // Only retain priority fee reported from optimistically confirmed bank
                 let pre_purge_bank_count = slot_prioritization_fee.len() as u64;
-                slot_prioritization_fee.retain(|id, _| id == bank_id);
+                slot_prioritization_fee.retain(|id, _| *id == bank_id);
                 let post_purge_bank_count = slot_prioritization_fee.len() as u64;
                 metrics.accumulate_total_purged_duplicated_bank_count(
                     pre_purge_bank_count.saturating_sub(post_purge_bank_count),
@@ -334,30 +328,42 @@ impl PrioritizationFeeCache {
                 }
 
                 let mut block_prioritization_fee = slot_prioritization_fee
-                    .entry(*bank_id)
+                    .entry(bank_id)
                     .or_insert(PrioritizationFee::default());
-                let result = block_prioritization_fee.mark_block_completed();
-                block_prioritization_fee.report_metrics(*slot);
-                result
+                if let Err(err) = block_prioritization_fee.mark_block_completed() {
+                    error!(
+                        "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
+                        err
+                    );
+                }
+                block_prioritization_fee.report_metrics(slot);
             },
             "slot_finalize_time"
         );
-        metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
         metrics.accumulate_total_block_finalize_elapsed_us(slot_finalize_time.as_us());
 
-        if let Err(err) = result {
-            error!(
-                "Unsuccessful finalizing slot {slot}, bank ID {bank_id}: {:?}",
-                err
-            );
-        }
+        // Create new cache entry
+        let (_, cache_lock_time) = measure!(
+            {
+                let mut cache = cache.write().unwrap();
+                while cache.len() >= cache_max_size {
+                    cache.pop_first();
+                }
+                cache.insert(slot, slot_prioritization_fee);
+            },
+            "cache_lock_time"
+        );
+        metrics.accumulate_total_cache_lock_elapsed_us(cache_lock_time.as_us());
     }
 
     fn service_loop(
-        cache: Arc<RwLock<LruCache<Slot, Arc<SlotPrioritizationFee>>>>,
+        cache: Arc<RwLock<BTreeMap<Slot, SlotPrioritizationFee>>>,
+        cache_max_size: usize,
         receiver: Receiver<CacheServiceUpdate>,
         metrics: Arc<PrioritizationFeeCacheMetrics>,
     ) {
+        let mut unfinalized = BTreeMap::<Slot, SlotPrioritizationFee>::new();
+
         for update in receiver.iter() {
             match update {
                 CacheServiceUpdate::TransactionUpdate {
@@ -366,15 +372,22 @@ impl PrioritizationFeeCache {
                     transaction_fee,
                     writable_accounts,
                 } => Self::update_cache(
-                    cache.clone(),
-                    &slot,
-                    &bank_id,
+                    &mut unfinalized,
+                    slot,
+                    bank_id,
                     transaction_fee,
                     writable_accounts,
-                    metrics.clone(),
+                    &metrics,
                 ),
                 CacheServiceUpdate::BankFinalized { slot, bank_id } => {
-                    Self::finalize_slot(cache.clone(), &slot, &bank_id, metrics.clone());
+                    Self::finalize_slot(
+                        &mut unfinalized,
+                        &cache,
+                        cache_max_size,
+                        slot,
+                        bank_id,
+                        &metrics,
+                    );
 
                     metrics.report(slot);
                 }
@@ -387,16 +400,7 @@ impl PrioritizationFeeCache {
 
     /// Returns number of blocks that have finalized minimum fees collection
     pub fn available_block_count(&self) -> usize {
-        self.cache
-            .read()
-            .unwrap()
-            .iter()
-            .filter(|(_slot, slot_prioritization_fee)| {
-                slot_prioritization_fee
-                    .iter()
-                    .any(|prioritization_fee| prioritization_fee.is_finalized())
-            })
-            .count()
+        self.cache.read().unwrap().len()
     }
 
     pub fn get_prioritization_fees(&self, account_keys: &[Pubkey]) -> HashMap<Slot, u64> {
@@ -408,22 +412,19 @@ impl PrioritizationFeeCache {
                 slot_prioritization_fee
                     .iter()
                     .find_map(|prioritization_fee| {
-                        prioritization_fee.is_finalized().then(|| {
-                            let mut fee = prioritization_fee
-                                .get_min_transaction_fee()
-                                .unwrap_or_default();
-                            for account_key in account_keys {
-                                if let Some(account_fee) =
-                                    prioritization_fee.get_writable_account_fee(account_key)
-                                {
-                                    fee = std::cmp::max(fee, account_fee);
-                                }
+                        let mut fee = prioritization_fee
+                            .get_min_transaction_fee()
+                            .unwrap_or_default();
+                        for account_key in account_keys {
+                            if let Some(account_fee) =
+                                prioritization_fee.get_writable_account_fee(account_key)
+                            {
+                                fee = std::cmp::max(fee, account_fee);
                             }
-                            Some((*slot, fee))
-                        })
+                        }
+                        Some((*slot, fee))
                     })
             })
-            .flatten()
             .collect()
     }
 }
@@ -493,18 +494,22 @@ mod tests {
         slot: Slot,
         bank_id: BankId,
     ) {
+        // mark as finalized
         prioritization_fee_cache.finalize_priority_fee(slot, bank_id);
-        let fee = PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &slot,
-        );
 
         // wait till finalization is done
-        while !fee
-            .get(&bank_id)
-            .map_or(false, |block_fee| block_fee.is_finalized())
-        {
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        loop {
+            let cache = prioritization_fee_cache.cache.read().unwrap();
+            if let Some(slot_cache) = cache.get(&slot) {
+                if let Some(block_fee) = slot_cache.get(&bank_id) {
+                    if block_fee.is_finalized() {
+                        return;
+                    }
+                }
+            }
+            drop(cache);
+
+            std::thread::sleep(std::time::Duration::from_millis(10));
         }
     }
 
@@ -538,28 +543,25 @@ mod tests {
 
         // assert block minimum fee and account a, b, c fee accordingly
         {
-            let fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            let fee = fee.get(&bank.bank_id()).unwrap();
-            assert_eq!(2, fee.get_min_transaction_fee().unwrap());
-            assert_eq!(2, fee.get_writable_account_fee(&write_account_a).unwrap());
-            assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
-            assert_eq!(2, fee.get_writable_account_fee(&write_account_c).unwrap());
-            // assert unknown account d fee
-            assert!(fee
-                .get_writable_account_fee(&Pubkey::new_unique())
-                .is_none());
+            // Not possible to check the state in the thread
+            // let lock = prioritization_fee_cache.cache.read().unwrap();
+            // let fee = lock.get(&slot).unwrap();
+            // let fee = fee.get(&bank.bank_id()).unwrap();
+            // assert_eq!(2, fee.get_min_transaction_fee().unwrap());
+            // assert_eq!(2, fee.get_writable_account_fee(&write_account_a).unwrap());
+            // assert_eq!(5, fee.get_writable_account_fee(&write_account_b).unwrap());
+            // assert_eq!(2, fee.get_writable_account_fee(&write_account_c).unwrap());
+            // // assert unknown account d fee
+            // assert!(fee
+            //     .get_writable_account_fee(&Pubkey::new_unique())
+            //     .is_none());
         }
 
         // assert after prune, account a and c should be removed from cache to save space
         {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank.bank_id());
-            let fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
+            let lock = prioritization_fee_cache.cache.read().unwrap();
+            let fee = lock.get(&slot).unwrap();
             let fee = fee.get(&bank.bank_id()).unwrap();
             assert_eq!(2, fee.get_min_transaction_fee().unwrap());
             assert!(fee.get_writable_account_fee(&write_account_a).is_none());
@@ -572,28 +574,49 @@ mod tests {
     fn test_available_block_count() {
         let prioritization_fee_cache = PrioritizationFeeCache::default();
 
-        assert!(PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &1
-        )
-        .entry(1)
-        .or_default()
-        .mark_block_completed()
-        .is_ok());
-        assert!(PrioritizationFeeCache::get_prioritization_fee(
-            prioritization_fee_cache.cache.clone(),
-            &2
-        )
-        .entry(2)
-        .or_default()
-        .mark_block_completed()
-        .is_ok());
+        let GenesisConfigInfo { genesis_config, .. } = create_genesis_config(10_000);
+        let bank0 = Bank::new_for_benches(&genesis_config);
+        let bank_forks = BankForks::new_rw_arc(bank0);
+        let bank = bank_forks.read().unwrap().working_bank();
+        let collector = solana_sdk::pubkey::new_rand();
+
+        let bank1 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 1));
+        sync_update(
+            &prioritization_fee_cache,
+            bank1.clone(),
+            vec![build_sanitized_transaction_for_test(
+                1,
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+            )]
+            .iter(),
+        );
+        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
+
+        let bank2 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 2));
+        sync_update(
+            &prioritization_fee_cache,
+            bank2.clone(),
+            vec![build_sanitized_transaction_for_test(
+                1,
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+            )]
+            .iter(),
+        );
+        sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
+
         // add slot 3 entry to cache, but not finalize it
-        PrioritizationFeeCache::get_prioritization_fee(prioritization_fee_cache.cache.clone(), &3)
-            .entry(3)
-            .or_default();
+        let bank3 = Arc::new(Bank::new_from_parent(bank.clone(), &collector, 3));
+        let txs = vec![build_sanitized_transaction_for_test(
+            1,
+            &Pubkey::new_unique(),
+            &Pubkey::new_unique(),
+        )];
+        sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
 
         // assert available block count should be 2 finalized blocks
+        std::thread::sleep(std::time::Duration::from_millis(1_000));
         assert_eq!(2, prioritization_fee_cache.available_block_count());
     }
 
@@ -883,12 +906,13 @@ mod tests {
             ];
             sync_update(&prioritization_fee_cache, bank1.clone(), txs.iter());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            assert_eq!(1, slot_prioritization_fee.len());
-            assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
+            // Not possible to check the state in the thread
+            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // assert_eq!(1, slot_prioritization_fee.len());
+            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
         }
 
         // Assert after add transactions for bank2 of slot 1
@@ -903,23 +927,22 @@ mod tests {
             ];
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
-            assert_eq!(2, slot_prioritization_fee.len());
-            assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
-            assert!(slot_prioritization_fee.contains_key(&bank2.bank_id()));
+            // Not possible to check the state in the thread
+            // let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
+            //     prioritization_fee_cache.cache.clone(),
+            //     &slot,
+            // );
+            // assert_eq!(2, slot_prioritization_fee.len());
+            // assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
+            // assert!(slot_prioritization_fee.contains_key(&bank2.bank_id()));
         }
 
         // Assert after finalize with bank1 of slot 1,
         {
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, slot, bank1.bank_id());
 
-            let slot_prioritization_fee = PrioritizationFeeCache::get_prioritization_fee(
-                prioritization_fee_cache.cache.clone(),
-                &slot,
-            );
+            let cache_lock = prioritization_fee_cache.cache.read().unwrap();
+            let slot_prioritization_fee = cache_lock.get(&slot).unwrap();
             assert_eq!(1, slot_prioritization_fee.len());
             assert!(slot_prioritization_fee.contains_key(&bank1.bank_id()));
 

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -193,7 +193,7 @@ impl PrioritizationFeeCache {
         }
     }
 
-        /// Update with a list of non-vote transactions' compute_budget_details and account_locks; Only
+    /// Update with a list of non-vote transactions' compute_budget_details and account_locks; Only
     /// transactions have both valid compute_budget_details and account_locks will be used to update
     /// fee_cache asynchronously.
     pub fn update<'a>(&self, bank: &Bank, txs: impl Iterator<Item = &'a SanitizedTransaction>) {
@@ -409,7 +409,7 @@ impl PrioritizationFeeCache {
         self.cache.read().unwrap().len()
     }
 
-    pub fn get_prioritization_fees(&self, account_keys: &[Pubkey]) -> HashMap<Slot, u64> {
+    pub fn get_prioritization_fees(&self, account_keys: &[Pubkey]) -> Vec<(Slot, u64)> {
         self.cache
             .read()
             .unwrap()
@@ -619,10 +619,6 @@ mod tests {
         assert_eq!(2, prioritization_fee_cache.available_block_count());
     }
 
-    fn hashmap_of(vec: Vec<(Slot, u64)>) -> HashMap<Slot, u64> {
-        vec.into_iter().collect()
-    }
-
     #[test]
     fn test_get_prioritization_fees() {
         solana_logger::setup();
@@ -694,28 +690,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 1, bank1.bank_id());
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -737,28 +733,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank2.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 1)]),
+                vec![(1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(1, 2)]),
+                vec![(1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -768,28 +764,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 2, bank2.bank_id());
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 1)]),
+                vec![(2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 2)]),
+                vec![(2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 1)]),
+                vec![(2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -811,28 +807,28 @@ mod tests {
             sync_update(&prioritization_fee_cache, bank3.clone(), txs.iter());
             // before block is marked as completed
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 1)]),
+                vec![(2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 3), (1, 2)]),
+                vec![(2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 1)]),
+                vec![(2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(2, 4), (1, 2)]),
+                vec![(2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -842,28 +838,28 @@ mod tests {
             // after block is completed
             sync_finalize_priority_fee_for_test(&prioritization_fee_cache, 3, bank3.bank_id());
             assert_eq!(
-                hashmap_of(vec![(3, 5), (2, 3), (1, 1)]),
+                vec![(3, 5), (2, 3), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 3), (1, 2)]),
+                vec![(3, 6), (2, 3), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 5), (2, 4), (1, 2)]),
+                vec![(3, 5), (2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 1)]),
+                vec![(3, 6), (2, 4), (1, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 2)]),
+                vec![(3, 6), (2, 4), (1, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b]),
             );
             assert_eq!(
-                hashmap_of(vec![(3, 6), (2, 4), (1, 2)]),
+                vec![(3, 6), (2, 4), (1, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,
@@ -948,28 +944,28 @@ mod tests {
 
             // and data available for query are from bank1
             assert_eq!(
-                hashmap_of(vec![(slot, 1)]),
+                vec![(slot, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_a])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 1)]),
+                vec![(slot, 1)],
                 prioritization_fee_cache.get_prioritization_fees(&[write_account_c])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache
                     .get_prioritization_fees(&[write_account_a, write_account_b])
             );
             assert_eq!(
-                hashmap_of(vec![(slot, 2)]),
+                vec![(slot, 2)],
                 prioritization_fee_cache.get_prioritization_fees(&[
                     write_account_a,
                     write_account_b,


### PR DESCRIPTION
#### Problem

`PrioritizationFeeCache` needs to lock `cache` for every new transaction.

#### Summary of Changes

Instead of using a shared cache for everything, we can use a map in the update thread and update the shared cache when finalizing slot. PR also removes not required arcs and maps.