### PR TITLE
Add watchtower feature to watch through multiple URLs

### DIFF
--- a/watchtower/run.sh
+++ b/watchtower/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+cargo run -- --monitor-active-stake --validator-identity 6WgdYhhGE53WrZ7ywJA15hBVkw7CRbQ8yDBBTwmBtAHN --minimum-validator-identity-balance 1 --url https://api.mainnet-beta.solana.com https://solana-mainnet.rpc.extrnode.com --unhealthy-threshold 4 --interval 30

--- a/watchtower/run.sh
+++ b/watchtower/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-cargo run -- --monitor-active-stake --validator-identity 6WgdYhhGE53WrZ7ywJA15hBVkw7CRbQ8yDBBTwmBtAHN --minimum-validator-identity-balance 1 --url https://api.mainnet-beta.solana.com https://solana-mainnet.rpc.extrnode.com --unhealthy-threshold 4 --interval 30

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::arithmetic_side_effects)]
 
 use {
-    clap::{crate_description, crate_name, value_t, value_t_or_exit, App, Arg},
+    clap::{crate_description, crate_name, value_t_or_exit, App, Arg},
     log::*,
     solana_clap_utils::{
         hidden_unless_forced,
@@ -253,10 +253,12 @@ fn get_cluster_info(
 
 // Evaluate the lowest latency URL, return an RPC client and a HashMap of all the latencies
 // This hashmap will be updated regularly
-fn get_lowest_latency_client(config: &Config) -> (HashMap<String, u128>, RpcClient) {
+fn get_all_latencies_and_lowest_latency_client(config: &Config) -> (HashMap<String, u128>, RpcClient) {
     let mut best_url = String::from("");
     let mut lowest_latency = u128::MAX;
-    let mut urls_and_latencies: HashMap<String, u128> = HashMap::new();
+    let mut urls_with_latencies: HashMap<String, u128> = HashMap::new();
+
+    info!("Evaluating all RPCs...");
 
     for url in config.json_rpc_urls.iter() {
         let rpc = RpcClient::new_with_timeout(url, config.rpc_timeout);
@@ -265,19 +267,27 @@ fn get_lowest_latency_client(config: &Config) -> (HashMap<String, u128>, RpcClie
 
         let result = rpc.get_latest_blockhash();
 
-        let latency = now.elapsed().as_millis();
+        let mut latency = now.elapsed().as_millis();
 
         if latency < lowest_latency && result.is_ok() {
             lowest_latency = latency;
             best_url = url.clone();
+        } else if result.is_err() {
+            latency = u128::MAX;
         }
 
-        urls_and_latencies.insert(url.clone(), latency);
+        if latency == u128::MAX {
+            error!("{} is unhealthy!", url);
+        } else {
+            info!("{} is healthy!", url);
+        }
+
+        urls_with_latencies.insert(url.clone(), latency);
     }
 
     (
-        urls_and_latencies,
-        RpcClient::new_with_timeout(best_url, config.rpc_timeout)
+        urls_with_latencies,
+        RpcClient::new_with_timeout(best_url, config.rpc_timeout),
     )
 }
 
@@ -287,7 +297,7 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 
     let config = get_config();
 
-    let (urls_with_latencies, rpc_client) = get_lowest_latency_client(&config);
+    let (mut urls_with_latencies, mut rpc_client) = get_all_latencies_and_lowest_latency_client(&config);
     let notifier = Notifier::default();
     let mut last_transaction_count = 0;
     let mut last_recent_blockhash = Hash::default();
@@ -295,12 +305,21 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     let mut num_consecutive_failures = 0;
     let mut last_success = Instant::now();
     let mut incident = Hash::new_unique();
+
+    // A latency of u128::MAX means the url is blacklisted
     let mut current_latency = u128::MAX;
 
+    // Iteration count
+    let mut i = 0u8;
     loop {
         info!("Current RPC: {}", rpc_client.url());
+        let now = Instant::now();
+
         let failure = match get_cluster_info(&config, &rpc_client) {
             Ok((transaction_count, recent_blockhash, vote_accounts, validator_balances)) => {
+                // Update the current latency of the current url
+                current_latency = now.elapsed().as_millis();
+
                 info!("Current transaction count: {}", transaction_count);
                 info!("Recent blockhash: {}", recent_blockhash);
                 info!("Current validator count: {}", vote_accounts.current.len());
@@ -424,6 +443,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             );
             num_consecutive_failures += 1;
             if num_consecutive_failures > config.unhealthy_threshold {
+                // The RPC is no longer usable. Time to use one that is more reliable
+                current_latency = u128::MAX;
+
                 datapoint_info!("watchtower-sanity", ("ok", false, bool));
                 if last_notification_msg != notification_msg {
                     notifier.send(&notification_msg, &NotificationType::Trigger { incident });
@@ -461,6 +483,26 @@ fn main() -> Result<(), Box<dyn error::Error>> {
             last_success = Instant::now();
             num_consecutive_failures = 0;
             incident = Hash::new_unique();
+        }
+        // Update latency of the current url to the new latency
+        urls_with_latencies.insert(rpc_client.url().clone(), current_latency);
+
+        // Go through all the previous latencies:
+        // If current_latency is higher that the first found lower latency url, pick that one.
+        for (url, latency) in urls_with_latencies.iter() {
+            if *latency < current_latency {
+                info!("Switching to {}", url);
+                rpc_client = RpcClient::new_with_timeout(url.clone(), config.rpc_timeout);
+                break;
+            }
+        }
+
+        i += 1u8;
+
+        // After every x iterations, re-evaluate all RPC healths
+        if i >= 10u8 {
+            i = 0u8;
+            (urls_with_latencies, rpc_client) = get_all_latencies_and_lowest_latency_client(&config);
         }
         sleep(config.interval);
     }

--- a/watchtower/src/main.rs
+++ b/watchtower/src/main.rs
@@ -269,15 +269,14 @@ fn get_all_latencies_and_lowest_latency_client(config: &Config) -> (HashMap<Stri
 
         let mut latency = now.elapsed().as_millis();
 
-        if latency < lowest_latency && result.is_ok() {
+        if latency < lowest_latency {
             lowest_latency = latency;
             best_url = url.clone();
-        } else if result.is_err() {
-            latency = u128::MAX;
         }
 
-        if latency == u128::MAX {
+        if result.is_err() {
             error!("{} is unhealthy!", url);
+            latency = u128::MAX;
         } else {
             info!("{} is healthy!", url);
         }


### PR DESCRIPTION
#### Problem
Watchtower could only use one URL so during outages it would seem as if only that RPC might have been affected.

#### Summary of Changes
Added feature to pass multiple URLs to the CLI tool
- Latency and health of every URL is evaluated and recorded at the start of the program and after every 10 iterations of the main loop.
- Only the lowest latency URL is picked for operations
- Latency for current URL is measured on every iteration
- At the end of every iteration, the current URL's latency is compared to all existing URLs latencies since last evaluation. If any URL is found to have a lower latency, the first one in the evaluation loop is picked to be the current URL.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
