### PR TITLE
Comments clarifying non-emptiness of threadset

### DIFF
--- a/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
+++ b/core/src/banking_stage/transaction_scheduler/prio_graph_scheduler.rs
@@ -388,7 +388,8 @@ impl PrioGraphScheduler {
     /// If the `chain_thread` is available, this thread will be selected, regardless of
     /// load-balancing.
     ///
-    /// Panics if the `thread_set` is empty.
+    /// Panics if the `thread_set` is empty. This should never happen, see comment
+    /// on `ThreadAwareAccountLocks::try_lock_accounts`.
     fn select_thread(
         thread_set: ThreadSet,
         batches_per_thread: &[Vec<SanitizedTransaction>],

--- a/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
+++ b/core/src/banking_stage/transaction_scheduler/thread_aware_account_locks.rs
@@ -65,6 +65,8 @@ impl ThreadAwareAccountLocks {
     /// `allowed_threads` is a set of threads that the caller restricts locking to.
     /// If accounts are schedulable, then they are locked for the thread
     /// selected by the `thread_selector` function.
+    /// `thread_selector` is only called if all accounts are schdulable, meaning
+    /// that the `thread_set` passed to `thread_selector` is non-empty.
     pub(crate) fn try_lock_accounts<'a>(
         &mut self,
         write_account_locks: impl Iterator<Item = &'a Pubkey> + Clone,


### PR DESCRIPTION
#### Problem
#35368 was reported. The code is fine, but clarifying comments are helpful here.

#### Summary of Changes
- Add comment on `ThreadAwareAccountLocks::try_lock_accounts` to clarify it will never call `thread_selector` with a non-empty thread-set.
- Add comment on `PrioGraphScheduler::select_thread` to clarify it will never be called with a non-empty set.

Fixes #35368 
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
