### PR TITLE
Rename `SanitizedMessage::try_from` to `try_from_legacy_message`

### DIFF
--- a/banks-server/src/banks_server.rs
+++ b/banks-server/src/banks_server.rs
@@ -31,7 +31,6 @@ use {
     },
     solana_svm::transaction_results::TransactionExecutionResult,
     std::{
-        convert::TryFrom,
         io,
         net::{Ipv4Addr, SocketAddr},
         sync::{atomic::AtomicBool, Arc, RwLock},
@@ -418,7 +417,7 @@ impl Banks for BanksServer {
         commitment: CommitmentLevel,
     ) -> Option<u64> {
         let bank = self.bank(commitment);
-        let sanitized_message = SanitizedMessage::try_from(message).ok()?;
+        let sanitized_message = SanitizedMessage::try_from_legacy_message(message).ok()?;
         bank.get_fee_for_message(&sanitized_message)
     }
 }

--- a/program-runtime/src/message_processor.rs
+++ b/program-runtime/src/message_processor.rs
@@ -187,7 +187,6 @@ mod tests {
             secp256k1_instruction::new_secp256k1_instruction,
             secp256k1_program, system_program,
         },
-        std::convert::TryFrom,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -200,7 +199,7 @@ mod tests {
     }
 
     fn new_sanitized_message(message: Message) -> SanitizedMessage {
-        SanitizedMessage::try_from(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message).unwrap()
     }
 
     #[test]

--- a/programs/sbf/tests/programs.rs
+++ b/programs/sbf/tests/programs.rs
@@ -200,7 +200,7 @@ fn execute_transactions(
                     }
                     .expect("lamports_per_signature must be available");
                     let fee = bank.get_fee_for_message_with_lamports_per_signature(
-                        &SanitizedMessage::try_from(tx.message().clone()).unwrap(),
+                        &SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap(),
                         lamports_per_signature,
                     );
 
@@ -3705,7 +3705,7 @@ fn test_program_fees() {
         Some(&mint_keypair.pubkey()),
     );
 
-    let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
+    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
     let expected_normal_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,
@@ -3729,7 +3729,7 @@ fn test_program_fees() {
         ],
         Some(&mint_keypair.pubkey()),
     );
-    let sanitized_message = SanitizedMessage::try_from(message.clone()).unwrap();
+    let sanitized_message = SanitizedMessage::try_from_legacy_message(message.clone()).unwrap();
     let expected_prioritized_fee = fee_structure.calculate_fee(
         &sanitized_message,
         congestion_multiplier,

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -5070,7 +5070,7 @@ pub mod tests {
             let prioritization_fee_cache = &self.meta.prioritization_fee_cache;
             let transactions: Vec<_> = transactions
                 .into_iter()
-                .map(|tx| SanitizedTransaction::try_from_legacy_transaction(tx).unwrap())
+                .map(SanitizedTransaction::from_transaction_for_tests)
                 .collect();
             prioritization_fee_cache.update(&bank, transactions.iter());
         }

--- a/runtime/benches/prioritization_fee_cache.rs
+++ b/runtime/benches/prioritization_fee_cache.rs
@@ -36,7 +36,7 @@ fn build_sanitized_transaction(
         Some(signer_account),
     ));
 
-    SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap()
+    SanitizedTransaction::from_transaction_for_tests(transaction)
 }
 
 #[bench]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -117,7 +117,7 @@ use {
     },
     std::{
         collections::{HashMap, HashSet},
-        convert::{TryFrom, TryInto},
+        convert::TryInto,
         fs::File,
         io::Read,
         str::FromStr,
@@ -196,7 +196,7 @@ fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
 }
 
 fn new_sanitized_message(message: Message) -> SanitizedMessage {
-    SanitizedMessage::try_from(message).unwrap()
+    SanitizedMessage::try_from_legacy_message(message).unwrap()
 }
 
 #[test]

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -195,6 +195,10 @@ fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
     solana_sdk::genesis_config::create_genesis_config(lamports)
 }
 
+fn new_sanitized_message(message: Message) -> SanitizedMessage {
+    SanitizedMessage::try_from(message).unwrap()
+}
+
 #[test]
 fn test_race_register_tick_freeze() {
     solana_logger::setup();
@@ -2666,7 +2670,7 @@ fn test_bank_tx_compute_unit_fee() {
     let (bank, bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
 
     let expected_fee_paid = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         genesis_config
             .fee_rate_governor
             .create_fee_calculator()
@@ -2794,7 +2798,7 @@ fn test_bank_blockhash_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let cheap_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         cheap_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2810,7 +2814,7 @@ fn test_bank_blockhash_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let expensive_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         expensive_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2856,7 +2860,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let cheap_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         cheap_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2872,7 +2876,7 @@ fn test_bank_blockhash_compute_unit_fee_structure() {
     assert_eq!(bank.process_transaction(&tx), Ok(()));
     assert_eq!(bank.get_balance(&key), 1);
     let expensive_fee = calculate_test_fee(
-        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap(),
+        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
         expensive_lamports_per_signature,
         &bank.fee_structure,
     );
@@ -2979,8 +2983,7 @@ fn test_filter_program_errors_and_collect_compute_unit_fee() {
                 .fee_rate_governor
                 .burn(
                     calculate_test_fee(
-                        &SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique())))
-                            .unwrap(),
+                        &new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique()))),
                         genesis_config
                             .fee_rate_governor
                             .create_fee_calculator()
@@ -5275,7 +5278,7 @@ fn test_nonce_transaction() {
     recent_message.recent_blockhash = bank.last_blockhash();
     let mut expected_balance = 4_650_000
         - bank
-            .get_fee_for_message(&recent_message.try_into().unwrap())
+            .get_fee_for_message(&new_sanitized_message(recent_message))
             .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_eq!(bank.get_balance(&nonce_pubkey), 250_000);
@@ -5334,7 +5337,7 @@ fn test_nonce_transaction() {
     let mut recent_message = nonce_tx.message.clone();
     recent_message.recent_blockhash = bank.last_blockhash();
     expected_balance -= bank
-        .get_fee_for_message(&SanitizedMessage::try_from(recent_message).unwrap())
+        .get_fee_for_message(&new_sanitized_message(recent_message))
         .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_ne!(
@@ -5402,7 +5405,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     recent_message.recent_blockhash = bank.last_blockhash();
     let mut expected_balance = 4_650_000
         - bank
-            .get_fee_for_message(&recent_message.try_into().unwrap())
+            .get_fee_for_message(&new_sanitized_message(recent_message))
             .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_eq!(bank.get_balance(&nonce_pubkey), 250_000);
@@ -5461,7 +5464,7 @@ fn test_nonce_transaction_with_tx_wide_caps() {
     let mut recent_message = nonce_tx.message.clone();
     recent_message.recent_blockhash = bank.last_blockhash();
     expected_balance -= bank
-        .get_fee_for_message(&SanitizedMessage::try_from(recent_message).unwrap())
+        .get_fee_for_message(&new_sanitized_message(recent_message))
         .unwrap();
     assert_eq!(bank.get_balance(&custodian_pubkey), expected_balance);
     assert_ne!(
@@ -5593,7 +5596,7 @@ fn test_nonce_payer() {
         bank.get_balance(&nonce_pubkey),
         nonce_starting_balance
             - bank
-                .get_fee_for_message(&recent_message.try_into().unwrap())
+                .get_fee_for_message(&new_sanitized_message(recent_message))
                 .unwrap()
     );
     assert_ne!(
@@ -5660,7 +5663,7 @@ fn test_nonce_payer_tx_wide_cap() {
         bank.get_balance(&nonce_pubkey),
         nonce_starting_balance
             - bank
-                .get_fee_for_message(&recent_message.try_into().unwrap())
+                .get_fee_for_message(&new_sanitized_message(recent_message))
                 .unwrap()
     );
     assert_ne!(
@@ -10034,8 +10037,7 @@ fn calculate_test_fee(
 #[test]
 fn test_calculate_fee() {
     // Default: no fee.
-    let message =
-        SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(
             &message,
@@ -10066,7 +10068,7 @@ fn test_calculate_fee() {
     let key1 = Pubkey::new_unique();
     let ix0 = system_instruction::transfer(&key0, &key1, 1);
     let ix1 = system_instruction::transfer(&key1, &key0, 1);
-    let message = SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&key0))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&key0)));
     assert_eq!(
         calculate_test_fee(
             &message,
@@ -10091,8 +10093,7 @@ fn test_calculate_fee_compute_units() {
 
     // One signature, no unit request
 
-    let message =
-        SanitizedMessage::try_from(Message::new(&[], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + lamports_per_signature
@@ -10102,8 +10103,7 @@ fn test_calculate_fee_compute_units() {
 
     let ix0 = system_instruction::transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1);
     let ix1 = system_instruction::transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1);
-    let message =
-        SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique()))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&Pubkey::new_unique())));
     assert_eq!(
         calculate_test_fee(&message, 1, &fee_structure,),
         max_fee + 3 * lamports_per_signature
@@ -10129,15 +10129,14 @@ fn test_calculate_fee_compute_units() {
             PrioritizationFeeType::ComputeUnitPrice(PRIORITIZATION_FEE_RATE),
             requested_compute_units as u64,
         );
-        let message = SanitizedMessage::try_from(Message::new(
+        let message = new_sanitized_message(Message::new(
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(requested_compute_units),
                 ComputeBudgetInstruction::set_compute_unit_price(PRIORITIZATION_FEE_RATE),
                 Instruction::new_with_bincode(Pubkey::new_unique(), &0_u8, vec![]),
             ],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        ));
         let fee = calculate_test_fee(&message, 1, &fee_structure);
         assert_eq!(
             fee,
@@ -10161,14 +10160,13 @@ fn test_calculate_prioritization_fee() {
     );
     let prioritization_fee = prioritization_fee_details.get_fee();
 
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             ComputeBudgetInstruction::set_compute_unit_limit(request_units),
             ComputeBudgetInstruction::set_compute_unit_price(request_unit_price),
         ],
         Some(&Pubkey::new_unique()),
-    ))
-    .unwrap();
+    ));
 
     let fee = calculate_test_fee(
         &message,
@@ -10202,24 +10200,22 @@ fn test_calculate_fee_secp256k1() {
         data: vec![1],
     };
 
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             ix0.clone(),
             secp_instruction1.clone(),
             secp_instruction2.clone(),
         ],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
     assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 2);
 
     secp_instruction1.data = vec![0];
     secp_instruction2.data = vec![10];
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[ix0, secp_instruction1, secp_instruction2],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
     assert_eq!(calculate_test_fee(&message, 1, &fee_structure,), 11);
 }
 
@@ -10745,7 +10741,7 @@ fn test_invalid_rent_state_changes_fee_payer() {
     .unwrap();
 
     // Dummy message to determine fee amount
-    let dummy_message = SanitizedMessage::try_from(Message::new_with_blockhash(
+    let dummy_message = new_sanitized_message(Message::new_with_blockhash(
         &[system_instruction::transfer(
             &rent_exempt_fee_payer.pubkey(),
             &recipient,
@@ -10753,8 +10749,7 @@ fn test_invalid_rent_state_changes_fee_payer() {
         )],
         Some(&rent_exempt_fee_payer.pubkey()),
         &recent_blockhash,
-    ))
-    .unwrap();
+    ));
     let fee = bank.get_fee_for_message(&dummy_message).unwrap();
 
     // RentPaying fee-payer can remain RentPaying
@@ -11814,7 +11809,7 @@ fn test_calculate_fee_with_congestion_multiplier() {
     let key1 = Pubkey::new_unique();
     let ix0 = system_instruction::transfer(&key0, &key1, 1);
     let ix1 = system_instruction::transfer(&key1, &key0, 1);
-    let message = SanitizedMessage::try_from(Message::new(&[ix0, ix1], Some(&key0))).unwrap();
+    let message = new_sanitized_message(Message::new(&[ix0, ix1], Some(&key0)));
 
     // assert when lamports_per_signature is less than BASE_LAMPORTS, turnning on/off
     // congestion_multiplier has no effect on fee.
@@ -11843,7 +11838,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
         lamports_per_signature: signature_fee,
         ..FeeStructure::default()
     };
-    let message = SanitizedMessage::try_from(Message::new(
+    let message = new_sanitized_message(Message::new(
         &[
             system_instruction::transfer(&key0, &key1, 1),
             ComputeBudgetInstruction::set_compute_unit_limit(request_cu as u32),
@@ -11851,8 +11846,7 @@ fn test_calculate_fee_with_request_heap_frame_flag() {
             ComputeBudgetInstruction::set_compute_unit_price(lamports_per_cu * 1_000_000),
         ],
         Some(&key0),
-    ))
-    .unwrap();
+    ));
 
     // assert when request_heap_frame is presented in tx, prioritization fee will be counted
     // into transaction fee

--- a/runtime/src/bank_client.rs
+++ b/runtime/src/bank_client.rs
@@ -19,7 +19,6 @@ use {
         transport::{Result, TransportError},
     },
     std::{
-        convert::TryFrom,
         io,
         sync::{Arc, Mutex},
         thread::{sleep, Builder},
@@ -286,7 +285,7 @@ impl SyncClient for BankClient {
     }
 
     fn get_fee_for_message(&self, message: &Message) -> Result<u64> {
-        SanitizedMessage::try_from(message.clone())
+        SanitizedMessage::try_from_legacy_message(message.clone())
             .ok()
             .and_then(|sanitized_message| self.bank.get_fee_for_message(&sanitized_message))
             .ok_or_else(|| {

--- a/runtime/src/compute_budget_details.rs
+++ b/runtime/src/compute_budget_details.rs
@@ -95,8 +95,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {
@@ -133,8 +132,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {
@@ -171,8 +169,7 @@ mod tests {
         );
 
         // assert for SanitizedTransaction
-        let sanitized_transaction =
-            SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap();
+        let sanitized_transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
         assert_eq!(
             sanitized_transaction.get_compute_budget_details(false),
             Some(ComputeBudgetDetails {

--- a/runtime/src/prioritization_fee_cache.rs
+++ b/runtime/src/prioritization_fee_cache.rs
@@ -459,7 +459,7 @@ mod tests {
             Some(signer_account),
         ));
 
-        SanitizedTransaction::try_from_legacy_transaction(transaction).unwrap()
+        SanitizedTransaction::from_transaction_for_tests(transaction)
     }
 
     // update fee cache is asynchronous, this test helper blocks until update is completed.

--- a/sdk/benches/serialize_instructions.rs
+++ b/sdk/benches/serialize_instructions.rs
@@ -9,7 +9,6 @@ use {
         pubkey::{self, Pubkey},
         sysvar::instructions::{self, construct_instructions_data},
     },
-    std::convert::TryFrom,
     test::Bencher,
 };
 
@@ -30,9 +29,11 @@ fn bench_bincode_instruction_serialize(b: &mut Bencher) {
 #[bench]
 fn bench_construct_instructions_data(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     b.iter(|| {
         let instructions = message.decompile_instructions();
         test::black_box(construct_instructions_data(&instructions));
@@ -51,9 +52,11 @@ fn bench_bincode_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {
         for i in 0..instructions.len() {
@@ -66,9 +69,11 @@ fn bench_manual_instruction_deserialize(b: &mut Bencher) {
 #[bench]
 fn bench_manual_instruction_deserialize_single(b: &mut Bencher) {
     let instructions = make_instructions();
-    let message =
-        SanitizedMessage::try_from(Message::new(&instructions, Some(&Pubkey::new_unique())))
-            .unwrap();
+    let message = SanitizedMessage::try_from_legacy_message(Message::new(
+        &instructions,
+        Some(&Pubkey::new_unique()),
+    ))
+    .unwrap();
     let serialized = construct_instructions_data(&message.decompile_instructions());
     b.iter(|| {
         #[allow(deprecated)]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -302,11 +302,10 @@ mod tests {
             message::{Message as LegacyMessage, SanitizedMessage},
             pubkey::Pubkey,
         },
-        std::convert::TryFrom,
     };
 
     fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
-        SanitizedMessage::try_from(message).unwrap()
+        SanitizedMessage::try_from_legacy_message(message).unwrap()
     }
 
     #[test]

--- a/sdk/program/src/sysvar/instructions.rs
+++ b/sdk/program/src/sysvar/instructions.rs
@@ -305,6 +305,10 @@ mod tests {
         std::convert::TryFrom,
     };
 
+    fn new_sanitized_message(message: LegacyMessage) -> SanitizedMessage {
+        SanitizedMessage::try_from(message).unwrap()
+    }
+
     #[test]
     fn test_load_store_instruction() {
         let mut data = [4u8; 10];
@@ -327,11 +331,11 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
+        let message = LegacyMessage::new(
             &[instruction0.clone(), instruction1.clone()],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        );
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -381,11 +385,9 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
-            &[instruction0, instruction1],
-            Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        let message =
+            LegacyMessage::new(&[instruction0, instruction1], Some(&Pubkey::new_unique()));
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -435,15 +437,15 @@ mod tests {
             &0,
             vec![AccountMeta::new(Pubkey::new_unique(), false)],
         );
-        let sanitized_message = SanitizedMessage::try_from(LegacyMessage::new(
+        let message = LegacyMessage::new(
             &[
                 instruction0.clone(),
                 instruction1.clone(),
                 instruction2.clone(),
             ],
             Some(&Pubkey::new_unique()),
-        ))
-        .unwrap();
+        );
+        let sanitized_message = new_sanitized_message(message);
 
         let key = id();
         let mut lamports = 0;
@@ -538,7 +540,7 @@ mod tests {
         ];
 
         let message = LegacyMessage::new(&instructions, Some(&id1));
-        let sanitized_message = SanitizedMessage::try_from(message).unwrap();
+        let sanitized_message = new_sanitized_message(message);
         let serialized = serialize_instructions(&sanitized_message.decompile_instructions());
 
         // assert that deserialize_instruction is compatible with SanitizedMessage::serialize_instructions
@@ -560,9 +562,9 @@ mod tests {
             Instruction::new_with_bincode(program_id0, &0, vec![AccountMeta::new(id1, true)]),
         ];
 
-        let message =
-            SanitizedMessage::try_from(LegacyMessage::new(&instructions, Some(&id1))).unwrap();
-        let serialized = serialize_instructions(&message.decompile_instructions());
+        let message = LegacyMessage::new(&instructions, Some(&id1));
+        let sanitized_message = new_sanitized_message(message);
+        let serialized = serialize_instructions(&sanitized_message.decompile_instructions());
         assert_eq!(
             deserialize_instruction(instructions.len(), &serialized).unwrap_err(),
             SanitizeError::IndexOutOfBounds,

--- a/sdk/src/nonce_info.rs
+++ b/sdk/src/nonce_info.rs
@@ -133,7 +133,7 @@ mod tests {
         instructions: &[Instruction],
         payer: Option<&Pubkey>,
     ) -> SanitizedMessage {
-        Message::new(instructions, payer).try_into().unwrap()
+        SanitizedMessage::try_from_legacy_message(Message::new(instructions, payer)).unwrap()
     }
 
     #[test]

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -678,7 +678,7 @@ mod tests {
             instructions,
         );
 
-        let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,
@@ -1207,7 +1207,7 @@ mod tests {
             Hash::default(),
         );
 
-        let message = SanitizedMessage::try_from(tx.message().clone()).unwrap();
+        let message = SanitizedMessage::try_from_legacy_message(tx.message().clone()).unwrap();
         let fee = FeeStructure::default().calculate_fee(
             &message,
             lamports_per_signature,

--- a/svm/tests/rent_state.rs
+++ b/svm/tests/rent_state.rs
@@ -55,7 +55,7 @@ fn test_rent_state_list_len() {
         last_block_hash,
     );
     let num_accounts = tx.message().account_keys.len();
-    let sanitized_tx = SanitizedTransaction::try_from_legacy_transaction(tx).unwrap();
+    let sanitized_tx = SanitizedTransaction::from_transaction_for_tests(tx);
     let mut error_counters = TransactionErrorMetrics::default();
     let loaded_txs = load_accounts(
         &bank,


### PR DESCRIPTION
#### Problem
`TryFrom` only supports a single argument, but in https://github.com/solana-labs/solana/pull/34901, `SanitizedMessage` will need an additional parameter for reserved account keys.

#### Summary of Changes
Rename `SanitizedMessage::try_from` to `try_from_legacy_message`

Note that the only non test/bench uses of the changed method are in banks-server and banks-client

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
