### PR TITLE
Replaces InMemAccountsIndex::get() with AccountsIndex::get_cloned()

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -9081,11 +9081,10 @@ impl AccountsDb {
                             let mut lookup_time = Measure::start("lookup_time");
                             for account_info in storage.accounts.account_iter() {
                                 let key = account_info.pubkey();
-                                let lock = self.accounts_index.get_bin(key);
-                                let x = lock.get(key).unwrap();
-                                let sl = x.slot_list.read().unwrap();
+                                let index_entry = self.accounts_index.get_cloned(key).unwrap();
+                                let slot_list = index_entry.slot_list.read().unwrap();
                                 let mut count = 0;
-                                for (slot2, account_info2) in sl.iter() {
+                                for (slot2, account_info2) in slot_list.iter() {
                                     if slot2 == slot {
                                         count += 1;
                                         let ai = AccountInfo::new(


### PR DESCRIPTION
#### Problem

`InMemAccountsIndex::get()` is a duplicate of `AccountsIndex::get_cloned()`, and one should be removed. For code outside of accounts index, it should call into `AccountsIndex` and not `InMemAccountsIndex`. So we should remove `InMemAcountsIndex::get()`.

In order to do that, we must update all the callers of `InMemAcountsIndex::get()`. Conveniently, there's only one: `AccountsDb::generate_index()`.


#### Summary of Changes

Replace calls to `InMemAccountsIndex::get()` with `AccountsIndex::get_cloned()`.

Note: This PR purposely does *not* remove `InMemAccountsIndex::get()`. That'll happen in the next PR.