### PR TITLE
Replaces ReadAccountMapEntry in ancient append vecs

### DIFF
--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -1506,11 +1506,9 @@ pub mod tests {
                             if two_refs {
                                 original_results.iter().for_each(|results| {
                                     results.stored_accounts.iter().for_each(|account| {
-                                        let entry = db
-                                            .accounts_index
-                                            .get_account_read_entry(account.pubkey())
-                                            .unwrap();
-                                        entry.addref();
+                                        db.accounts_index.get_and_then(account.pubkey(), |entry| {
+                                            (false, entry.unwrap().addref())
+                                        });
                                     })
                                 });
                             }
@@ -1854,11 +1852,8 @@ pub mod tests {
             );
             original_results.iter().for_each(|results| {
                 results.stored_accounts.iter().for_each(|account| {
-                    let entry = db
-                        .accounts_index
-                        .get_account_read_entry(account.pubkey())
-                        .unwrap();
-                    entry.addref();
+                    db.accounts_index
+                        .get_and_then(account.pubkey(), |entry| (true, entry.unwrap().addref()));
                 })
             });
 


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

In ancient append vec tests, we manually incremental the ref count on accounts index entries. Currently the impl uses `ReadAccountMapEntry` via `AccountsIndex::get_account_read_entry()`, but it could `get_and_then()` instead.


#### Summary of Changes

Replace `get_account_read_entry()` in ancient append vecs