### PR TITLE
Remove unnecessary unwrap from `simulate_transaction_unchecked()`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -4305,9 +4305,7 @@ impl Bank {
         let post_simulation_accounts = loaded_transactions
             .into_iter()
             .next()
-            .unwrap()
-            .0
-            .ok()
+            .and_then(|(loaded_transactions_res, _)| loaded_transactions_res.ok())
             .map(|loaded_transaction| {
                 loaded_transaction
                     .accounts
@@ -4329,7 +4327,12 @@ impl Bank {
 
         debug!("simulate_transaction: {:?}", timings);
 
-        let execution_result = execution_results.pop().unwrap();
+        let execution_result =
+            execution_results
+                .pop()
+                .unwrap_or(TransactionExecutionResult::NotExecuted(
+                    TransactionError::InvalidProgramForExecution,
+                ));
         let flattened_result = execution_result.flattened_result();
         let (logs, return_data, inner_instructions) = match execution_result {
             TransactionExecutionResult::Executed { details, .. } => (


### PR DESCRIPTION
#### Problem
`simulate_transaction_unchecked()` does unnecessary `unwrap()`, that can be handled more gracefully.

#### Summary of Changes
Replace `unwrap()` with better handling.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
