### PR TITLE
add warning if unfinished slot is None to avoid panic

### DIFF
--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -141,6 +141,7 @@ impl StandardBroadcastRun {
                         process_stats.num_extant_slots += 1;
                         // This is a faulty situation that should not happen.
                         // Refrain from generating shreds for the slot.
+                        warn!("Blockstore already has shreds. Don't recreate this slot.");
                         return Ok((Vec::default(), Vec::default()));
                     }
                 }

--- a/turbine/src/broadcast_stage/standard_broadcast_run.rs
+++ b/turbine/src/broadcast_stage/standard_broadcast_run.rs
@@ -460,7 +460,10 @@ impl StandardBroadcastRun {
     }
 
     fn report_and_reset_stats(&mut self, was_interrupted: bool) {
-        let unfinished_slot = self.unfinished_slot.as_ref().unwrap();
+        let Some(unfinished_slot) = self.unfinished_slot.as_ref() else {
+            warn!("Unfinished slot is None, unable to report and reset stats.");
+            return;
+        };
         if was_interrupted {
             self.process_shreds_stats.submit(
                 "broadcast-process-shreds-interrupted-stats",


### PR DESCRIPTION
#### Problem

Looks like there is an invariant in the code that `unfinished_slot` is never `None`, but if this invariant is broken due to some code enhancements, it can panic which is undesirable for stats function. 

Alternatively, if we really want to panic, we can add `expect` instead.

#### Summary of Changes

Add warnings and avoid panicking. 

