### PR TITLE
Increases account hash's stack buffer to hold 200 bytes of data

### DIFF
--- a/accounts-db/Cargo.toml
+++ b/accounts-db/Cargo.toml
@@ -42,7 +42,7 @@ regex = { workspace = true }
 seqlock = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_derive = { workspace = true }
-smallvec = { workspace = true }
+smallvec = { workspace = true, features = ["const_generics"] }
 solana-bucket-map = { workspace = true }
 solana-config-program = { workspace = true }
 solana-frozen-abi = { workspace = true }


### PR DESCRIPTION
#### Problem

When hashing an account, we create a buffer on the stack to reduce the number of unique hash calls to make. The buffer is currently 128 bytes. The metadata fields occupy 81 bytes, which leaves 47 bytes for the account's data.

On mnb today there is approximately 431 million accounts. Of that, approximately 388 million are token accounts. That's 90% of accounts. We should ensure the stack buffer can hold the account data for a token account.

Token accounts have a size of 165 bytes[^1]. This size will be growing though. ATA and Token22 extensions will be larger too. Jon estimates 170-182 bytes is "safe"[^2].

Also, there are ~1 million stake accounts. They are 200 bytes.

We could size the stack buffer to hold 200 bytes, which will cover the vast majority of accounts. Currently, the vast majority of calls to hash an account have to perform a heap allocation.

TODO: metrics before and after

[^1]: https://github.com/solana-labs/solana-program-library/blob/e651623033fca7997ccd21e55d0f2388473122f9/token/program/src/state.rs#L134 

[^2]: https://discord.com/channels/428295358100013066/977244255212937306/1212827836281524224

#### Summary of Changes

Increases account hash's stack buffer to hold 200 bytes of data