### PR TITLE
uses struct instead of tuple for Merkle shreds variant

### DIFF
--- a/ledger/src/shred/common.rs
+++ b/ledger/src/shred/common.rs
@@ -56,7 +56,7 @@ macro_rules! impl_shred_common {
                     self.common_header.index = index;
                     bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
                 }
-                ShredVariant::MerkleCode(..) | ShredVariant::MerkleData(..) => {
+                ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. } => {
                     panic!("Not Implemented!");
                 }
             }
@@ -69,7 +69,7 @@ macro_rules! impl_shred_common {
                     self.common_header.slot = slot;
                     bincode::serialize_into(&mut self.payload[..], &self.common_header).unwrap();
                 }
-                ShredVariant::MerkleCode(..) | ShredVariant::MerkleData(..) => {
+                ShredVariant::MerkleCode { .. } | ShredVariant::MerkleData { .. } => {
                     panic!("Not Implemented!");
                 }
             }

--- a/ledger/src/shred/shred_data.rs
+++ b/ledger/src/shred/shred_data.rs
@@ -97,8 +97,10 @@ impl ShredData {
     // Possibly zero pads bytes stored in blockstore.
     pub(crate) fn resize_stored_shred(shred: Vec<u8>) -> Result<Vec<u8>, Error> {
         match shred::layout::get_shred_variant(&shred)? {
-            ShredVariant::LegacyCode | ShredVariant::MerkleCode(..) => Err(Error::InvalidShredType),
-            ShredVariant::MerkleData(..) => {
+            ShredVariant::LegacyCode | ShredVariant::MerkleCode { .. } => {
+                Err(Error::InvalidShredType)
+            }
+            ShredVariant::MerkleData { .. } => {
                 if shred.len() != merkle::ShredData::SIZE_OF_PAYLOAD {
                     return Err(Error::InvalidPayloadSize(shred.len()));
                 }


### PR DESCRIPTION


#### Problem
Working towards adding a new Merkle shred variant with retransmitter's signature.

#### Summary of Changes
The commit uses struct instead of tuple for Merkle shreds variant.
This is part of https://github.com/solana-labs/solana/pull/35293 factored out into its own commit.

