### PR TITLE
Add tests for private functions in `account_loader.rs`

### DIFF
--- a/sdk/src/transaction/sanitized.rs
+++ b/sdk/src/transaction/sanitized.rs
@@ -271,6 +271,20 @@ impl SanitizedTransaction {
             Ok(())
         }
     }
+
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn new_for_tests(
+        message: SanitizedMessage,
+        signatures: Vec<Signature>,
+        is_simple_vote_tx: bool,
+    ) -> SanitizedTransaction {
+        SanitizedTransaction {
+            message,
+            message_hash: Hash::new_unique(),
+            signatures,
+            is_simple_vote_tx,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Problem

Private functions in `svm/account_loader.rs` lacked unit tests.

#### Summary of Changes

I added tests for them.

PS: Tests for the public functions and for the SVM entry points (file `transfer_processor.rs`) will be in another PR.

