### PR TITLE
Build transfer hook for downstream project

### DIFF
--- a/ci/downstream-projects/func-spl.sh
+++ b/ci/downstream-projects/func-spl.sh
@@ -5,6 +5,7 @@ spl() {
     # Mind the order!
     PROGRAMS=(
       instruction-padding/program
+      token/transfer-hook/example
       token/program
       token/program-2022
       token/program-2022-test
@@ -37,9 +38,6 @@ spl() {
     for program in "${PROGRAMS[@]}"; do
       $CARGO_TEST_SBF --manifest-path "$program"/Cargo.toml
     done
-
-    # token hook example isn't built with `cargo build`, but it is necessary for `cargo test`
-    $CARGO_BUILD_SBF --manifest-path token/transfer-hook/example/Cargo.toml
 
     # TODO better: `build.rs` for spl-token-cli doesn't seem to properly build
     # the required programs to run the tests, so instead we run the tests

--- a/ci/downstream-projects/func-spl.sh
+++ b/ci/downstream-projects/func-spl.sh
@@ -38,6 +38,9 @@ spl() {
       $CARGO_TEST_SBF --manifest-path "$program"/Cargo.toml
     done
 
+    # token hook example isn't built with `cargo build`, but it is necessary for `cargo test`
+    $CARGO_BUILD_SBF --manifest-path token/transfer-hook/example/Cargo.toml
+
     # TODO better: `build.rs` for spl-token-cli doesn't seem to properly build
     # the required programs to run the tests, so instead we run the tests
     # after we know programs have been built


### PR DESCRIPTION
#### Problem

When running `ci/downstream-projects/func-spl.sh`, the binary for `spl_transfer_hook_example.so` is missing and we get the error:
```
---- test::test_create stdout ----
thread 'test::test_create' panicked at /Users/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/solana-program-test-1.17.17/src/lib.rs:451:31:
Failed to open "../../../target/deploy/spl_transfer_hook_example.so": No such file or directory (os error 2)
```
#### Summary of Changes

I added a command to build the aforementioned binary.

