### PR TITLE
Program Test: Overwrite builtin when program ID matches

### DIFF
--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -23,6 +23,7 @@ use {
         accounts_background_service::{AbsRequestSender, SnapshotRequestKind},
         bank::Bank,
         bank_forks::BankForks,
+        builtins::BUILTINS,
         commitment::BlockCommitmentCache,
         genesis_utils::{create_genesis_config_with_leader_ex, GenesisConfigInfo},
     },
@@ -526,6 +527,14 @@ impl ProgramTest {
         builtin_function: Option<BuiltinFunctionWithContext>,
     ) -> Self {
         let mut me = Self::default();
+        if BUILTINS.iter().any(|b| b.program_id == program_id) {
+            info!(
+                "Detected program ID matching builtin. Overwriting existing builtin with provided \
+                program: {}",
+                program_id,
+            );
+            me.prefer_bpf = false;
+        }
         me.add_program(program_name, program_id, builtin_function);
         me
     }


### PR DESCRIPTION
#### Problem
In order to test the Core BPF version of a builtin program, we need to be able to overwrite the existing builtin with the Core BPF version using `solana-program-test`.

Since `ProgramTest::new()` will call `Self::default()`, which automatically determines `prefer_bpf` based on the `SBF_OUT_DIR`, this will result in `prefer_bpf = true` for the provided program. This will cause the provided Core BPF program to be overwritten by the existing builtin when the bank is set up.

#### Summary of Changes
Add a check to `ProgramTest::new()` that will set `prefer_bpf` to `false` if the provided program ID matches that of a builtin. With `prefer_bpf` set to `false`, the Core BPF version of the program will replace the existing builtin during `ProgramTest::start()`.

Note: @Lichtso I've rebased this commit on top of your recent PR #35233 since it requires the changes you've made to `LoadedPrograms::assign_program()`.
