### PR TITLE
AccountsIndex::get_cloned() *must* add entry to in-mem cache

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1158,9 +1158,11 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
     /// Gets the index's entry for `pubkey` and clones it
     ///
     /// Prefer `get_and_then()` whenever possible.
-    /// NOTE: The entry is *not* added to the in-mem cache.
     pub fn get_cloned(&self, pubkey: &Pubkey) -> Option<AccountMapEntry<T>> {
-        self.get_and_then(pubkey, |entry| (false, entry.cloned()))
+        // We *must* add the index entry to the in-mem cache!
+        // If the index entry is only on-disk, returning a clone would allow the entry
+        // to be modified, but those modifications would be lost on drop!
+        self.get_and_then(pubkey, |entry| (true, entry.cloned()))
     }
 
     /// Is `pubkey` in the index?


### PR DESCRIPTION
#### Problem

`AccountsIndex::get_cloned()` currently does *not* add the entry to the in-mem cache, but that could lead to lost modifications.

If the entry is only on-disk, returning the cloned entry would allow the caller to modify the entry (i.e. make it 'dirty'). Since the entry is still not in-mem, when the entry gets dropped, those modifications would *not* get written back to disk, thus losing any modification.


#### Summary of Changes

Always add the index entry to the in-mem cache when using `get_cloned()`.