### PR TITLE
Removes get_account_read_entry_with_lock()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1126,14 +1126,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     pub fn get_account_read_entry(&self, pubkey: &Pubkey) -> Option<ReadAccountMapEntry<T>> {
         let lock = self.get_bin(pubkey);
-        self.get_account_read_entry_with_lock(pubkey, &lock)
-    }
-
-    pub fn get_account_read_entry_with_lock(
-        &self,
-        pubkey: &Pubkey,
-        lock: &AccountMaps<'_, T, U>,
-    ) -> Option<ReadAccountMapEntry<T>> {
         lock.get(pubkey)
             .map(ReadAccountMapEntry::from_account_map_entry)
     }


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

We want to remove `get_account_read_entry_with_lock()`, and it is only used by `get_account_read_entry()`, so the separate function can be removed.


#### Summary of Changes

Removes `get_account_read_entry_with_lock()` and inlines the impl into `get_account_read_entry()`