### PR TITLE
Replaces ReadAccountMapEntry in slots_by_pubkey()

### DIFF
--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -1631,7 +1631,7 @@ fn test_rent_eager_under_fixed_cycle_for_development() {
 }
 
 impl Bank {
-    fn slots_by_pubkey(&self, pubkey: &Pubkey, _ancestors: &Ancestors) -> Vec<Slot> {
+    fn slots_by_pubkey(&self, pubkey: &Pubkey) -> Vec<Slot> {
         self.rc
             .accounts
             .accounts_db
@@ -1699,7 +1699,6 @@ fn test_rent_eager_collect_rent_in_partition(should_collect_rent: bool) {
     );
 
     let genesis_slot = 0;
-    let ancestors = vec![(some_slot, 0), (0, 1)].into_iter().collect();
 
     let previous_epoch = bank.epoch();
     bank = Arc::new(Bank::new_from_parent(bank, &Pubkey::default(), some_slot));
@@ -1712,16 +1711,13 @@ fn test_rent_eager_collect_rent_in_partition(should_collect_rent: bool) {
         little_lamports
     );
     assert_eq!(bank.get_account(&rent_due_pubkey).unwrap().rent_epoch(), 0);
+    assert_eq!(bank.slots_by_pubkey(&rent_due_pubkey), vec![genesis_slot]);
     assert_eq!(
-        bank.slots_by_pubkey(&rent_due_pubkey, &ancestors),
+        bank.slots_by_pubkey(&rent_exempt_pubkey),
         vec![genesis_slot]
     );
     assert_eq!(
-        bank.slots_by_pubkey(&rent_exempt_pubkey, &ancestors),
-        vec![genesis_slot]
-    );
-    assert_eq!(
-        bank.slots_by_pubkey(&zero_lamport_pubkey, &ancestors),
+        bank.slots_by_pubkey(&zero_lamport_pubkey),
         vec![genesis_slot]
     );
 
@@ -1746,15 +1742,15 @@ fn test_rent_eager_collect_rent_in_partition(should_collect_rent: bool) {
         RENT_EXEMPT_RENT_EPOCH
     );
     assert_eq!(
-        bank.slots_by_pubkey(&rent_due_pubkey, &ancestors),
+        bank.slots_by_pubkey(&rent_due_pubkey),
         vec![genesis_slot, some_slot]
     );
     assert_eq!(
-        bank.slots_by_pubkey(&rent_exempt_pubkey, &ancestors),
+        bank.slots_by_pubkey(&rent_exempt_pubkey),
         vec![genesis_slot, some_slot]
     );
     assert_eq!(
-        bank.slots_by_pubkey(&zero_lamport_pubkey, &ancestors),
+        bank.slots_by_pubkey(&zero_lamport_pubkey),
         vec![genesis_slot]
     );
 }


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

`Bank` tests uses `AccountsIndex::get()`, which calls `AccountsIndex::get_account_read_entry()`. The `slots_by_pubkey()` function returns the slots from an entry's slot list as a Vec. We can do the same thing with `get_and_then()`, instead of `get()`.


#### Summary of Changes

- Uses get_and_then() in `slots_by_pubkey()`
- removes unused Ancestors parameter