### PR TITLE
Set slot and env in tx batch specific cache

### DIFF
--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -416,7 +416,12 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         .finish_cooperative_loading_task(self.slot, key, program)
                         && limit_to_load_programs
                     {
-                        let mut ret = LoadedProgramsForTxBatch::default();
+                        let mut ret = LoadedProgramsForTxBatch::new(
+                            self.slot,
+                            loaded_programs_cache
+                                .get_environments_for_epoch(self.epoch)
+                                .clone(),
+                        );
                         ret.hit_max_limit = true;
                         return ret;
                     }


### PR DESCRIPTION
#### Problem
The transaction batch specific cache sometimes doesn't have the `slot` and `environment` set correctly. It's currently not a problem, as it's missing during error scenario, and is never used. But, for future proofing, it should be correctly set.

#### Summary of Changes
Set the slot and environment in the returned cache object.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
