### PR TITLE
Update build downstream projects script

### DIFF
--- a/scripts/build-downstream-anchor-projects.sh
+++ b/scripts/build-downstream-anchor-projects.sh
@@ -68,25 +68,27 @@ anchor() {
   cd "$solana_dir"/target/downstream-projects-anchor
 }
 
+openbook() {
+  # Openbook-v2 is still using cargo 1.70.0, which is not compatible with the latest main
+  rm -rf openbook-v2
+  git clone https://github.com/openbook-dex/openbook-v2.git
+  cd openbook-v2
+  update_solana_dependencies . "$solana_ver"
+  patch_crates_io_solana Cargo.toml "$solana_dir"
+  $cargo_build_sbf --features enable-gpl
+  cd programs/openbook-v2
+  $cargo_test_sbf  --features enable-gpl
+}
+
 mango() {
   (
     set -x
-    rm -rf mango-v3
-    git clone https://github.com/blockworks-foundation/mango-v3
-    # copy toolchain file to use solana's rust version
-    cp "$solana_dir"/rust-toolchain.toml mango-v3/
-    cd mango-v3
-
+    rm -rf mango-v4
+    git clone https://github.com/blockworks-foundation/mango-v4.git
+    cd mango-v4
     update_solana_dependencies . "$solana_ver"
-    update_anchor_dependencies . "$anchor_ver"
-    patch_crates_io_solana Cargo.toml "$solana_dir"
-    patch_crates_io_anchor Cargo.toml "$anchor_dir"
-
-    cd program
-    $cargo build
-    $cargo test
-    $cargo_build_sbf
-    $cargo_test_sbf
+    patch_crates_io_solana_no_header Cargo.toml "$solana_dir"
+    $cargo_test_sbf --features enable-gpl
   )
 }
 
@@ -97,18 +99,21 @@ metaplex() {
     git clone https://github.com/metaplex-foundation/mpl-token-metadata
     # copy toolchain file to use solana's rust version
     cp "$solana_dir"/rust-toolchain.toml mpl-token-metadata/
-    cd mpl-token-metadata/programs/token-metadata/program
+    cd mpl-token-metadata
+    ./configs/program-scripts/dump.sh ./programs/bin
+    ROOT_DIR=$(pwd)
+    cd programs/token-metadata
 
     update_solana_dependencies . "$solana_ver"
     patch_crates_io_solana Cargo.toml "$solana_dir"
 
-    $cargo build
-    $cargo test
-    $cargo_build_sbf
-    $cargo_test_sbf
+    OUT_DIR="$ROOT_DIR"/programs/bin
+    export SBF_OUT_DIR="$OUT_DIR"
+    $cargo_test_sbf --sbf-out-dir "${OUT_DIR}"
   )
 }
 
 _ anchor
 #_ metaplex
 #_ mango
+#_ openbook

--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -31,6 +31,14 @@ patch_crates_io_solana() {
   declare solana_dir="$2"
   cat >> "$Cargo_toml" <<EOF
 [patch.crates-io]
+EOF
+patch_crates_io_solana_no_header Cargo_toml solana_dir
+}
+
+patch_crates_io_solana_no_header() {
+  declare Cargo_toml="$1"
+  declare solana_dir="$2"
+  cat >> "$Cargo_toml" <<EOF
 solana-account-decoder = { path = "$solana_dir/account-decoder" }
 solana-clap-utils = { path = "$solana_dir/clap-utils" }
 solana-client = { path = "$solana_dir/client" }


### PR DESCRIPTION
#### Problem

The script for building mango and metaplex was outdated.

#### Summary of Changes

I updated the script for testing Solana (and the runtime tools) with Mango-v4 and Metaplex. I also included a function for testing it against Openbook-v2.
