### PR TITLE
Proposal: Use SanitizedMessage when possible in `svm/account_loader.rs`

### DIFF
--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7534,13 +7534,13 @@ impl TransactionProcessingCallback for Bank {
 
     fn check_account_access(
         &self,
-        tx: &SanitizedTransaction,
+        message: &SanitizedMessage,
         account_index: usize,
         account: &AccountSharedData,
         error_counters: &mut TransactionErrorMetrics,
     ) -> Result<()> {
         if self.get_reward_interval() == RewardInterval::InsideInterval
-            && tx.message().is_writable(account_index)
+            && message.is_writable(account_index)
             && solana_stake_program::check_id(account.owner())
         {
             error_counters.program_execution_temporarily_restricted += 1;

--- a/svm/src/account_loader.rs
+++ b/svm/src/account_loader.rs
@@ -66,15 +66,14 @@ pub fn load_accounts<CB: TransactionProcessingCallback>(
         .zip(lock_results)
         .map(|etx| match etx {
             (tx, (Ok(()), nonce, lamports_per_signature)) => {
+                let message = tx.message();
                 let fee = if let Some(lamports_per_signature) = lamports_per_signature {
                     fee_structure.calculate_fee(
-                        tx.message(),
+                        message,
                         *lamports_per_signature,
-                        &process_compute_budget_instructions(
-                            tx.message().program_instructions_iter(),
-                        )
-                        .unwrap_or_default()
-                        .into(),
+                        &process_compute_budget_instructions(message.program_instructions_iter())
+                            .unwrap_or_default()
+                            .into(),
                         feature_set
                             .is_active(&include_loaded_accounts_data_size_in_fee_calculation::id()),
                         feature_set.is_active(&remove_rounding_in_fee_calculation::id()),
@@ -86,7 +85,7 @@ pub fn load_accounts<CB: TransactionProcessingCallback>(
                 // load transactions
                 let loaded_transaction = match load_transaction_accounts(
                     callbacks,
-                    tx,
+                    message,
                     fee,
                     error_counters,
                     account_overrides,
@@ -101,7 +100,7 @@ pub fn load_accounts<CB: TransactionProcessingCallback>(
                 let nonce = if let Some(nonce) = nonce {
                     match NonceFull::from_partial(
                         nonce,
-                        tx.message(),
+                        message,
                         &loaded_transaction.accounts,
                         &loaded_transaction.rent_debits,
                     ) {
@@ -121,25 +120,19 @@ pub fn load_accounts<CB: TransactionProcessingCallback>(
 
 fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     callbacks: &CB,
-    tx: &SanitizedTransaction,
+    message: &SanitizedMessage,
     fee: u64,
     error_counters: &mut TransactionErrorMetrics,
     account_overrides: Option<&AccountOverrides>,
     program_accounts: &HashMap<Pubkey, (&Pubkey, u64)>,
     loaded_programs: &LoadedProgramsForTxBatch,
 ) -> Result<LoadedTransaction> {
-    // NOTE: this check will never fail because `tx` is sanitized
-    if tx.signatures().is_empty() && fee != 0 {
-        return Err(TransactionError::MissingSignatureForFee);
-    }
-
     let feature_set = callbacks.get_feature_set();
 
     // There is no way to predict what program will execute without an error
     // If a fee can pay for execution then the program will be scheduled
     let mut validated_fee_payer = false;
     let mut tx_rent: TransactionRent = 0;
-    let message = tx.message();
     let account_keys = message.account_keys();
     let mut accounts_found = Vec::with_capacity(account_keys.len());
     let mut account_deps = Vec::with_capacity(account_keys.len());
@@ -147,7 +140,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
     let rent_collector = callbacks.get_rent_collector();
 
     let requested_loaded_accounts_data_size_limit =
-        get_requested_loaded_accounts_data_size_limit(tx)?;
+        get_requested_loaded_accounts_data_size_limit(message)?;
     let mut accumulated_accounts_data_size: usize = 0;
 
     let instruction_accounts = message
@@ -229,7 +222,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
 
                 if !validated_fee_payer && message.is_non_loader_key(i) {
                     if i != 0 {
-                        warn!("Payer index should be 0! {:?}", tx);
+                        warn!("Payer index should be 0! {:?}", message);
                     }
 
                     validate_fee_payer(
@@ -244,7 +237,7 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
                     validated_fee_payer = true;
                 }
 
-                callbacks.check_account_access(tx, i, &account, error_counters)?;
+                callbacks.check_account_access(message, i, &account, error_counters)?;
 
                 tx_rent += rent;
                 rent_debits.insert(key, rent, account.lamports());
@@ -349,10 +342,10 @@ fn load_transaction_accounts<CB: TransactionProcessingCallback>(
 ///     user requested loaded accounts size.
 ///     Note, requesting zero bytes will result transaction error
 fn get_requested_loaded_accounts_data_size_limit(
-    tx: &SanitizedTransaction,
+    sanitized_message: &SanitizedMessage,
 ) -> Result<Option<NonZeroUsize>> {
     let compute_budget_limits =
-        process_compute_budget_instructions(tx.message().program_instructions_iter())
+        process_compute_budget_instructions(sanitized_message.program_instructions_iter())
             .unwrap_or_default();
     // sanitize against setting size limit to zero
     NonZeroUsize::new(
@@ -1147,7 +1140,7 @@ mod tests {
             ));
             assert_eq!(
                 *expected_result,
-                get_requested_loaded_accounts_data_size_limit(&tx)
+                get_requested_loaded_accounts_data_size_limit(tx.message())
             );
         }
 
@@ -1428,30 +1421,6 @@ mod tests {
     }
 
     #[test]
-    fn test_load_transaction_accounts_failure() {
-        let message = Message::default();
-        let legacy = LegacyMessage::new(message);
-        let sanitized_message = SanitizedMessage::Legacy(legacy);
-        let mock_bank = TestCallbacks::default();
-        let mut error_counter = TransactionErrorMetrics::default();
-        let loaded_programs = LoadedProgramsForTxBatch::default();
-
-        let sanitized_transaction =
-            SanitizedTransaction::new_for_tests(sanitized_message, vec![], false);
-        let result = load_transaction_accounts(
-            &mock_bank,
-            &sanitized_transaction,
-            32,
-            &mut error_counter,
-            None,
-            &HashMap::new(),
-            &loaded_programs,
-        );
-
-        assert_eq!(result.err(), Some(TransactionError::MissingSignatureForFee));
-    }
-
-    #[test]
     fn test_load_transaction_accounts_fail_to_validate_fee_payer() {
         let message = Message {
             account_keys: vec![Pubkey::new_from_array([0; 32])],
@@ -1477,7 +1446,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1522,7 +1491,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1589,7 +1558,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1633,7 +1602,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1677,7 +1646,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1728,7 +1697,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1797,7 +1766,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1855,7 +1824,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -1918,7 +1887,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,
@@ -2007,7 +1976,7 @@ mod tests {
         );
         let result = load_transaction_accounts(
             &mock_bank,
-            &sanitized_transaction,
+            sanitized_transaction.message(),
             32,
             &mut error_counter,
             None,

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -78,7 +78,7 @@ pub trait TransactionProcessingCallback {
 
     fn check_account_access(
         &self,
-        _tx: &SanitizedTransaction,
+        _message: &SanitizedMessage,
         _account_index: usize,
         _account: &AccountSharedData,
         _error_counters: &mut TransactionErrorMetrics,


### PR DESCRIPTION
#### Problem

In `svm/src/account_loader.rs` `SanitizedTransaction` is passed between functions in many cases, when just a `SanitizedMessage` can work without any loss.

#### Summary of Changes

I swapped `SanitizedTransaction` for `SanitizedMessage` in the pertinent locations. One item to be cautious in the review is that I removed one if-condition (see line 131 in `account_loader.rs`) marked as unused, because the message was previously sanitized, so that the check would never evaluate true.

