### PR TITLE
change default `bench-tps` client to `tpu-client`

### DIFF
--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -336,7 +336,8 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .conflicts_with("tpu_client")
                 .takes_value(false)
                 .hidden(hidden_unless_forced())
-                .help("Submit transactions with a ThinClient")
+                .help("Submit transactions with a ThinClient. Note: usage is discouraged. \
+                    ThinClient will be deprecated.")
         )
         .arg(
             Arg::with_name("tpu_disable_quic")
@@ -455,8 +456,6 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
-    } else if matches.is_present("tpu_client") {
-        args.external_client_type = ExternalClientType::TpuClient;
     } else if matches.is_present("thin_client") {
         args.external_client_type = ExternalClientType::ThinClient;
     }

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -34,7 +34,7 @@ pub enum ExternalClientType {
 
 impl Default for ExternalClientType {
     fn default() -> Self {
-        Self::ThinClient
+        Self::TpuClient
     }
 }
 
@@ -167,19 +167,19 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .long("rpc-addr")
                 .value_name("HOST:PORT")
                 .takes_value(true)
-                .conflicts_with("tpu_client")
                 .conflicts_with("rpc_client")
                 .requires("tpu_addr")
+                .requires("thin_client")
                 .help("Specify custom rpc_addr to create thin_client"),
         )
         .arg(
             Arg::with_name("tpu_addr")
                 .long("tpu-addr")
                 .value_name("HOST:PORT")
-                .conflicts_with("tpu_client")
                 .conflicts_with("rpc_client")
                 .takes_value(true)
                 .requires("rpc_addr")
+                .requires("thin_client")
                 .help("Specify custom tpu_addr to create thin_client"),
         )
         .arg(
@@ -316,30 +316,30 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
         .arg(
             Arg::with_name("rpc_client")
                 .long("use-rpc-client")
-                .conflicts_with("tpu_client")
+                .conflicts_with("thin_client")
                 .takes_value(false)
                 .help("Submit transactions with a RpcClient")
         )
         .arg(
-            Arg::with_name("tpu_client")
-                .long("use-tpu-client")
+            Arg::with_name("thin_client")
+                .long("use-thin-client")
                 .conflicts_with("rpc_client")
                 .takes_value(false)
-                .help("Submit transactions with a TpuClient")
+                .help("Submit transactions with a ThinClient")
         )
         .arg(
             Arg::with_name("tpu_disable_quic")
                 .long("tpu-disable-quic")
                 .takes_value(false)
-                .help("Do not submit transactions via QUIC; only affects ThinClient (default) \
-                    or TpuClient sends"),
+                .help("Do not submit transactions via QUIC; only affects ThinClient \
+                    or TpuClient (default) sends"),
         )
         .arg(
             Arg::with_name("tpu_connection_pool_size")
                 .long("tpu-connection-pool-size")
                 .takes_value(true)
-                .help("Controls the connection pool size per remote address; only affects ThinClient (default) \
-                    or TpuClient sends"),
+                .help("Controls the connection pool size per remote address; only affects ThinClient  \
+                    or TpuClient (default) sends"),
         )
         .arg(
             Arg::with_name("compute_unit_price")
@@ -442,11 +442,11 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
         return Err("could not parse identity path");
     }
 
-    if matches.is_present("tpu_client") {
-        args.external_client_type = ExternalClientType::TpuClient;
-    } else if matches.is_present("rpc_client") {
+    if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
-    }
+    } else if matches.is_present("thin_client") {
+        args.external_client_type = ExternalClientType::ThinClient;
+    };
 
     if matches.is_present("tpu_disable_quic") {
         args.use_quic = false;
@@ -679,7 +679,7 @@ mod tests {
             }
         );
 
-        // select different client type
+        // select different client type and CommitmentConfig
         let keypair = read_keypair_file(&keypair_file_name).unwrap();
         let matches = build_args("1.0.0").get_matches_from(vec![
             "solana-bench-tps",
@@ -687,7 +687,9 @@ mod tests {
             &keypair_file_name,
             "-u",
             "http://123.4.5.6:8899",
-            "--use-tpu-client",
+            "--use-rpc-client",
+            "--commitment-config",
+            "finalized",
         ]);
         let actual = parse_args(&matches).unwrap();
         assert_eq!(
@@ -696,7 +698,8 @@ mod tests {
                 json_rpc_url: "http://123.4.5.6:8899".to_string(),
                 websocket_url: "ws://123.4.5.6:8900/".to_string(),
                 id: keypair,
-                external_client_type: ExternalClientType::TpuClient,
+                external_client_type: ExternalClientType::RpcClient,
+                commitment_config: CommitmentConfig::finalized(),
                 ..Config::default()
             }
         );

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -317,14 +317,25 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
             Arg::with_name("rpc_client")
                 .long("use-rpc-client")
                 .conflicts_with("thin_client")
+                .conflicts_with("tpu_client")
                 .takes_value(false)
                 .help("Submit transactions with a RpcClient")
+        )
+        .arg(
+            Arg::with_name("tpu_client")
+                .long("use-tpu-client")
+                .conflicts_with("rpc_client")
+                .conflicts_with("thin_client")
+                .takes_value(false)
+                .help("Submit transactions with a TpuClient")
         )
         .arg(
             Arg::with_name("thin_client")
                 .long("use-thin-client")
                 .conflicts_with("rpc_client")
+                .conflicts_with("tpu_client")
                 .takes_value(false)
+                .hidden(hidden_unless_forced())
                 .help("Submit transactions with a ThinClient")
         )
         .arg(
@@ -444,9 +455,11 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("rpc_client") {
         args.external_client_type = ExternalClientType::RpcClient;
+    } else if matches.is_present("tpu_client") {
+        args.external_client_type = ExternalClientType::TpuClient;
     } else if matches.is_present("thin_client") {
         args.external_client_type = ExternalClientType::ThinClient;
-    };
+    }
 
     if matches.is_present("tpu_disable_quic") {
         args.use_quic = false;

--- a/net/net.sh
+++ b/net/net.sh
@@ -118,7 +118,7 @@ Operate a configured testnet
                                       - Enable UDP for tpu transactions
 
    --client-type
-                                      - Specify backend client type for bench-tps. Valid options are (thin-client|rpc-client|tpu-client), thin-client is default
+                                      - Specify backend client type for bench-tps. Valid options are (thin-client|rpc-client|tpu-client), tpu-client is default
 
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
@@ -834,7 +834,7 @@ waitForNodeInit=true
 extraPrimordialStakes=0
 disableQuic=false
 enableUdp=false
-clientType=thin-client
+clientType=tpu-client
 maybeUseUnstakedConnection=""
 
 command=$1

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -43,19 +43,19 @@ skip)
   exit 1
 esac
 
-TPU_CLIENT=false
+THIN_CLIENT=false
 RPC_CLIENT=false
 case "$clientType" in
   thin-client)
-    TPU_CLIENT=false
+    THIN_CLIENT=true
     RPC_CLIENT=false
     ;;
   tpu-client)
-    TPU_CLIENT=true
+    THIN_CLIENT=false
     RPC_CLIENT=false
     ;;
   rpc-client)
-    TPU_CLIENT=false
+    THIN_CLIENT=false
     RPC_CLIENT=true
     ;;
   *)
@@ -74,12 +74,11 @@ solana-bench-tps)
 
   args=()
 
-  if ${TPU_CLIENT}; then
-    args+=(--use-tpu-client)
+  if ${THIN_CLIENT}; then
+    args+=(--entrypoint "$entrypointIp:8001")
+    args+=(--use-thin-client)
   elif ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
-  else
-    args+=(--entrypoint "$entrypointIp:8001")
   fi
 
   if [[ -z "$maybeUseUnstakedConnection" ]]; then

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -11,7 +11,7 @@ if [[ -n $4 ]]; then
 fi
 benchTpsExtraArgs="$5"
 clientIndex="$6"
-clientType="${7:-thin-client}"
+clientType="${7:-tpu-client}"
 maybeUseUnstakedConnection="$8"
 
 missing() {


### PR DESCRIPTION
#### Problem
It is time to deprecate and then remove `ThinClient` from `bench-tps`. This is the first PR to simply just change the default `bench-tps` client from `ThinClient` to `TpuClient` 

#### Summary of Changes
Change `ThinClient` to `TpuClient`, add flag for running `thin-client` explicitly (will be removed in future), and update `net.sh` scripts to reflect the change.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
