### PR TITLE
Deserialize Collector Fee Details 

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -252,6 +252,14 @@ impl AddAssign for SquashTiming {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CollectorFeeDetails {
+    pub transaction_fee: u64,
+    pub priority_fee: u64,
+    pub reserved: u64,
+}
+
 #[derive(Debug)]
 pub struct BankRc {
     /// where all the Accounts are stored
@@ -434,6 +442,7 @@ pub struct BankFieldsToDeserialize {
     pub(crate) incremental_snapshot_persistence: Option<BankIncrementalSnapshotPersistence>,
     pub(crate) epoch_accounts_hash: Option<Hash>,
     pub(crate) epoch_reward_status: EpochRewardStatus,
+    pub(crate) collector_fee_details: CollectorFeeDetails,
 }
 
 /// Bank's common fields shared by all supported snapshot versions for serialization.

--- a/runtime/src/serde_snapshot/newer.rs
+++ b/runtime/src/serde_snapshot/newer.rs
@@ -5,7 +5,7 @@ use {
         *,
     },
     crate::{
-        bank::EpochRewardStatus,
+        bank::{CollectorFeeDetails, EpochRewardStatus},
         stakes::{serde_stakes_enum_compat, StakesEnum},
     },
     solana_accounts_db::{accounts_hash::AccountsHash, ancestors::AncestorsForSerialization},
@@ -87,6 +87,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             epoch: dvb.epoch,
             block_height: dvb.block_height,
             collector_id: dvb.collector_id,
+            // deprecating `collector_fees`, replacing it with `collector_fee_details`
             collector_fees: dvb.collector_fees,
             fee_calculator: dvb.fee_calculator,
             fee_rate_governor: dvb.fee_rate_governor,
@@ -100,6 +101,7 @@ impl From<DeserializableVersionedBank> for BankFieldsToDeserialize {
             incremental_snapshot_persistence: None,
             epoch_accounts_hash: None,
             epoch_reward_status: EpochRewardStatus::Inactive,
+            collector_fee_details: CollectorFeeDetails::default(),
         }
     }
 }
@@ -346,6 +348,9 @@ impl<'a> TypeContext<'a> for Context {
 
         let epoch_reward_status = ignore_eof_error(deserialize_from(&mut stream))?;
         bank_fields.epoch_reward_status = epoch_reward_status;
+
+        let collector_fee_details = ignore_eof_error(deserialize_from(&mut stream))?;
+        bank_fields.collector_fee_details = collector_fee_details;
 
         Ok((bank_fields, accounts_db_fields))
     }


### PR DESCRIPTION
#### Problem

`bank` needs to collect transaction signature fees separately from priority fee, so it can be rewarded differently (per [SIMD-0096](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0096-reward-collected-priority-fee-in-entirety.md)).

This PR _only_ does deserialize the new field, so it can be backport to beta to allow beta to load snapshot generated from edge. It is part of [end-to-end poc implementation](https://github.com/solana-labs/solana/pull/34980) of simd-0096.

#### Summary of Changes
- comment to deprecate `collector_fees` from deserialization 
- define `CollectorFeeDetails`
- add code to support deserialize, of eof, new field

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
