### PR TITLE
RPC-call `getSignaturesForAddress` misbehaves if `before`/`until` args land on one of multiple transactions within a slot.

### DIFF
--- a/ledger/src/blockstore.rs
+++ b/ledger/src/blockstore.rs
@@ -2749,39 +2749,6 @@ impl Blockstore {
         Ok(vec![])
     }
 
-    // // Returns all signatures for an address in a particular slot, regardless of whether that slot
-    // // has been rooted. The transactions will be ordered by their occurrence in the block
-    // fn find_address_signatures_for_slot(
-    //     &self,
-    //     pubkey: Pubkey,
-    //     slot: Slot,
-    // ) -> Result<Vec<(Slot, Signature)>> {
-    //     let (lock, lowest_available_slot) = self.ensure_lowest_cleanup_slot();
-    //     let mut signatures: Vec<(Slot, Signature)> = vec![];
-    //     if slot < lowest_available_slot {
-    //         return Ok(signatures);
-    //     }
-    //     let index_iterator =
-    //         self.address_signatures_cf
-    //             .iter_current_index_filtered(IteratorMode::From(
-    //                 (
-    //                     pubkey,
-    //                     slot.max(lowest_available_slot),
-    //                     0,
-    //                     Signature::default(),
-    //                 ),
-    //                 IteratorDirection::Forward,
-    //             ))?;
-    //     for ((address, transaction_slot, _transaction_index, signature), _) in index_iterator {
-    //         if transaction_slot > slot || address != pubkey {
-    //             break;
-    //         }
-    //         signatures.push((slot, signature));
-    //     }
-    //     drop(lock);
-    //     Ok(signatures)
-    // }
-
     // DEPRECATED and decommissioned
     // This method always returns an empty Vec
     pub fn get_confirmed_signatures_for_address(


### PR DESCRIPTION
#### Problem

[Strange behaviour when `before` and/or `until` refer a transaction that is not the only transaction within the slot](https://solana.stackexchange.com/questions/10412/getsignaturesforaddress-rpc-method-is-unreliable-on-the-same-block-when-using-b)

#### Summary of Changes

An attempt to streamline the selection of transaction, so that the first/last/other slots are treated less differently.

Also this PR yields the entries exactly in the newest-to-oldest order as returned by the `address_signatures_cf`, without putting it into temporary collections, reversing them etc.


Disclaimer: this is a draft PR. The primary goal is to trigger the CI and with some luck — a conversation.