### PR TITLE
Adds more info to panic message in AccountsHashVerifier

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -7443,6 +7443,11 @@ impl AccountsDb {
         self.accounts_hashes.lock().unwrap().get(&slot).cloned()
     }
 
+    /// Get all accounts hashes
+    pub fn get_accounts_hashes(&self) -> HashMap<Slot, (AccountsHash, /*capitalization*/ u64)> {
+        self.accounts_hashes.lock().unwrap().clone()
+    }
+
     /// Set the incremental accounts hash for `slot`
     ///
     /// returns the previous incremental accounts hash for `slot`
@@ -7477,6 +7482,13 @@ impl AccountsDb {
             .unwrap()
             .get(&slot)
             .cloned()
+    }
+
+    /// Get all incremental accounts hashes
+    pub fn get_incremental_accounts_hashes(
+        &self,
+    ) -> HashMap<Slot, (IncrementalAccountsHash, /*capitalization*/ u64)> {
+        self.incremental_accounts_hashes.lock().unwrap().clone()
     }
 
     /// Purge accounts hashes that are older than `last_full_snapshot_slot`

--- a/core/src/accounts_hash_verifier.rs
+++ b/core/src/accounts_hash_verifier.rs
@@ -297,11 +297,26 @@ impl AccountsHashVerifier {
                 else {
                     panic!("Calculating incremental accounts hash requires a base slot");
                 };
-                let (base_accounts_hash, base_capitalization) = accounts_package
-                    .accounts
-                    .accounts_db
-                    .get_accounts_hash(base_slot)
-                    .expect("incremental snapshot requires accounts hash and capitalization from the full snapshot it is based on");
+                let accounts_db = &accounts_package.accounts.accounts_db;
+                let Some((base_accounts_hash, base_capitalization)) =
+                    accounts_db.get_accounts_hash(base_slot)
+                else {
+                    panic!(
+                        "incremental snapshot requires accounts hash and capitalization \
+                         from the full snapshot it is based on \n\
+                         package: {accounts_package:?} \n\
+                         accounts hashes: {:?} \n\
+                         incremental accounts hashes: {:?} \n\
+                         full snapshot archives: {:?} \n\
+                         bank snapshots: {:?}",
+                        accounts_db.get_accounts_hashes(),
+                        accounts_db.get_incremental_accounts_hashes(),
+                        snapshot_utils::get_full_snapshot_archives(
+                            &snapshot_config.full_snapshot_archives_dir,
+                        ),
+                        snapshot_utils::get_bank_snapshots(&snapshot_config.bank_snapshots_dir),
+                    );
+                };
                 let (incremental_accounts_hash, incremental_capitalization) =
                     Self::_calculate_incremental_accounts_hash(accounts_package, base_slot);
                 let bank_incremental_snapshot_persistence = BankIncrementalSnapshotPersistence {


### PR DESCRIPTION
#### Problem

There have been reports on Discord where a node panics shortly after starting up with fastboot. The panic in particular is in AccountsHashVerifier, when calculating the incremental accounts hash, and it says the node doesn't have the necessary accounts hash from the base slot (i.e. full snapshot).

So far this issue has been difficult to debug, as it often depends on the state of the machine (and filesystem) when the panic occurs. If we end up in this exceptional scenario, we could log more information that could help the debugging effort.

Related to https://github.com/solana-labs/solana/pull/35350 and https://github.com/solana-labs/solana/issues/35190.


#### Summary of Changes

Adds more information to the panic message, for debugging.