### PR TITLE
Add zk_token_proof_program module to sdk

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -535,6 +535,7 @@ pub mod system_program;
 pub mod sysvar;
 pub mod vote;
 pub mod wasm;
+pub mod zk_token_proof_program;
 
 #[deprecated(
     since = "1.17.0",

--- a/sdk/program/src/zk_token_proof_program.rs
+++ b/sdk/program/src/zk_token_proof_program.rs
@@ -1,0 +1,9 @@
+//! The [ZK Token Proof Program][np].
+//!
+//! [np]: https://docs.solanalabs.com/runtime/zk-token-proof
+//!
+//! Documentation can be found in [`solana-zk-token-sdk`].
+//!
+//! [`solana-zk-token-sdk`]: https://docs.rs/solana-zk-token-sdk/latest/solana_zk_token_sdk
+
+crate::declare_id!("ZkTokenProof1111111111111111111111111111111");

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -55,7 +55,7 @@ pub use solana_program::{
     program_pack, rent, sanitize, sdk_ids, secp256k1_program, secp256k1_recover, serde_varint,
     serialize_utils, short_vec, slot_hashes, slot_history, stable_layout, stake, stake_history,
     syscalls, system_instruction, system_program, sysvar, unchecked_div_by_const, vote,
-    wasm_bindgen,
+    wasm_bindgen, zk_token_proof_program,
 };
 
 pub mod account;


### PR DESCRIPTION
#### Problem
The zk token program id is not accessible within the sdk yet but is needed for https://github.com/solana-labs/solana/pull/34901

#### Summary of Changes
Adds a `zk_token_proof_program` module to sdk so that other core crates have easy access to its ID.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
