### PR TITLE
Removes cap_accounts_data_len feature

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -262,10 +262,6 @@ pub mod allow_votes_to_directly_update_vote_state {
     solana_sdk::declare_id!("Ff8b1fBeB86q8cjq47ZhsQLgv5EkHu3G1C99zjUfAzrq");
 }
 
-pub mod cap_accounts_data_len {
-    solana_sdk::declare_id!("capRxUrBjNkkCpjrJxPGfPaWijB7q3JoDfsWXAnt46r");
-}
-
 pub mod max_tx_account_locks {
     solana_sdk::declare_id!("CBkDroRDqm8HwHe6ak9cguPjUomrASEkfmxEaZ5CNNxz");
 }
@@ -843,7 +839,6 @@ lazy_static! {
         (reject_non_rent_exempt_vote_withdraws::id(), "fail vote withdraw instructions which leave the account non-rent-exempt"),
         (evict_invalid_stakes_cache_entries::id(), "evict invalid stakes cache entries on epoch boundaries"),
         (allow_votes_to_directly_update_vote_state::id(), "enable direct vote state update"),
-        (cap_accounts_data_len::id(), "cap the accounts data len"),
         (max_tx_account_locks::id(), "enforce max number of locked accounts per transaction"),
         (require_rent_exempt_accounts::id(), "require all new transaction accounts with data to be rent-exempt"),
         (filter_votes_outside_slot_hashes::id(), "filter vote slots older than the slot hashes history"),


### PR DESCRIPTION
#### Problem

The `cap_accounts_data_len` feature *cannot* and *will not* ever be activated. The code has been removed, but before that, it would introduce potential non-determinism. For more information, please refer to https://github.com/solana-labs/solana/issues/27029

Here's the original feature gate issue: https://github.com/solana-labs/solana/issues/24135

Now all that remains is the feature itself, and can be safely removed.

PRs that removed code gated by this feature:
* #26772
* #26776
* #26773
* #34688
* #34701


#### Summary of Changes

Remove the cap_accounts_data_len feature

Feature Gate Issue: #24135