### PR TITLE
validator: ignore too old tower error

### DIFF
--- a/core/src/consensus.rs
+++ b/core/src/consensus.rs
@@ -1533,6 +1533,9 @@ impl TowerError {
             false
         }
     }
+    pub fn is_too_old(&self) -> bool {
+        matches!(self, TowerError::TooOldTower(_, _))
+    }
 }
 
 #[derive(Debug)]

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1176,8 +1176,8 @@ impl ReplayStage {
                     warn!("Failed to load tower, too old for {}: {}. Creating a new tower from bankforks.", node_pubkey, err);
                     Tower::new_from_bankforks(
                         &bank_forks.read().unwrap(),
-                        &node_pubkey,
-                        &vote_account,
+                        node_pubkey,
+                        vote_account,
                     )
                 } else {
                     error!("Failed to load tower for {}: {}", node_pubkey, err);

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1173,7 +1173,7 @@ impl ReplayStage {
                         vote_account,
                     )
                 } else if err.is_too_old() {
-                    warn!("Failed to load tower for {}: {}", node_pubkey, err);
+                    warn!("Failed to load tower, too old for {}: {}. Creating a new tower from bankforks.", node_pubkey, err);
                     Tower::new_from_bankforks(
                         &bank_forks.read().unwrap(),
                         &node_pubkey,

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -1172,6 +1172,13 @@ impl ReplayStage {
                         node_pubkey,
                         vote_account,
                     )
+                } else if err.is_too_old() {
+                    warn!("Failed to load tower for {}: {}", node_pubkey, err);
+                    Tower::new_from_bankforks(
+                        &bank_forks.read().unwrap(),
+                        &node_pubkey,
+                        &vote_account,
+                    )
                 } else {
                     error!("Failed to load tower for {}: {}", node_pubkey, err);
                     std::process::exit(1);


### PR DESCRIPTION
#### Problem

If the identity is changed on the validator using `set-identity` and there is a tower file for new identity, but the data in the file is outdated, then the validator terminates its operation.

#### Summary of Changes

Instead of terminating, the data for the tower will be taken from the current state of the cluster.
