### PR TITLE
Add github action to close new pull requests

### DIFF
--- a/.github/workflows/close-new-pull-requests.yml
+++ b/.github/workflows/close-new-pull-requests.yml
@@ -1,0 +1,20 @@
+name: Close new pull requests
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  comment-and-close:
+    runs-on: ubuntu-latest
+    steps:
+      - shell: bash
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          COMMENT: >
+            This repository is no longer in use. Please re-open this
+            pull request in the agave repo: https://github.com/anza-xyz/agave
+        run: >
+          gh pr close "$PR_NUMBER" --comment "$COMMENT"


### PR DESCRIPTION
After 2024-03-03T04:00:00Z we don't want any new commits merged to solana-labs/solana. This will ensure that anyone attempting to open a pull request gets redirected to agave.

This PR should be merged *after* the solana -> agave sync (so it isn't synced to agave)

Tested by pushing close-new-pull-requests.yml to willhickey/solana/master and then opening a PR on my fork:
https://github.com/willhickey/solana/pull/19