### PR TITLE
Replaces ReadAccountMapEntry in more tests

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2333,24 +2333,11 @@ pub mod tests {
             index.insert_new_if_missing_into_primary_index(slot, items.len(), items.into_iter());
         assert_eq!(result.count, 1);
         index.set_startup(Startup::Normal);
-        if let AccountIndexGetResult::Found(entry, index) =
-            // the entry for
-            index.get_for_tests(pubkey, Some(&ancestors), None)
-        {
-            // make sure the one with the correct info is added
-            assert_eq!(entry.slot_list()[index], (slot, account_info2));
-            // make sure it wasn't inserted twice
-            assert_eq!(
-                entry
-                    .slot_list()
-                    .iter()
-                    .filter_map(|(entry_slot, _)| (entry_slot == &slot).then_some(true))
-                    .count(),
-                1
-            );
-        } else {
-            panic!("failed");
-        }
+        let index_entry = index.get_cloned(pubkey).unwrap();
+        let slot_list = index_entry.slot_list.read().unwrap();
+        // make sure the one with the correct info is added, and wasn't inserted twice
+        assert_eq!(slot_list.len(), 1);
+        assert_eq!(slot_list[0], (slot, account_info2));
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

There are two tests that use `get_for_tests()` that really need the whole index entry in order the check the invariants. To remove ReadAccountMapEntry usage from these tests, we can use the `get_and_then()` family instead. And given the actual implementation, using `get_cloned()` will be more straight forward.


#### Summary of Changes

Replaces uses of `get_for_tests()` with `get_cloned()`.