### PR TITLE
Rename SamplePerformance thread to be consistent with others

### DIFF
--- a/core/src/sample_performance_service.rs
+++ b/core/src/sample_performance_service.rs
@@ -26,11 +26,12 @@ impl SamplePerformanceService {
     ) -> Self {
         let bank_forks = bank_forks.clone();
 
-        info!("Starting SamplePerformance service");
         let thread_hdl = Builder::new()
-            .name("sample-performance".to_string())
+            .name("solSamplePerf".to_string())
             .spawn(move || {
+                info!("SamplePerformanceService has started");
                 Self::run(bank_forks, blockstore, exit);
+                info!("SamplePerformanceService has stopped");
             })
             .unwrap();
 


### PR DESCRIPTION
#### Problem
Thread name inconsistent with others.

#### Summary of Changes
Rename thread + add `has started` / `has stopped` logs that are consistent with other services (like this one):
https://github.com/solana-labs/solana/blob/8ad125d0c0688aaf2b62bb95b535ff988ed7f9ac/runtime/src/accounts_background_service.rs#L612