### PR TITLE
Replaces ReadAccountMapEntry in calculate_accounts_hash_from_index()

### DIFF
--- a/accounts-db/src/accounts_index.rs
+++ b/accounts-db/src/accounts_index.rs
@@ -1155,7 +1155,7 @@ impl<T: IndexValue, U: DiskIndexValue + From<T> + Into<T>> AccountsIndex<T, U> {
 
     /// Gets the account info (and slot) in `entry`, with `ancestors` and `max_root`,
     /// and applies `callback` to it
-    fn get_account_info_with_and_then<R>(
+    pub(crate) fn get_account_info_with_and_then<R>(
         &self,
         entry: &AccountMapEntryInner<T>,
         ancestors: Option<&Ancestors>,


### PR DESCRIPTION
#### Problem

See https://github.com/solana-labs/solana/issues/34786 for background.

We want to limit the use of `ReadAccountMapEntry`, from AccountsIndex, everywhere. Ultimately removing it once there are no more uses.

Calculating the accounts hash from the index is only used in special/exceptional or cases or tests. It's impl currently uses `ReadAccountMapEntry` via `AccountsIndex::get()`, but we can do it other ways without `ReadAccountMapEntry`. This will allow us to remove `ReadAccountMapEntry`.


#### Summary of Changes

Replace `get()` with `get_cloned()`