### PR TITLE
Refactor - `LoadedPrograms::assign_program()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6649,6 +6649,7 @@ dependencies = [
  "solana-metrics",
  "solana-sdk",
  "solana_rbpf",
+ "test-case",
  "thiserror",
 ]
 

--- a/program-runtime/Cargo.toml
+++ b/program-runtime/Cargo.toml
@@ -35,6 +35,7 @@ assert_matches = { workspace = true }
 libsecp256k1 = { workspace = true }
 solana-logger = { workspace = true }
 solana-sdk = { workspace = true, features = ["dev-context-only-utils"] }
+test-case = { workspace = true }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
#### Problem


#### Summary of Changes
- Forbids all program replacements except for reloads and builtins.
- Removes `test_assign_program_tombstones()`
- Adds `test_assign_program_failure()` and `test_assign_program_success()`.