### PR TITLE
deserialize StakeHistory incrementally

### DIFF
--- a/account-decoder/src/parse_sysvar.rs
+++ b/account-decoder/src/parse_sysvar.rs
@@ -79,7 +79,7 @@ pub fn parse_sysvar(data: &[u8], pubkey: &Pubkey) -> Result<SysvarAccountType, P
                     .iter()
                     .map(|entry| UiStakeHistoryEntry {
                         epoch: entry.0,
-                        stake_history: entry.1.clone(),
+                        stake_history: entry.1,
                     })
                     .collect();
                 SysvarAccountType::StakeHistory(stake_history)
@@ -340,7 +340,7 @@ mod test {
             activating: 2,
             deactivating: 3,
         };
-        stake_history.add(1, stake_history_entry.clone());
+        stake_history.add(1, stake_history_entry);
         let stake_history_sysvar = create_account_for_test(&stake_history);
         assert_eq!(
             parse_sysvar(&stake_history_sysvar.data, &sysvar::stake_history::id()).unwrap(),

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -2381,7 +2381,7 @@ mod tests {
         }
 
         for epoch in 0..=stake.deactivation_epoch + 1 {
-            let history = stake_history.get(epoch).unwrap();
+            let history = stake_history.get_entry(epoch).unwrap();
             let other_activations: u64 = other_activations[..=epoch as usize].iter().sum();
             let expected_stake = history.effective - base_stake - other_activations;
             let (expected_activating, expected_deactivating) = if epoch < stake.deactivation_epoch {

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -256,10 +256,10 @@ struct CalculatedStakePoints {
 /// for a given stake and vote_state, calculate how many
 ///   points were earned (credits * stake) and new value
 ///   for credits_observed were the points paid
-fn calculate_stake_points_and_credits(
+fn calculate_stake_points_and_credits<T: StakeHistoryGetEntry>(
     stake: &Stake,
     new_vote_state: &VoteState,
-    stake_history: &StakeHistory,
+    stake_history: &T,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> CalculatedStakePoints {
@@ -373,12 +373,12 @@ struct CalculatedStakeRewards {
 ///   * voter_rewards to be distributed
 ///   * new value for credits_observed in the stake
 /// returns None if there's no payout or if any deserved payout is < 1 lamport
-fn calculate_stake_rewards(
+fn calculate_stake_rewards<T: StakeHistoryGetEntry>(
     rewarded_epoch: Epoch,
     stake: &Stake,
     point_value: &PointValue,
     vote_state: &VoteState,
-    stake_history: &StakeHistory,
+    stake_history: &T,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> Option<CalculatedStakeRewards> {

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -256,10 +256,10 @@ struct CalculatedStakePoints {
 /// for a given stake and vote_state, calculate how many
 ///   points were earned (credits * stake) and new value
 ///   for credits_observed were the points paid
-fn calculate_stake_points_and_credits<T: StakeHistoryGetEntry>(
+fn calculate_stake_points_and_credits(
     stake: &Stake,
     new_vote_state: &VoteState,
-    stake_history: &T,
+    stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> CalculatedStakePoints {
@@ -373,12 +373,12 @@ struct CalculatedStakeRewards {
 ///   * voter_rewards to be distributed
 ///   * new value for credits_observed in the stake
 /// returns None if there's no payout or if any deserved payout is < 1 lamport
-fn calculate_stake_rewards<T: StakeHistoryGetEntry>(
+fn calculate_stake_rewards(
     rewarded_epoch: Epoch,
     stake: &Stake,
     point_value: &PointValue,
     vote_state: &VoteState,
-    stake_history: &T,
+    stake_history: &StakeHistory,
     inflation_point_calc_tracer: Option<impl Fn(&InflationPointCalculationEvent)>,
     new_rate_activation_epoch: Option<Epoch>,
 ) -> Option<CalculatedStakeRewards> {

--- a/programs/stake/src/stake_state.rs
+++ b/programs/stake/src/stake_state.rs
@@ -24,7 +24,7 @@ use {
             stake_flags::StakeFlags,
             tools::{acceptable_reference_epoch_credits, eligible_for_deactivate_delinquent},
         },
-        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry},
         transaction_context::{
             BorrowedAccount, IndexOfAccount, InstructionContext, TransactionContext,
         },
@@ -1807,6 +1807,7 @@ mod tests {
             native_token,
             pubkey::Pubkey,
             stake::state::warmup_cooldown_rate,
+            stake_history::StakeHistoryGetEntry,
             sysvar::{epoch_schedule, SysvarId},
         },
         test_case::test_case,

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -51,7 +51,7 @@ use {
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
         stake_account::StakeAccount,
-        stake_history::StakeHistory,
+        stake_history::{StakeHistory, StakeHistoryGetEntry},
         stake_weighted_timestamp::{
             calculate_stake_weighted_timestamp, MaxAllowableDrift,
             MAX_ALLOWABLE_DRIFT_PERCENTAGE_FAST, MAX_ALLOWABLE_DRIFT_PERCENTAGE_SLOW_V2,
@@ -2438,7 +2438,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes_cache.stakes().history().get(prev_epoch)
+            self.stakes_cache.stakes().history().get_entry(prev_epoch)
         {
             stake_history_entry.effective
         } else {
@@ -2551,7 +2551,7 @@ impl Bank {
             .fetch_add(validator_rewards_paid, Relaxed);
 
         let active_stake = if let Some(stake_history_entry) =
-            self.stakes_cache.stakes().history().get(prev_epoch)
+            self.stakes_cache.stakes().history().get_entry(prev_epoch)
         {
             stake_history_entry.effective
         } else {

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -99,7 +99,7 @@ mod tests {
         let mut stake_history_inner = StakeHistoryInner::default();
         (2134..).take(11).for_each(|epoch| {
             let entry = rand_stake_history_entry();
-            stake_history_outer.add(epoch, entry.clone());
+            stake_history_outer.add(epoch, entry);
             stake_history_inner.add(epoch, entry);
         });
 

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -1,8 +1,14 @@
 //! This module implements clone-on-write semantics for the SDK's `StakeHistory` to reduce
 //! unnecessary cloning of the underlying vector.
-use std::{
-    ops::{Deref, DerefMut},
-    sync::Arc,
+use {
+    solana_sdk::{
+        clock::Epoch,
+        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
+    },
+    std::{
+        ops::{Deref, DerefMut},
+        sync::Arc,
+    },
 };
 
 /// The SDK's stake history with clone-on-write semantics
@@ -19,6 +25,12 @@ impl Deref for StakeHistory {
 impl DerefMut for StakeHistory {
     fn deref_mut(&mut self) -> &mut Self::Target {
         Arc::make_mut(&mut self.0)
+    }
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.0.get_entry(epoch)
     }
 }
 

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -29,7 +29,7 @@ impl DerefMut for StakeHistory {
 }
 
 impl StakeHistoryGetEntry for StakeHistory {
-    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+    fn get_entry(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.0.get_entry(epoch)
     }
 }

--- a/runtime/src/stake_history.rs
+++ b/runtime/src/stake_history.rs
@@ -1,10 +1,8 @@
 //! This module implements clone-on-write semantics for the SDK's `StakeHistory` to reduce
 //! unnecessary cloning of the underlying vector.
+pub use solana_sdk::stake_history::StakeHistoryGetEntry;
 use {
-    solana_sdk::{
-        clock::Epoch,
-        stake_history::{StakeHistoryEntry, StakeHistoryGetEntry},
-    },
+    solana_sdk::{clock::Epoch, stake_history::StakeHistoryEntry},
     std::{
         ops::{Deref, DerefMut},
         sync::Arc,

--- a/sdk/program/src/stake/state.rs
+++ b/sdk/program/src/stake/state.rs
@@ -12,7 +12,7 @@ use {
             instruction::{LockupArgs, StakeError},
             stake_flags::StakeFlags,
         },
-        stake_history::{StakeHistory, StakeHistoryEntry},
+        stake_history::{StakeHistory, StakeHistoryEntry, StakeHistoryGetEntry},
     },
     borsh::{io, BorshDeserialize, BorshSchema, BorshSerialize},
     std::collections::HashSet,
@@ -638,10 +638,10 @@ impl Delegation {
         self.activation_epoch == std::u64::MAX
     }
 
-    pub fn stake(
+    pub fn stake<T: StakeHistoryGetEntry>(
         &self,
         epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> u64 {
         self.stake_activating_and_deactivating(epoch, history, new_rate_activation_epoch)
@@ -649,10 +649,10 @@ impl Delegation {
     }
 
     #[allow(clippy::comparison_chain)]
-    pub fn stake_activating_and_deactivating(
+    pub fn stake_activating_and_deactivating<T: StakeHistoryGetEntry>(
         &self,
         target_epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> StakeActivationStatus {
         // first, calculate an effective and activating stake
@@ -674,7 +674,7 @@ impl Delegation {
             // can only deactivate what's activated
             StakeActivationStatus::with_deactivating(effective_stake)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
-            .get(self.deactivation_epoch)
+            .get_entry(self.deactivation_epoch)
             .map(|cluster_stake_at_deactivation_epoch| {
                 (
                     history,
@@ -719,7 +719,7 @@ impl Delegation {
                 if current_epoch >= target_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(current_epoch) {
+                if let Some(current_cluster_stake) = history.get_entry(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {
@@ -736,10 +736,10 @@ impl Delegation {
     }
 
     // returned tuple is (effective, activating) stake
-    fn stake_and_activating(
+    fn stake_and_activating<T: StakeHistoryGetEntry>(
         &self,
         target_epoch: Epoch,
-        history: &StakeHistory,
+        history: &T,
         new_rate_activation_epoch: Option<Epoch>,
     ) -> (u64, u64) {
         let delegated_stake = self.stake;
@@ -758,7 +758,7 @@ impl Delegation {
             // not yet enabled
             (0, 0)
         } else if let Some((history, mut prev_epoch, mut prev_cluster_stake)) = history
-            .get(self.activation_epoch)
+            .get_entry(self.activation_epoch)
             .map(|cluster_stake_at_activation_epoch| {
                 (
                     history,
@@ -804,7 +804,7 @@ impl Delegation {
                 if current_epoch >= target_epoch || current_epoch >= self.deactivation_epoch {
                     break;
                 }
-                if let Some(current_cluster_stake) = history.get(current_epoch) {
+                if let Some(current_cluster_stake) = history.get_entry(current_epoch) {
                     prev_epoch = current_epoch;
                     prev_cluster_stake = current_cluster_stake;
                 } else {

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -66,6 +66,8 @@ impl std::ops::Add for StakeHistoryEntry {
 pub struct StakeHistory(Vec<(Epoch, StakeHistoryEntry)>);
 
 impl StakeHistory {
+    // deprecated due to naming clash with `Sysvar::get()`
+    #[deprecated(note = "Please use `get_entry` instead")]
     pub fn get(&self, epoch: Epoch) -> Option<&StakeHistoryEntry> {
         self.binary_search_by(|probe| epoch.cmp(&probe.0))
             .ok()

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -129,10 +129,10 @@ impl StakeHistoryGetEntry for Arc<StakeHistory> {
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Zeroable, Pod)]
 struct StakeHistoryEpochEntry {
-    pub epoch: Epoch,
-    pub effective: u64,
-    pub activating: u64,
-    pub deactivating: u64,
+    epoch: Epoch,
+    effective: u64,
+    activating: u64,
+    deactivating: u64,
 }
 
 impl StakeHistoryGetEntry for StakeHistoryData<'_> {

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -223,7 +223,7 @@ mod tests {
         );
         stake_history.to_account_info(&mut account_info).unwrap();
 
-        let stake_history_data = StakeHistoryData::from_account_info(&account_info);
+        let stake_history_data = StakeHistoryData::from_account_info(&account_info).unwrap();
 
         assert_eq!(stake_history_data.get_entry(0), None);
         assert_eq!(

--- a/sdk/program/src/stake_history.rs
+++ b/sdk/program/src/stake_history.rs
@@ -7,7 +7,10 @@
 //! [`sysvar::stake_history`]: crate::sysvar::stake_history
 
 pub use crate::clock::Epoch;
-use std::ops::Deref;
+use {
+    crate::{account_info::AccountInfo, serialize_utils::cursor::read_u64},
+    std::{cell::RefCell, io::Cursor, ops::Deref, rc::Rc, sync::Arc},
+};
 
 pub const MAX_ENTRIES: usize = 512; // it should never take as many as 512 epochs to warm up or cool down
 
@@ -81,9 +84,80 @@ impl Deref for StakeHistory {
     }
 }
 
+// HANA my stuff below
+
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub struct StakeHistoryData<'a>(Rc<RefCell<&'a mut [u8]>>);
+
+impl<'a> StakeHistoryData<'a> {
+    pub fn from_account_info(account_info: &AccountInfo<'a>) -> StakeHistoryData<'a> {
+        // TODO check address
+        StakeHistoryData(account_info.data.clone())
+    }
+}
+
+// HANA i would like to change this to Option<&StakeHistoryEntry> but the types are complicated
+// i dont think its possible to take a reference to the data inside the RefCell
+// i also dont think theres any way to heap allocation in my new impl and get a normal reference
+// and i dont think theres a way to use something like AsRef to let me box my new one and not the old one
+// and anyway callers of the old one wouldnt have a type specialized to normal reference
+// so really i would need like... hmm i can put `ReturnType: AsRef<StakeHistoryEntry>`
+// and have each impl define its own return, Option<&StakeHistoryEntry> or Option<Box<StakeHistoryEntry>>
+pub trait StakeHistoryGetEntry {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry>;
+}
+
+impl StakeHistoryGetEntry for StakeHistory {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.binary_search_by(|probe| epoch.cmp(&probe.0))
+            .ok()
+            .map(|index| self[index].1.clone())
+    }
+}
+
+// HANA this is only required as long as we use the sysvar cache
+impl StakeHistoryGetEntry for Arc<StakeHistory> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        self.deref().get_entry(epoch)
+    }
+}
+
+impl StakeHistoryGetEntry for StakeHistoryData<'_> {
+    fn get_entry(&self, epoch: Epoch) -> Option<StakeHistoryEntry> {
+        // TODO binary search
+        let data = self.0.borrow();
+        let mut cursor = Cursor::new(&*data);
+        let entry_count = read_u64(&mut cursor).unwrap();
+
+        for _ in 0..entry_count {
+            // TODO skip reading next three and just adjust the cursor
+            let entry_epoch = read_u64(&mut cursor).unwrap();
+            let effective = read_u64(&mut cursor).unwrap();
+            let activating = read_u64(&mut cursor).unwrap();
+            let deactivating = read_u64(&mut cursor).unwrap();
+
+            if epoch == entry_epoch {
+                return Some(StakeHistoryEntry {
+                    effective,
+                    activating,
+                    deactivating,
+                });
+            }
+        }
+
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use {
+        super::*,
+        crate::{
+            pubkey::Pubkey,
+            sysvar::{Sysvar, SysvarId},
+        },
+    };
 
     #[test]
     fn test_stake_history() {
@@ -100,10 +174,55 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
         assert_eq!(
-            stake_history.get(1),
-            Some(&StakeHistoryEntry {
+            stake_history.get_entry(1),
+            Some(StakeHistoryEntry {
+                activating: 1,
+                ..StakeHistoryEntry::default()
+            })
+        );
+    }
+
+    #[test]
+    fn test_stake_history_data() {
+        let mut stake_history = StakeHistory::default();
+
+        for i in 0..MAX_ENTRIES as u64 + 1 {
+            stake_history.add(
+                i,
+                StakeHistoryEntry {
+                    activating: i,
+                    ..StakeHistoryEntry::default()
+                },
+            );
+        }
+
+        assert_eq!(stake_history.len(), MAX_ENTRIES);
+        assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+
+        let id = StakeHistory::id();
+        let mut lamports = 0;
+        let mut data = vec![0; StakeHistory::size_of()];
+        let owner = Pubkey::default();
+        let mut account_info = AccountInfo::new(
+            &id,
+            false,
+            false,
+            &mut lamports,
+            &mut data,
+            &owner,
+            false,
+            0,
+        );
+        stake_history.to_account_info(&mut account_info).unwrap();
+
+        let stake_history_data = StakeHistoryData::from_account_info(&account_info);
+
+        assert_eq!(stake_history_data.get_entry(0), None);
+        assert_eq!(
+            stake_history_data.get_entry(1),
+            Some(StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()
             })

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -95,10 +95,10 @@ mod tests {
         }
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
-        assert_eq!(stake_history.get(0), None);
+        assert_eq!(stake_history.get_entry(0), None);
         assert_eq!(
-            stake_history.get(1),
-            Some(&StakeHistoryEntry {
+            stake_history.get_entry(1),
+            Some(StakeHistoryEntry {
                 activating: 1,
                 ..StakeHistoryEntry::default()
             })

--- a/sdk/program/src/sysvar/stake_history.rs
+++ b/sdk/program/src/sysvar/stake_history.rs
@@ -93,15 +93,18 @@ mod tests {
                 },
             );
         }
+
         assert_eq!(stake_history.len(), MAX_ENTRIES);
         assert_eq!(stake_history.iter().map(|entry| entry.0).min().unwrap(), 1);
+
         assert_eq!(stake_history.get_entry(0), None);
-        assert_eq!(
-            stake_history.get_entry(1),
-            Some(StakeHistoryEntry {
-                activating: 1,
+        for i in 1..MAX_ENTRIES as u64 + 1 {
+            let expected = Some(StakeHistoryEntry {
+                activating: i,
                 ..StakeHistoryEntry::default()
-            })
-        );
+            });
+
+            assert_eq!(stake_history.get_entry(i), expected.as_ref());
+        }
     }
 }


### PR DESCRIPTION
#### Problem
with 512 maximum entries, each of which is four u64, stake history can be as large as 16kb. the current stake program makes the data structure available as part of the transaction context, but in moving to bpf, we don't want to have to deserialize the entire thing and use half our heap, since stake history is used in the stake program typically (perhaps exclusively) to locate only one 32 byte entry for a given epoch

#### Summary of Changes
this adds a new struct `StakeHistoryData`, which is a newtype wrapper over the raw account data. it also adds a trait `StakeHistoryGetEntry`, which provides a function equivalent to `StakeHistory::get()`, and changes some key consumers of `StakeHistory` to accept `T: StakeHistoryGetEntry` instead. this allows existing functionality to (NOTE: mostly, see comments) remain unchanged, while also permitting new functionality for the bpf stake program

the impl for `StakeHistoryData` does the same thing as `StakeHistory::get()`: search for an entry matching a given epoch and return it, parsing only as much of the data is needed to locate the relevant entry
