### PR TITLE
Name PubSubService tokio threads

### DIFF
--- a/rpc/src/rpc_pubsub_service.rs
+++ b/rpc/src/rpc_pubsub_service.rs
@@ -91,7 +91,9 @@ impl PubSubService {
         let thread_hdl = Builder::new()
             .name("solRpcPubSub".to_string())
             .spawn(move || {
+                info!("PubSubService has started");
                 let runtime = tokio::runtime::Builder::new_multi_thread()
+                    .thread_name("solRpcPubSubRt")
                     .worker_threads(pubsub_config.worker_threads)
                     .enable_all()
                     .build()
@@ -102,8 +104,9 @@ impl PubSubService {
                     subscription_control,
                     tripwire,
                 )) {
-                    error!("pubsub service failed: {}", err);
+                    error!("PubSubService has stopped due to error: {err}");
                 };
+                info!("PubSubService has stopped");
             })
             .expect("thread spawn failed");
 


### PR DESCRIPTION
#### Problem
These threads use the default name (`tokio-runtime-worker`). By not having specific names, it is harder to profile the threads from this service vs. other threads that also use default name

#### Summary of Changes
Name the threads in this pool, and also add logs to note that the service has stopped/started. These logs will be useful if we ever need to debug the validator process hanging on teardown.
