### PR TITLE
Purges all bank snapshots after fastboot

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -339,12 +339,12 @@ fn bank_forks_from_snapshot(
         })?;
 
         // If the node crashes before taking the next bank snapshot, the next startup will attempt
-        // to load from the same bank snapshot again. And if `shrink` has run, the account storage
+        // to load from the same bank snapshot again.  And if `shrink` has run, the account storage
         // files that are hard linked in bank snapshot will be *different* than what the bank
-        // snapshot exists.  This would cause the node to crash again.  To prevent that, purge all
+        // snapshot expects.  This would cause the node to crash again.  To prevent that, purge all
         // the bank snapshots here.  In the above scenario, this will cause the node to load from a
         // snapshot archive next time, which is safe.
-        snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
+        snapshot_utils::purge_old_bank_snapshots(&snapshot_config.bank_snapshots_dir, 0, None);
 
         bank
     };


### PR DESCRIPTION
#### Problem

Given the following scenario:

* a (bank) snapshot interval of 100
* a node starts up and loads from a bank snapshot at slot 200 (i.e. fastboot)
* the node crashes shortly after load; before the next bank snapshot is taken (before slot 300)
* and `shrink` *has* run (e.g. shrink proceeds up to slot 275)
* the node restarts, still with fastboot enabled

Then the result is:

* due to `shrink`, the account storage files on disk will (may) have changed, and reflect the account state as of slot 275
* the bank snapshot at 200 has hard links to the account storage files, and those account storage files may have been shrunk
* the bank snapshot contains information about the accounts as of slot 200, but the actual storages reflect the accounts as of slot 275
* at startup, the bank snapshot at slot 200 will be selected for fastboot again, and the node will crash, saying that the/an account storage file does not hold the correct number of accounts

If the node has a script to auto-restart, it will enter a boot-crash loop indefinitely.


#### Summary of Changes

To break out of the boot-crash loop, purge all bank snapshots after loading from one. In the above scenario, this would cause the node to load from a snapshot archive instead, which is safe. If the node crashes *after* creating another bank snapshot, then fastboot will work properly again in that situation.

Fixes #35190

#### More Info

This problem has been hit on v1.17, so I want a solution that can be backported to v1.17. The implemented solution is the least invasive—and safest—one I am aware of. A different solution to allow successfully reusing the bank snapshot from slot 200 will land in `master` and *not* be backported.