### PR TITLE
Removes cap_accounts_data_size_per_block feature

### DIFF
--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -454,10 +454,6 @@ pub mod vote_authorize_with_seed {
     solana_sdk::declare_id!("6tRxEYKuy2L5nnv5bgn7iT28MxUbYxp5h7F3Ncf1exrT");
 }
 
-pub mod cap_accounts_data_size_per_block {
-    solana_sdk::declare_id!("qywiJyZmqTKspFg2LeuUHqcA5nNvBgobqb9UprywS9N");
-}
-
 pub mod preserve_rent_epoch_for_rent_exempt_accounts {
     solana_sdk::declare_id!("HH3MUYReL2BvqqA3oEcAa7txju5GY6G4nxJ51zvsEjEZ");
 }
@@ -890,7 +886,6 @@ lazy_static! {
         (nonce_must_be_authorized::id(), "nonce must be authorized"),
         (nonce_must_be_advanceable::id(), "durable nonces must be advanceable"),
         (vote_authorize_with_seed::id(), "An instruction you can use to change a vote accounts authority when the current authority is a derived key #25860"),
-        (cap_accounts_data_size_per_block::id(), "cap the accounts data size per block #25517"),
         (stake_redelegate_instruction::id(), "enable the redelegate stake instruction #26294"),
         (preserve_rent_epoch_for_rent_exempt_accounts::id(), "preserve rent epoch for rent exempt accounts #26479"),
         (enable_bpf_loader_extend_program_ix::id(), "enable bpf upgradeable loader ExtendProgram instruction #25234"),


### PR DESCRIPTION
#### Problem

The `cap_accounts_data_size_per_block` feature *cannot* and *will not* ever be activated. The code has been removed, but before that, it would introduce potential non-determinism. For more information, please refer to https://github.com/solana-labs/solana/issues/27029

Here's the original feature gate issue: https://github.com/solana-labs/solana/issues/25517

Now all that remains is the feature itself, and can be safely removed.

PRs that removed code gated by this feature:
* #26776


#### Summary of Changes

Remove the cap_accounts_data_size_per_block feature

Feature Gate Issue: #25517