### PR TITLE
Casts executable bool to integer when computing account hash

### DIFF
--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -6144,11 +6144,7 @@ impl AccountsDb {
         }
 
         // collect exec_flag, owner, pubkey into buffer to hash
-        if executable {
-            buffer.push(1_u8);
-        } else {
-            buffer.push(0_u8);
-        }
+        buffer.push(executable.into());
         buffer.extend_from_slice(owner.as_ref());
         buffer.extend_from_slice(pubkey.as_ref());
         hasher.update(&buffer);


### PR DESCRIPTION
#### Problem

Per Rust, https://doc.rust-lang.org/std/primitive.bool.html:
> The bool represents a value, which could only be either [true](https://doc.rust-lang.org/std/keyword.true.html) or [false](https://doc.rust-lang.org/std/keyword.false.html). If you cast a bool into an integer, [true](https://doc.rust-lang.org/std/keyword.true.html) will be 1 and [false](https://doc.rust-lang.org/std/keyword.false.html) will be 0.

We can use this guarantee to simplify the account hashing code.


#### Summary of Changes

Cast executable boolean to integer when computing account hash.