### PR TITLE
Adds snapshot_utils::purge_all_bank_snapshots()

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -262,7 +262,7 @@ fn bank_forks_from_snapshot(
         // be released.  They will be released by the account_background_service anyway.  But in the case of the account_paths
         // using memory-mounted file system, they are not released early enough to give space for the new append-vecs from
         // the archives, causing the out-of-memory problem.  So, purge the snapshot dirs upfront before loading from the archive.
-        snapshot_utils::purge_old_bank_snapshots(&snapshot_config.bank_snapshots_dir, 0, None);
+        snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
 
         let (bank, _) = snapshot_bank_utils::bank_from_snapshot_archives(
             &account_paths,

--- a/runtime/src/snapshot_bank_utils.rs
+++ b/runtime/src/snapshot_bank_utils.rs
@@ -1261,7 +1261,7 @@ mod tests {
             snapshot_utils::{
                 clean_orphaned_account_snapshot_dirs, create_tmp_accounts_dir_for_tests,
                 get_bank_snapshots, get_bank_snapshots_post, get_bank_snapshots_pre,
-                get_highest_bank_snapshot, purge_bank_snapshot,
+                get_highest_bank_snapshot, purge_all_bank_snapshots, purge_bank_snapshot,
                 purge_bank_snapshots_older_than_slot, purge_incomplete_bank_snapshots,
                 purge_old_bank_snapshots, purge_old_bank_snapshots_at_startup,
                 snapshot_storage_rebuilder::get_slot_and_append_vec_id, ArchiveFormat,
@@ -2403,6 +2403,19 @@ mod tests {
             deserialized_bank, bank,
             "Ensure rebuilding bank from the highest snapshot dir results in the highest bank",
         );
+    }
+
+    #[test]
+    fn test_purge_all_bank_snapshots() {
+        let genesis_config = GenesisConfig::default();
+        let bank_snapshots_dir = tempfile::TempDir::new().unwrap();
+        let _bank = create_snapshot_dirs_for_tests(&genesis_config, &bank_snapshots_dir, 10, 5);
+        // Keep bank in this scope so that its account_paths tmp dirs are not released, and purge_all_bank_snapshots
+        // can clear the account hardlinks correctly.
+
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 10);
+        purge_all_bank_snapshots(&bank_snapshots_dir);
+        assert_eq!(get_bank_snapshots(&bank_snapshots_dir).len(), 0);
     }
 
     #[test]

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -2138,6 +2138,12 @@ pub fn verify_snapshot_archive(
     assert!(!dir_diff::is_different(&storages_to_verify, unpack_account_dir).unwrap());
 }
 
+/// Purges all bank snapshots
+pub fn purge_all_bank_snapshots(bank_snapshots_dir: impl AsRef<Path>) {
+    let bank_snapshots = get_bank_snapshots(&bank_snapshots_dir);
+    purge_bank_snapshots(&bank_snapshots);
+}
+
 /// Purges bank snapshots, retaining the newest `num_bank_snapshots_to_retain`
 pub fn purge_old_bank_snapshots(
     bank_snapshots_dir: impl AsRef<Path>,


### PR DESCRIPTION
#### Problem

When loading from a snapshot archive, we purge all the bank snapshots. The function, that's currently called, sorts all the snapshots, which is unnecessary since we're going to purge *all* of them.

Additionally, there's a fastboot issue that can occur if we startup from the same bank snapshot *more than once*, and `shrink` has run in the meantime. One fix that I'm investigating is purging all the bank snapshots after fastboot completes.

In both cases, I'd like a dedicated function for purging all the bank snapshots.


#### Summary of Changes

Add a dedicated function for purging all the bank snapshots.