### PR TITLE
Runtime: Bank: Prioritize additional builtins for init and feature activations

### DIFF
--- a/core/tests/snapshots.rs
+++ b/core/tests/snapshots.rs
@@ -106,6 +106,7 @@ impl SnapshotTestConfig {
             vec![accounts_dir.clone()],
             AccountSecondaryIndexes::default(),
             accounts_db::AccountShrinkThreshold::default(),
+            None,
         );
         bank0.freeze();
         bank0.set_startup_verification_complete();

--- a/ledger/src/blockstore_processor.rs
+++ b/ledger/src/blockstore_processor.rs
@@ -3894,6 +3894,7 @@ pub mod tests {
             account_paths,
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
+            None,
         );
         bank.epoch_schedule().clone()
     }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7645,6 +7645,7 @@ impl Bank {
             Vec::new(),
             account_indexes,
             shrink_ratio,
+            None,
         )
     }
 
@@ -7654,13 +7655,14 @@ impl Bank {
         paths: Vec<PathBuf>,
         account_indexes: AccountSecondaryIndexes,
         shrink_ratio: AccountShrinkThreshold,
+        additional_builtins: Option<&[BuiltinPrototype]>,
     ) -> Self {
         Self::new_with_paths(
             genesis_config,
             runtime_config,
             paths,
             None,
-            None,
+            additional_builtins,
             account_indexes,
             shrink_ratio,
             false,

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -39,6 +39,7 @@ mod tests {
         bank.apply_builtin_program_feature_transitions(
             only_apply_transitions_for_new_features,
             &HashSet::new(),
+            None,
         );
     }
 

--- a/runtime/src/bank/builtin_programs.rs
+++ b/runtime/src/bank/builtin_programs.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
 mod tests {
     use {
-        crate::bank::*,
+        crate::{bank::*, builtins::BUILTINS},
         solana_sdk::{
-            ed25519_program, feature_set::FeatureSet, genesis_config::create_genesis_config,
+            ed25519_program,
+            feature::{self, Feature},
+            feature_set::FeatureSet,
+            genesis_config::create_genesis_config,
         },
     };
 
@@ -61,5 +64,184 @@ mod tests {
 
         // Simulate starting up from snapshot finishing the initialization for a frozen bank
         bank.finish_init(&genesis_config, None, false);
+    }
+
+    #[test]
+    fn test_override_builtins() {
+        let check_bank_builtins = |builtins: &[BuiltinPrototype], expected_len| {
+            let bank = Bank::new_with_paths_for_tests(
+                &GenesisConfig::default(),
+                Arc::<RuntimeConfig>::default(),
+                Vec::new(),
+                AccountSecondaryIndexes::default(),
+                AccountShrinkThreshold::default(),
+                Some(builtins),
+            );
+
+            // Assert the bank's builtins contain all additional builtins.
+            assert_eq!(bank.builtin_programs.len(), expected_len);
+            BUILTINS
+                .iter()
+                .filter(|b| b.feature_id.is_none())
+                .chain(builtins)
+                .for_each(|b| {
+                    assert!(bank.builtin_programs.get(&b.program_id).is_some());
+                });
+        };
+
+        let builtins_len = BUILTINS.iter().filter(|b| b.feature_id.is_none()).count();
+
+        check_bank_builtins(&[], builtins_len);
+        check_bank_builtins(
+            &[BuiltinPrototype {
+                feature_id: None,
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            }],
+            // System program should be overriden.
+            builtins_len,
+        );
+        check_bank_builtins(
+            &[
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_system_program::id(),
+                    name: "system_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "random_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+            ],
+            // System program should be overriden, and random program should be added.
+            builtins_len + 1,
+        );
+        check_bank_builtins(
+            &[
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_system_program::id(),
+                    name: "system_program",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: solana_stake_program::id(),
+                    name: "stake_program",
+                    entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "random_program1",
+                    entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+                },
+                BuiltinPrototype {
+                    feature_id: None,
+                    program_id: Pubkey::new_unique(),
+                    name: "stake_program2",
+                    entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+                },
+            ],
+            // System & stake should be overriden, and random programs should be added.
+            builtins_len + 2,
+        );
+    }
+
+    #[test]
+    fn test_override_builtins_on_feature_activation() {
+        let check_bank_builtin_feature_activation = |builtins: &[BuiltinPrototype]| {
+            let mut bank = Bank::new_with_paths_for_tests(
+                &GenesisConfig::default(),
+                Arc::<RuntimeConfig>::default(),
+                Vec::new(),
+                AccountSecondaryIndexes::default(),
+                AccountShrinkThreshold::default(),
+                Some(builtins),
+            );
+
+            let mut feature_set = FeatureSet::default();
+            builtins
+                .iter()
+                .filter_map(|builtin| builtin.feature_id)
+                .for_each(|feature_id| {
+                    feature_set.inactive.insert(feature_id);
+                    bank.store_account(
+                        &feature_id,
+                        &feature::create_account(&Feature::default(), 42),
+                    );
+                });
+            bank.feature_set = Arc::new(feature_set.clone());
+
+            // Assert the bank's builtins _do not_ contain the additional
+            // builtins, since they have not been enabled.
+            builtins.iter().for_each(|b| {
+                assert!(bank.builtin_programs.get(&b.program_id).is_none());
+            });
+
+            bank.apply_feature_activations(
+                ApplyFeatureActivationsCaller::NewFromParent,
+                false,
+                Some(builtins),
+            );
+
+            // Assert the bank's builtins contain the additional builtins,
+            // since they have now been enabled.
+            builtins.iter().for_each(|builtin| {
+                assert!(bank.builtin_programs.get(&builtin.program_id).is_some());
+            });
+        };
+
+        check_bank_builtin_feature_activation(&[]);
+        check_bank_builtin_feature_activation(&[BuiltinPrototype {
+            feature_id: Some(Pubkey::new_unique()),
+            program_id: solana_system_program::id(),
+            name: "system_program",
+            entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+        }]);
+        check_bank_builtin_feature_activation(&[
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "random_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+        ]);
+        check_bank_builtin_feature_activation(&[
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_system_program::id(),
+                name: "system_program",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: solana_stake_program::id(),
+                name: "stake_program",
+                entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "random_program1",
+                entrypoint: solana_system_program::system_processor::Entrypoint::vm,
+            },
+            BuiltinPrototype {
+                feature_id: Some(Pubkey::new_unique()),
+                program_id: Pubkey::new_unique(),
+                name: "stake_program2",
+                entrypoint: solana_stake_program::stake_instruction::Entrypoint::vm,
+            },
+        ]);
     }
 }

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -7944,7 +7944,7 @@ fn test_compute_active_feature_set() {
     assert!(new_activations.contains(&test_feature));
 
     // Actually activate the pending activation
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, true, None);
     let feature = feature::from_account(&bank.get_account(&test_feature).expect("get_account"))
         .expect("from_account");
     assert_eq!(feature.activated_at, Some(1));
@@ -11699,7 +11699,7 @@ fn test_feature_activation_idempotent() {
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Don't activate feature
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Activate feature
@@ -11709,11 +11709,11 @@ fn test_feature_activation_idempotent() {
         &feature_set::update_hashes_per_tick::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 
     // Activate feature "again"
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 }
 
@@ -11727,7 +11727,7 @@ fn test_feature_hashes_per_tick() {
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Don't activate feature
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(HASHES_PER_TICK_START));
 
     // Activate feature
@@ -11737,7 +11737,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(DEFAULT_HASHES_PER_TICK));
 
     // Activate feature
@@ -11747,7 +11747,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick2::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK2));
 
     // Activate feature
@@ -11757,7 +11757,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick3::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK3));
 
     // Activate feature
@@ -11767,7 +11767,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick4::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK4));
 
     // Activate feature
@@ -11777,7 +11777,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick5::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK5));
 
     // Activate feature
@@ -11787,7 +11787,7 @@ fn test_feature_hashes_per_tick() {
         &feature_set::update_hashes_per_tick6::id(),
         &feature::create_account(&Feature { activated_at: None }, feature_account_balance),
     );
-    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false);
+    bank.apply_feature_activations(ApplyFeatureActivationsCaller::NewFromParent, false, None);
     assert_eq!(bank.hashes_per_tick, Some(UPDATED_HASHES_PER_TICK6));
 }
 

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1774,6 +1774,7 @@ mod tests {
             vec![accounts_dir.clone()],
             AccountSecondaryIndexes::default(),
             AccountShrinkThreshold::default(),
+            None,
         )
         .wrap_with_bank_forks_for_tests();
         bank0


### PR DESCRIPTION
#### Problem
In order to expand on testing feature activation behavior for builtins, the bank should have a method for providing additional test builtins to `apply_feature_activations`.

#### Summary of Changes
Add an additional parameter to `apply_feature_activations` and `apply_builtin_program_feature_transitions` to allow for providing additional test builtins to be activated on their corresponding `feature_id`.

Additionally, I've modified the iterator over `BUILTINS` to opt for any additional builtins with the same program ID, to ensure they are only added when the feature dictates so.