### PR TITLE
Uses purge_all_bank_snapshots()

### DIFF
--- a/ledger/src/bank_forks_utils.rs
+++ b/ledger/src/bank_forks_utils.rs
@@ -344,7 +344,7 @@ fn bank_forks_from_snapshot(
         // snapshot expects.  This would cause the node to crash again.  To prevent that, purge all
         // the bank snapshots here.  In the above scenario, this will cause the node to load from a
         // snapshot archive next time, which is safe.
-        snapshot_utils::purge_old_bank_snapshots(&snapshot_config.bank_snapshots_dir, 0, None);
+        snapshot_utils::purge_all_bank_snapshots(&snapshot_config.bank_snapshots_dir);
 
         bank
     };


### PR DESCRIPTION
#### Problem

PR https://github.com/solana-labs/solana/pull/35350 purges all bank snapshots after fastboot. It's implementation originally used `purge_all_bank_snapshots()`, a la https://github.com/solana-labs/solana/pull/35291, but the impl was changed to make backporting to v1.18 easy.

This PR exists to update master back to the new function.


#### Summary of Changes

Use `purge_all_bank_snapshots()`.