### PR TITLE
genesis: Skip inserting genesis accounts for Development clusters

### DIFF
--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -230,9 +230,9 @@ fn add_stakes(
         .sum::<u64>()
 }
 
-/// Add MainnetBeta accounts that should be present in genesis; do nothing for other cluster types
+/// Add acounts that should be present in genesis; skip for development clusters
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lamports: u64) {
-    if genesis_config.cluster_type != ClusterType::MainnetBeta {
+    if genesis_config.cluster_type == ClusterType::Development {
         return;
     }
 
@@ -279,8 +279,8 @@ mod tests {
     fn test_add_genesis_accounts() {
         let clusters_and_expected_lamports = [
             (ClusterType::MainnetBeta, 500_000_000 * LAMPORTS_PER_SOL),
-            (ClusterType::Testnet, 0),
-            (ClusterType::Devnet, 0),
+            (ClusterType::Testnet, 500_000_000 * LAMPORTS_PER_SOL),
+            (ClusterType::Devnet, 500_000_000 * LAMPORTS_PER_SOL),
             (ClusterType::Development, 0),
         ];
 

--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -277,16 +277,26 @@ mod tests {
 
     #[test]
     fn test_add_genesis_accounts() {
-        let mut genesis_config = GenesisConfig::default();
+        let clusters_and_expected_lamports = [
+            (ClusterType::MainnetBeta, 500_000_000 * LAMPORTS_PER_SOL),
+            (ClusterType::Testnet, 0),
+            (ClusterType::Devnet, 0),
+            (ClusterType::Development, 0),
+        ];
 
-        add_genesis_accounts(&mut genesis_config, 0);
+        for (cluster_type, expected_lamports) in clusters_and_expected_lamports.iter() {
+            let mut genesis_config = GenesisConfig {
+                cluster_type: *cluster_type,
+                ..GenesisConfig::default()
+            };
+            add_genesis_accounts(&mut genesis_config, 0);
 
-        let lamports = genesis_config
-            .accounts
-            .values()
-            .map(|account| account.lamports)
-            .sum::<u64>();
-
-        assert_eq!(500_000_000 * LAMPORTS_PER_SOL, lamports);
+            let lamports = genesis_config
+                .accounts
+                .values()
+                .map(|account| account.lamports)
+                .sum::<u64>();
+            assert_eq!(*expected_lamports, lamports);
+        }
     }
 }

--- a/genesis/src/genesis_accounts.rs
+++ b/genesis/src/genesis_accounts.rs
@@ -3,7 +3,10 @@ use {
         stakes::{create_and_add_stakes, StakerInfo},
         unlocks::UnlockInfo,
     },
-    solana_sdk::{genesis_config::GenesisConfig, native_token::LAMPORTS_PER_SOL},
+    solana_sdk::{
+        genesis_config::{ClusterType, GenesisConfig},
+        native_token::LAMPORTS_PER_SOL,
+    },
 };
 
 // 9 month schedule is 100% after 9 months
@@ -227,10 +230,14 @@ fn add_stakes(
         .sum::<u64>()
 }
 
+/// Add MainnetBeta accounts that should be present in genesis; do nothing for other cluster types
 pub fn add_genesis_accounts(genesis_config: &mut GenesisConfig, mut issued_lamports: u64) {
+    if genesis_config.cluster_type != ClusterType::MainnetBeta {
+        return;
+    }
+
     // add_stakes() and add_validators() award tokens for rent exemption and
     //  to cover an initial transfer-free period of the network
-
     issued_lamports += add_stakes(
         genesis_config,
         CREATOR_STAKER_INFOS,


### PR DESCRIPTION
#### Problem
There is a list of accounts to be created and included in the MainnetBeta genesis. These accounts also exist in Devnet genesis, but they don't need to exist in Development clusters (especially since nobody has the keys)

#### Summary of Changes
Skip adding the accounts for Development clusters