### PR TITLE
Revert "remove repetitive words (#35434)"

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -1167,7 +1167,7 @@ impl HeaviestSubtreeForkChoice {
                         //
                         // In this scenario only 60% of the network has voted before the duplicate proof for Slot 1 and 1'
                         // was viewed. Neither version of the slot will reach the duplicate confirmed threshold, so it is
-                        // critical that a new fork Slot 2 from Slot 0 is created to allow the validators on Slot 1 and
+                        // critical that a new fork Slot 2 from Slot 0 is created to allow the the validators on Slot 1 and
                         // Slot 1' to switch. Since the `best_slot` is an ancestor of the last vote (Slot 0 is ancestor of last
                         // vote Slot 1 or Slot 1'), we will trigger `SwitchForkDecision::FailedSwitchDuplicateRollback`, which
                         // will create an alternate fork off of Slot 0. Once this alternate fork is created, the `best_slot`
@@ -3514,7 +3514,7 @@ mod test {
             (vote_pubkeys[1], duplicate_leaves_descended_from_5[0]),
         ];
 
-        // The best slot should be the smallest leaf descended from 4
+        // The best slot should be the the smallest leaf descended from 4
         assert_eq!(
             heaviest_subtree_fork_choice.add_votes(
                 pubkey_votes.iter(),
@@ -3560,7 +3560,7 @@ mod test {
             ..,
         ) = setup_mark_invalid_forks_duplicate_tests();
 
-        // Marking candidate as valid again will choose the heaviest leaf of
+        // Marking candidate as valid again will choose the the heaviest leaf of
         // the newly valid branch
         let duplicate_slot = duplicate_leaves_descended_from_4[0].0;
         let duplicate_descendant = (duplicate_slot + 1, Hash::new_unique());

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -3558,7 +3558,7 @@ impl ReplayStage {
             SwitchForkDecision::SameFork
         } else {
             // If we can't switch and our last vote was on a non-duplicate/confirmed slot, then
-            // reset to the next votable bank on the same fork as our last vote,
+            // reset to the the next votable bank on the same fork as our last vote,
             // but don't vote.
 
             // We don't just reset to the heaviest fork when switch threshold fails because

--- a/docs/static/katex/katex.js
+++ b/docs/static/katex/katex.js
@@ -3662,7 +3662,7 @@ function assertSpan(group) {
 // In TeX, there are actually three sets of dimensions, one for each of
 // textstyle (size index 5 and higher: >=9pt), scriptstyle (size index 3 and 4:
 // 7-8pt), and scriptscriptstyle (size index 1 and 2: 5-6pt).  These are
-// provided in the arrays below, in that order.
+// provided in the the arrays below, in that order.
 //
 // The font metrics are stored in fonts cmsy10, cmsy7, and cmsy5 respsectively.
 // This was determined by running the following script:

--- a/docs/static/katex/katex.mjs
+++ b/docs/static/katex/katex.mjs
@@ -3686,7 +3686,7 @@ var metricMap = {
 // In TeX, there are actually three sets of dimensions, one for each of
 // textstyle (size index 5 and higher: >=9pt), scriptstyle (size index 3 and 4:
 // 7-8pt), and scriptscriptstyle (size index 1 and 2: 5-6pt).  These are
-// provided in the arrays below, in that order.
+// provided in the the arrays below, in that order.
 //
 // The font metrics are stored in fonts cmsy10, cmsy7, and cmsy5 respsectively.
 // This was determined by running the following script:

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -547,7 +547,7 @@ fn create_payers<T: 'static + BenchTpsClient + Send + Sync>(
     // Assume that if we use valid blockhash, we also have a payer
     if valid_blockhash {
         // each payer is used to fund transaction
-        // transactions are built to be invalid so the amount here is arbitrary
+        // transactions are built to be invalid so the the amount here is arbitrary
         let funding_key = Keypair::new();
         let funding_key = Arc::new(funding_key);
         let res = generate_and_fund_keypairs(

--- a/download-utils/src/lib.rs
+++ b/download-utils/src/lib.rs
@@ -39,7 +39,7 @@ fn new_spinner_progress_bar() -> ProgressBar {
 pub struct DownloadProgressRecord {
     // Duration since the beginning of the download
     pub elapsed_time: Duration,
-    // Duration since the last notification
+    // Duration since the the last notification
     pub last_elapsed_time: Duration,
     // the bytes/sec speed measured for the last notification period
     pub last_throughput: f32,
@@ -51,7 +51,7 @@ pub struct DownloadProgressRecord {
     pub current_bytes: usize,
     // percentage downloaded
     pub percentage_done: f32,
-    // Estimated remaining time (in seconds) to finish the download if it keeps at the last download speed
+    // Estimated remaining time (in seconds) to finish the download if it keeps at the the last download speed
     pub estimated_remaining_time: f32,
     // The times of the progress is being notified, it starts from 1 and increments by 1 each time
     pub notification_count: u64,

--- a/local-cluster/tests/local_cluster.rs
+++ b/local-cluster/tests/local_cluster.rs
@@ -5072,7 +5072,7 @@ fn test_boot_from_local_state() {
 // 0
 //   \--- 2
 //
-// 1. > DUPLICATE_THRESHOLD of the nodes vote on some version of the duplicate block 3,
+// 1. > DUPLICATE_THRESHOLD of the nodes vote on some version of the the duplicate block 3,
 // but don't immediately duplicate confirm so they remove 3 from fork choice and reset PoH back to 1.
 // 2. All the votes on 3 don't land because there are no further blocks building off 3.
 // 3. Some < SWITCHING_THRESHOLD of nodes vote on 2, making it the heaviest fork because no votes on 3 landed

--- a/sdk/program/src/secp256k1_recover.rs
+++ b/sdk/program/src/secp256k1_recover.rs
@@ -233,7 +233,7 @@ impl Secp256k1Pubkey {
 /// lengths of `hash` and `signature` beforehand.
 ///
 /// When run on-chain this function will not directly validate the lengths of
-/// `hash` and `signature`. It will assume they are the correct lengths and
+/// `hash` and `signature`. It will assume they are the the correct lengths and
 /// pass their pointers to the runtime, which will interpret them as 32-byte and
 /// 64-byte buffers. If the provided slices are too short, the runtime will read
 /// invalid data and attempt to interpret it, most likely returning an error,

--- a/sdk/src/secp256k1_instruction.rs
+++ b/sdk/src/secp256k1_instruction.rs
@@ -98,7 +98,7 @@
 //! Many steps must be done manually.
 //!
 //! The `solana_program` crate provides no APIs to assist in interpreting
-//! the secp256k1 instruction data. It must be done manually.
+//! the the secp256k1 instruction data. It must be done manually.
 //!
 //! The secp256k1 program is implemented with the [`libsecp256k1`] crate,
 //! which clients may also want to use.

--- a/send-transaction-service/src/tpu_info.rs
+++ b/send-transaction-service/src/tpu_info.rs
@@ -3,7 +3,7 @@ use {solana_client::connection_cache::Protocol, solana_sdk::clock::Slot, std::ne
 pub trait TpuInfo {
     fn refresh_recent_peers(&mut self);
     fn get_leader_tpus(&self, max_count: u64, protocol: Protocol) -> Vec<&SocketAddr>;
-    /// In addition to the tpu address, also return the leader slot
+    /// In addition to the the tpu address, also return the leader slot
     fn get_leader_tpus_with_slots(
         &self,
         max_count: u64,


### PR DESCRIPTION
#### Problem
I completely spaced and merged https://github.com/solana-labs/solana/pull/35434; not realizing that I was operating on the solana-labs repo and NOT agave.

#### Summary of Changes
This reverts commit 556a7499487d32359019e1e3f8fd3a28e2033b0b.