### PR TITLE
update comments for is_builtin

### DIFF
--- a/sdk/src/account.rs
+++ b/sdk/src/account.rs
@@ -845,9 +845,12 @@ pub fn is_executable(account: &impl ReadableAccount, feature_set: &FeatureSet) -
     }
 }
 
-/// Return true if the account program is a builtin program. Note that for
-/// builtin program, even when its account data is empty, it is still be
-/// executable, such as vote program etc.
+/// Return true if the account program is a builtin program.
+///
+/// This function also ensures that all valid builtin programs have non-empty
+/// program data. Typically, the program data contains only the "name" for the
+/// program. If, for some reason, the program account's data is empty, we should
+/// exclude such a program from `builtins`.
 pub fn is_builtin(account: &impl ReadableAccount) -> bool {
     native_loader::check_id(account.owner()) && !account.data().is_empty()
 }


### PR DESCRIPTION
#### Problem

The code comments for `is_builtin` is inaccurate. 

For all valid builtin accounts, the account's data are not empty. 

Vote program actually has 19 bytes data on mainnet/testnet.
Interestingly, vote program has only 12 bytes data on devnet (maybe we should
fix it?).

https://explorer.solana.com/address/Vote111111111111111111111111111111111111111

The extra check for non-empty accounts data is to prevent user from create
empty builtin account.


#### Summary of Changes

Update the code comments for `is_buitin`.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
