### PR TITLE
Removes get_account_read_entry()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1124,12 +1124,6 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         }
     }
 
-    pub fn get_account_read_entry(&self, pubkey: &Pubkey) -> Option<ReadAccountMapEntry<T>> {
-        let lock = self.get_bin(pubkey);
-        lock.get(pubkey)
-            .map(ReadAccountMapEntry::from_account_map_entry)
-    }
-
     /// Gets the index's entry for `pubkey` and applies `callback` to it
     ///
     /// If `callback`'s boolean return value is true, add this entry to the in-mem cache.
@@ -1457,7 +1451,12 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
         ancestors: Option<&Ancestors>,
         max_root: Option<Slot>,
     ) -> AccountIndexGetResult<T> {
-        self.get_account_read_entry(pubkey)
+        let read_account_map_entry = self
+            .get_bin(pubkey)
+            .get(pubkey)
+            .map(ReadAccountMapEntry::from_account_map_entry);
+
+        read_account_map_entry
             .and_then(|locked_entry| {
                 let slot_list = locked_entry.slot_list();
                 self.latest_slot(ancestors, slot_list, max_root)


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

`get_account_read_entry()` is now only used by `get()`. Removing these functions is the ultimate goal. Removing one at a time makes it easier to see (1) everything is still correct, and (2) future changes only need to look for one fn instead of two.


#### Summary of Changes

Remove `get_account_read_entry()` and inline the impl into `get()`.