### PR TITLE
Revert "Update build downstream projects script (#35262)"

### DIFF
--- a/scripts/patch-crates.sh
+++ b/scripts/patch-crates.sh
@@ -31,14 +31,6 @@ patch_crates_io_solana() {
   declare solana_dir="$2"
   cat >> "$Cargo_toml" <<EOF
 [patch.crates-io]
-EOF
-patch_crates_io_solana_no_header Cargo_toml solana_dir
-}
-
-patch_crates_io_solana_no_header() {
-  declare Cargo_toml="$1"
-  declare solana_dir="$2"
-  cat >> "$Cargo_toml" <<EOF
 solana-account-decoder = { path = "$solana_dir/account-decoder" }
 solana-clap-utils = { path = "$solana_dir/clap-utils" }
 solana-client = { path = "$solana_dir/client" }


### PR DESCRIPTION
#### Problem
https://github.com/solana-labs/solana/pull/35262 breaks CI; namely:
```
Updating crates.io index
    Updating git repository `[https://github.com/openbook-dex/program/`](https://github.com/openbook-dex/program/%60)
error: failed to select a version for the requirement `solana-cli-config = "=1.19.0"`
candidate versions found which didn't match: 1.18.2, 1.18.1, 1.18.0, ...
location searched: crates.io index
required by package `anchor-cli v0.29.0 (/home/runner/work/solana/solana/target/downstream-projects-anchor/anchor/cli)`
perhaps a crate was updated and forgotten to be re-vendored?
```
#### Summary of Changes
This reverts commit 40224345765cb6a379a4182ad395582284d6bdd9.


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
