### PR TITLE
Removes get_for_tests()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -2170,18 +2170,6 @@ pub mod tests {
         }
     }
 
-    impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
-        /// provides the ability to refactor this function on the api without bloody changes
-        pub fn get_for_tests(
-            &self,
-            pubkey: &Pubkey,
-            ancestors: Option<&Ancestors>,
-            max_root: Option<Slot>,
-        ) -> AccountIndexGetResult<T> {
-            self.get(pubkey, ancestors, max_root)
-        }
-    }
-
     const COLLECT_ALL_UNSORTED_FALSE: bool = false;
 
     #[test]


### PR DESCRIPTION
#### Problem

`get_for_tests()` is no longer used by anything.


#### Summary of Changes

Remove it.