### PR TITLE
Text-dump banking trace files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,6 +6253,7 @@ name = "solana-ledger-tool"
 version = "1.19.0"
 dependencies = [
  "assert_cmd",
+ "bincode",
  "bs58",
  "bytecount",
  "chrono",

--- a/core/src/banking_stage.rs
+++ b/core/src/banking_stage.rs
@@ -67,7 +67,7 @@ mod immutable_deserialized_packet;
 mod latest_unprocessed_votes;
 mod leader_slot_timing_metrics;
 mod multi_iterator_scanner;
-mod packet_deserializer;
+pub mod packet_deserializer;
 mod packet_receiver;
 mod read_write_account_set;
 #[allow(dead_code)]

--- a/core/src/banking_stage/packet_deserializer.rs
+++ b/core/src/banking_stage/packet_deserializer.rs
@@ -67,7 +67,7 @@ impl PacketDeserializer {
 
     /// Deserialize packet batches, aggregates tracer packet stats, and collect
     /// them into ReceivePacketResults
-    fn deserialize_and_collect_packets(
+    pub fn deserialize_and_collect_packets(
         packet_count: usize,
         banking_batches: &[BankingPacketBatch],
         round_compute_unit_price_enabled: bool,

--- a/ledger-tool/Cargo.toml
+++ b/ledger-tool/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+bincode = { workspace = true }
 bs58 = { workspace = true }
 chrono = { workspace = true, features = ["default"] }
 clap = { workspace = true }


### PR DESCRIPTION
#### Problem

#### Summary of Changes

dump banking trace file in dirtiest way

how to use:

```bash
cat ./path/to/banking_trace/events.11 | ./solana-ledger-tool shred-version | less
```


cc: @apfitzge (i need to look at https://github.com/apfitzge/banking-trace-tool)
@jstarry here it is, as requested.