### PR TITLE
Replaces ReadAccountMapEntry in retry_to_get_account_accessor()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -5344,7 +5344,7 @@ impl AccountsDb {
                     storage_location,
                     load_hint,
                     new_storage_location,
-                    self.accounts_index.get_account_read_entry(pubkey)
+                    self.accounts_index.get_cloned(pubkey)
                 );
                 // Considering that we've failed to get accessor above and further that
                 // the index still returned the same (slot, store_id) tuple, offset must be same


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

When `retry_to_get_account_accessor()` hits an exceptional case with a bad index entry, we panic. In the panic message we include the index entry, which currently uses `ReadAccountMapEntry` via `get_account_read_entry()`. We can use a different impl to remove the `ReadAccountMapEntry`.


#### Summary of Changes

Replaces `get_account_read_entry()` in `retry_to_get_account_accessor()`.