### PR TITLE
Makes help's default for `--accounts-index-path` consistent

### DIFF
--- a/ledger-tool/src/main.rs
+++ b/ledger-tool/src/main.rs
@@ -616,8 +616,9 @@ fn main() {
         .takes_value(true)
         .multiple(true)
         .help(
-            "Persistent accounts-index location. May be specified multiple times. [default: \
-             [ledger]/accounts_index]",
+            "Persistent accounts-index location. \
+            May be specified multiple times. \
+            [default: <LEDGER>/accounts_index]",
         );
     let accounts_db_test_hash_calculation_arg = Arg::with_name("accounts_db_test_hash_calculation")
         .long("accounts-db-test-hash-calculation")

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1293,9 +1293,11 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                 .value_name("PATH")
                 .takes_value(true)
                 .multiple(true)
-                .help("Persistent accounts-index location. \
-                       May be specified multiple times. \
-                       [default: [ledger]/accounts_index]"),
+                .help(
+                    "Persistent accounts-index location. \
+                    May be specified multiple times. \
+                    [default: <LEDGER>/accounts_index]",
+                ),
         )
         .arg(
             Arg::with_name("accounts_db_test_hash_calculation")


### PR DESCRIPTION
#### Problem

The help text for `--accounts-index-path` on the validator and ledger-tool is inconsistent with other cli args that default to within the ledger directory.

Related to https://github.com/solana-labs/solana/pull/35254


#### Summary of Changes

Make the help text default value consistent.