### PR TITLE
Deprecate `ThinClient` and remove `ThinClient` from `bench-tps`

### DIFF
--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    clap::value_t,
     log::*,
     solana_bench_tps::{
         bench::{do_bench_tps, max_lamports_for_prioritization},
@@ -11,11 +10,9 @@ use {
     },
     solana_client::{
         connection_cache::ConnectionCache,
-        thin_client::ThinClient,
         tpu_client::{TpuClient, TpuClientConfig},
     },
     solana_genesis::Base64Account,
-    solana_gossip::gossip_service::{discover_cluster, get_client, get_multi_client},
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
         commitment_config::CommitmentConfig,
@@ -24,12 +21,12 @@ use {
         signature::{Keypair, Signer},
         system_program,
     },
-    solana_streamer::{socket::SocketAddrSpace, streamer::StakedNodes},
+    solana_streamer::streamer::StakedNodes,
     std::{
         collections::HashMap,
         fs::File,
         io::prelude::*,
-        net::{IpAddr, SocketAddr},
+        net::IpAddr,
         path::Path,
         process::exit,
         sync::{Arc, RwLock},
@@ -125,13 +122,8 @@ fn create_connection_cache(
 #[allow(clippy::too_many_arguments)]
 fn create_client(
     external_client_type: &ExternalClientType,
-    entrypoint_addr: &SocketAddr,
     json_rpc_url: &str,
     websocket_url: &str,
-    multi_client: bool,
-    rpc_tpu_sockets: Option<(SocketAddr, SocketAddr)>,
-    num_nodes: usize,
-    target_node: Option<Pubkey>,
     connection_cache: ConnectionCache,
     commitment_config: CommitmentConfig,
 ) -> Arc<dyn BenchTpsClient + Send + Sync> {
@@ -140,53 +132,6 @@ fn create_client(
             json_rpc_url.to_string(),
             commitment_config,
         )),
-        ExternalClientType::ThinClient => {
-            let connection_cache = Arc::new(connection_cache);
-            if let Some((rpc, tpu)) = rpc_tpu_sockets {
-                Arc::new(ThinClient::new(rpc, tpu, connection_cache))
-            } else {
-                let nodes =
-                    discover_cluster(entrypoint_addr, num_nodes, SocketAddrSpace::Unspecified)
-                        .unwrap_or_else(|err| {
-                            eprintln!("Failed to discover {num_nodes} nodes: {err:?}");
-                            exit(1);
-                        });
-                if multi_client {
-                    let (client, num_clients) =
-                        get_multi_client(&nodes, &SocketAddrSpace::Unspecified, connection_cache);
-                    if nodes.len() < num_clients {
-                        eprintln!(
-                            "Error: Insufficient nodes discovered.  Expecting {num_nodes} or more"
-                        );
-                        exit(1);
-                    }
-                    Arc::new(client)
-                } else if let Some(target_node) = target_node {
-                    info!("Searching for target_node: {:?}", target_node);
-                    let mut target_client = None;
-                    for node in nodes {
-                        if node.pubkey() == &target_node {
-                            target_client = Some(get_client(
-                                &[node],
-                                &SocketAddrSpace::Unspecified,
-                                connection_cache,
-                            ));
-                            break;
-                        }
-                    }
-                    Arc::new(target_client.unwrap_or_else(|| {
-                        eprintln!("Target node {target_node} not found");
-                        exit(1);
-                    }))
-                } else {
-                    Arc::new(get_client(
-                        &nodes,
-                        &SocketAddrSpace::Unspecified,
-                        connection_cache,
-                    ))
-                }
-            }
-        }
         ExternalClientType::TpuClient => {
             let rpc_client = Arc::new(RpcClient::new_with_commitment(
                 json_rpc_url.to_string(),
@@ -236,20 +181,16 @@ fn main() {
     };
 
     let cli::Config {
-        entrypoint_addr,
         json_rpc_url,
         websocket_url,
         id,
-        num_nodes,
         tx_count,
         keypair_multiplier,
         client_ids_and_stake_file,
         write_to_client_file,
         read_from_client_file,
         target_lamports_per_signature,
-        multi_client,
         num_lamports_per_account,
-        target_node,
         external_client_type,
         use_quic,
         tpu_connection_pool_size,
@@ -295,25 +236,6 @@ fn main() {
         return;
     }
 
-    info!("Connecting to the cluster");
-    let rpc_tpu_sockets: Option<(SocketAddr, SocketAddr)> =
-        if let Ok(rpc_addr) = value_t!(matches, "rpc_addr", String) {
-            let rpc = rpc_addr.parse().unwrap_or_else(|e| {
-                eprintln!("RPC address should parse as socketaddr {e:?}");
-                exit(1);
-            });
-            let tpu = value_t!(matches, "tpu_addr", String)
-                .unwrap()
-                .parse()
-                .unwrap_or_else(|e| {
-                    eprintln!("TPU address should parse to a socket: {e:?}");
-                    exit(1);
-                });
-            Some((rpc, tpu))
-        } else {
-            None
-        };
-
     let connection_cache = create_connection_cache(
         json_rpc_url,
         *tpu_connection_pool_size,
@@ -324,13 +246,8 @@ fn main() {
     );
     let client = create_client(
         external_client_type,
-        entrypoint_addr,
         json_rpc_url,
         websocket_url,
-        *multi_client,
-        rpc_tpu_sockets,
-        *num_nodes,
-        *target_node,
         connection_cache,
         *commitment_config,
     );

--- a/bench-tps/src/perf_utils.rs
+++ b/bench-tps/src/perf_utils.rs
@@ -47,7 +47,6 @@ pub fn sample_txs<T>(
         let mut txs =
             match client.get_transaction_count_with_commitment(CommitmentConfig::processed()) {
                 Err(e) => {
-                    // ThinClient with multiple options should pick a better one now.
                     info!("Couldn't get transaction count {:?}", e);
                     sleep(Duration::from_secs(sample_period));
                     continue;

--- a/client/src/thin_client.rs
+++ b/client/src/thin_client.rs
@@ -2,7 +2,7 @@
 //! a server-side TPU.  Client code should use this object instead of writing
 //! messages to the network directly. The binary encoding of its messages are
 //! unstable and may change in future releases.
-
+#[allow(deprecated)]
 use {
     crate::connection_cache::{dispatch, ConnectionCache},
     solana_quic_client::{QuicConfig, QuicConnectionManager, QuicPool},
@@ -32,11 +32,13 @@ use {
 /// A thin wrapper over thin-client/ThinClient to ease
 /// construction of the ThinClient for code dealing both with udp and quic.
 /// For the scenario only using udp or quic, use thin-client/ThinClient directly.
+#[allow(deprecated)]
 pub enum ThinClient {
     Quic(BackendThinClient<QuicPool, QuicConnectionManager, QuicConfig>),
     Udp(BackendThinClient<UdpPool, UdpConnectionManager, UdpConfig>),
 }
 
+#[allow(deprecated)]
 impl ThinClient {
     /// Create a new ThinClient that will interface with the Rpc at `rpc_addr` using TCP
     /// and the Tpu at `tpu_addr` over `transactions_socket` using Quic or UDP

--- a/net/net.sh
+++ b/net/net.sh
@@ -118,7 +118,7 @@ Operate a configured testnet
                                       - Enable UDP for tpu transactions
 
    --client-type
-                                      - Specify backend client type for bench-tps. Valid options are (thin-client|rpc-client|tpu-client), tpu-client is default
+                                      - Specify backend client type for bench-tps. Valid options are (rpc-client|tpu-client), tpu-client is default
 
  sanity/start-specific options:
    -F                   - Discard validator nodes that didn't bootup successfully
@@ -972,7 +972,7 @@ while [[ -n $1 ]]; do
     elif [[ $1 = --client-type ]]; then
       clientType=$2
       case "$clientType" in
-        thin-client|tpu-client|rpc-client)
+        tpu-client|rpc-client)
           ;;
         *)
           echo "Unexpected client type: \"$clientType\""

--- a/net/remote/remote-client.sh
+++ b/net/remote/remote-client.sh
@@ -43,19 +43,12 @@ skip)
   exit 1
 esac
 
-THIN_CLIENT=false
 RPC_CLIENT=false
 case "$clientType" in
-  thin-client)
-    THIN_CLIENT=true
-    RPC_CLIENT=false
-    ;;
   tpu-client)
-    THIN_CLIENT=false
     RPC_CLIENT=false
     ;;
   rpc-client)
-    THIN_CLIENT=false
     RPC_CLIENT=true
     ;;
   *)
@@ -74,10 +67,7 @@ solana-bench-tps)
 
   args=()
 
-  if ${THIN_CLIENT}; then
-    args+=(--entrypoint "$entrypointIp:8001")
-    args+=(--use-thin-client)
-  elif ${RPC_CLIENT}; then
+  if ${RPC_CLIENT}; then
     args+=(--use-rpc-client)
   fi
 

--- a/thin-client/README.md
+++ b/thin-client/README.md
@@ -1,0 +1,4 @@
+# thin-client
+This crate for `thin-client` is deprecated as of v2.0.0. It will receive no bugfixes or updates.
+
+Please use `tpu-client` or `rpc-client`.

--- a/thin-client/README.md
+++ b/thin-client/README.md
@@ -1,4 +1,4 @@
 # thin-client
-This crate for `thin-client` is deprecated as of v2.0.0. It will receive no bugfixes or updates.
+This crate for `thin-client` is deprecated as of v1.19.0. It will receive no bugfixes or updates.
 
 Please use `tpu-client` or `rpc-client`.

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -111,6 +111,7 @@ impl ClientOptimizer {
 }
 
 /// An object for querying and sending transactions to the network.
+#[deprecated(since = "1.18.4", note = "Use [RpcClient] or [TpuClient] instead.")]
 pub struct ThinClient<
     P, // ConnectionPool
     M, // ConnectionManager
@@ -122,6 +123,7 @@ pub struct ThinClient<
     connection_cache: Arc<ConnectionCache<P, M, C>>,
 }
 
+#[allow(deprecated)]
 impl<P, M, C> ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
@@ -323,6 +325,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<P, M, C> Client for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
@@ -334,6 +337,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<P, M, C> SyncClient for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,
@@ -619,6 +623,7 @@ where
     }
 }
 
+#[allow(deprecated)]
 impl<P, M, C> AsyncClient for ThinClient<P, M, C>
 where
     P: ConnectionPool<NewConnectionConfig = C>,

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -111,7 +111,7 @@ impl ClientOptimizer {
 }
 
 /// An object for querying and sending transactions to the network.
-#[deprecated(since = "1.18.4", note = "Use [RpcClient] or [TpuClient] instead.")]
+#[deprecated(since = "2.0.0", note = "Use [RpcClient] or [TpuClient] instead.")]
 pub struct ThinClient<
     P, // ConnectionPool
     M, // ConnectionManager

--- a/thin-client/src/thin_client.rs
+++ b/thin-client/src/thin_client.rs
@@ -111,7 +111,7 @@ impl ClientOptimizer {
 }
 
 /// An object for querying and sending transactions to the network.
-#[deprecated(since = "2.0.0", note = "Use [RpcClient] or [TpuClient] instead.")]
+#[deprecated(since = "1.19.0", note = "Use [RpcClient] or [TpuClient] instead.")]
 pub struct ThinClient<
     P, // ConnectionPool
     M, // ConnectionManager


### PR DESCRIPTION
2nd PR on the way to remove `ThinClient` completely. 
See first PR: [#35335](https://github.com/solana-labs/solana/pull/35335)
#### Problem
It is time to deprecate `ThinClient` as it is rarely used and only sends to one leader. 

#### Summary of Changes
- Deprecate `ThinClient`
- Remove `ThinClient` from `bench-tps`

Note: I left in `BenchTpsClient` implementation for `ThinClient` since `dos/` requires `ThinClient` as of now. Next PR will remove the `dos/` `ThinClient` dependency. 