### PR TITLE
List the default value for `--accounts` in CLI help

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -604,7 +604,11 @@ fn main() {
         .long("accounts")
         .value_name("PATHS")
         .takes_value(true)
-        .help("Comma separated persistent accounts location");
+        .help(
+            "Persistent accounts location. \
+            May be specified multiple times. \
+            [default: <LEDGER>/accounts]",
+        );
     let accounts_hash_cache_path_arg = Arg::with_name("accounts_hash_cache_path")
         .long("accounts-hash-cache-path")
         .value_name("PATH")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -276,7 +276,10 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("PATHS")
                 .takes_value(true)
                 .multiple(true)
-                .help("Comma separated persistent accounts location [default: <LEDGER>/accounts]"),
+                .help("Comma separated persistent accounts location. \
+                    May be specified multiple times. \
+                    [default: <LEDGER>/accounts]"
+                ),
         )
         .arg(
             Arg::with_name("account_shrink_path")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -276,7 +276,7 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("PATHS")
                 .takes_value(true)
                 .multiple(true)
-                .help("Comma separated persistent accounts location"),
+                .help("Comma separated persistent accounts location [default: <LEDGER>/accounts]"),
         )
         .arg(
             Arg::with_name("account_shrink_path")


### PR DESCRIPTION
#### Problem
`--accounts` is not a required argument, so list what the default location is if unspecified. We do this for several others similar arguments.
