### PR TITLE
bench-tps: allow option to not set account data size on every transaction

### DIFF
--- a/bench-tps/src/bench.rs
+++ b/bench-tps/src/bench.rs
@@ -139,6 +139,7 @@ struct TransactionChunkGenerator<'a, 'b, T: ?Sized> {
     reclaim_lamports_back_to_source_account: bool,
     compute_unit_price: Option<ComputeUnitPrice>,
     instruction_padding_config: Option<InstructionPaddingConfig>,
+    skip_tx_account_data_size: bool,
 }
 
 impl<'a, 'b, T> TransactionChunkGenerator<'a, 'b, T>
@@ -153,6 +154,7 @@ where
         compute_unit_price: Option<ComputeUnitPrice>,
         instruction_padding_config: Option<InstructionPaddingConfig>,
         num_conflict_groups: Option<usize>,
+        skip_tx_account_data_size: bool,
     ) -> Self {
         let account_chunks = if let Some(num_conflict_groups) = num_conflict_groups {
             KeypairChunks::new_with_conflict_groups(gen_keypairs, chunk_size, num_conflict_groups)
@@ -170,6 +172,7 @@ where
             reclaim_lamports_back_to_source_account: false,
             compute_unit_price,
             instruction_padding_config,
+            skip_tx_account_data_size,
         }
     }
 
@@ -195,6 +198,7 @@ where
                 source_nonce_chunk,
                 dest_nonce_chunk,
                 self.reclaim_lamports_back_to_source_account,
+                self.skip_tx_account_data_size,
                 &self.instruction_padding_config,
             )
         } else {
@@ -206,6 +210,7 @@ where
                 blockhash.unwrap(),
                 &self.instruction_padding_config,
                 &self.compute_unit_price,
+                self.skip_tx_account_data_size,
             )
         };
 
@@ -397,6 +402,7 @@ where
         sustained,
         target_slots_per_epoch,
         compute_unit_price,
+        skip_tx_account_data_size,
         use_durable_nonce,
         instruction_padding_config,
         num_conflict_groups,
@@ -412,6 +418,7 @@ where
         compute_unit_price,
         instruction_padding_config,
         num_conflict_groups,
+        skip_tx_account_data_size,
     );
 
     let first_tx_count = loop {
@@ -538,6 +545,7 @@ fn generate_system_txs(
     blockhash: &Hash,
     instruction_padding_config: &Option<InstructionPaddingConfig>,
     compute_unit_price: &Option<ComputeUnitPrice>,
+    skip_tx_account_data_size: bool,
 ) -> Vec<TimestampedTransaction> {
     let pairs: Vec<_> = if !reclaim {
         source.iter().zip(dest.iter()).collect()
@@ -575,6 +583,7 @@ fn generate_system_txs(
                         *blockhash,
                         instruction_padding_config,
                         Some(**compute_unit_price),
+                        skip_tx_account_data_size,
                     ),
                     Some(timestamp()),
                 )
@@ -592,6 +601,7 @@ fn generate_system_txs(
                         *blockhash,
                         instruction_padding_config,
                         None,
+                        skip_tx_account_data_size,
                     ),
                     Some(timestamp()),
                 )
@@ -607,6 +617,7 @@ fn transfer_with_compute_unit_price_and_padding(
     recent_blockhash: Hash,
     instruction_padding_config: &Option<InstructionPaddingConfig>,
     compute_unit_price: Option<u64>,
+    skip_tx_account_data_size: bool,
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
     let transfer_instruction = system_instruction::transfer(&from_pubkey, to, lamports);
@@ -621,12 +632,15 @@ fn transfer_with_compute_unit_price_and_padding(
     } else {
         transfer_instruction
     };
-    let mut instructions = vec![
-        ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+    let mut instructions = vec![];
+    if !skip_tx_account_data_size {
+        instructions.push(
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
             get_transaction_loaded_accounts_data_size(instruction_padding_config.is_some()),
-        ),
-        instruction,
-    ];
+            )
+        )
+    }
+    instructions.push(instruction);
     if instruction_padding_config.is_some() {
         // By default, CU budget is DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT which is much larger than needed
         instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(
@@ -711,6 +725,7 @@ fn nonced_transfer_with_padding(
     nonce_account: &Pubkey,
     nonce_authority: &Keypair,
     nonce_hash: Hash,
+    skip_tx_account_data_size: bool,
     instruction_padding_config: &Option<InstructionPaddingConfig>,
 ) -> Transaction {
     let from_pubkey = from_keypair.pubkey();
@@ -726,12 +741,15 @@ fn nonced_transfer_with_padding(
     } else {
         transfer_instruction
     };
-    let instructions = vec![
-        ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+    let mut instructions = vec![];
+    if !skip_tx_account_data_size {
+        instructions.push(
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
             get_transaction_loaded_accounts_data_size(instruction_padding_config.is_some()),
-        ),
-        instruction,
-    ];
+            )
+        )
+    }
+    instructions.push(instruction);
     let message = Message::new_with_nonce(
         instructions,
         Some(&from_pubkey),
@@ -748,6 +766,7 @@ fn generate_nonced_system_txs<T: 'static + BenchTpsClient + Send + Sync + ?Sized
     source_nonce: &[&Keypair],
     dest_nonce: &VecDeque<&Keypair>,
     reclaim: bool,
+    skip_tx_account_data_size: bool,
     instruction_padding_config: &Option<InstructionPaddingConfig>,
 ) -> Vec<TimestampedTransaction> {
     let length = source.len();
@@ -768,6 +787,7 @@ fn generate_nonced_system_txs<T: 'static + BenchTpsClient + Send + Sync + ?Sized
                     &source_nonce[i].pubkey(),
                     source[i],
                     blockhashes[i],
+                    skip_tx_account_data_size,
                     instruction_padding_config,
                 ),
                 None,
@@ -786,6 +806,7 @@ fn generate_nonced_system_txs<T: 'static + BenchTpsClient + Send + Sync + ?Sized
                     &dest_nonce[i].pubkey(),
                     dest[i],
                     blockhashes[i],
+                    skip_tx_account_data_size,
                     instruction_padding_config,
                 ),
                 None,
@@ -1046,6 +1067,7 @@ pub fn generate_and_fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?S
     funding_key: &Keypair,
     keypair_count: usize,
     lamports_per_account: u64,
+    skip_tx_account_data_size: bool,
     enable_padding: bool,
 ) -> Result<Vec<Keypair>> {
     let rent = client.get_minimum_balance_for_rent_exemption(0)?;
@@ -1059,6 +1081,7 @@ pub fn generate_and_fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?S
         &keypairs,
         extra,
         lamports_per_account,
+        skip_tx_account_data_size,
         enable_padding,
     )?;
 
@@ -1074,6 +1097,7 @@ pub fn fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
     keypairs: &[Keypair],
     extra: u64,
     lamports_per_account: u64,
+    skip_tx_account_data_size: bool,
     enable_padding: bool,
 ) -> Result<()> {
     let rent = client.get_minimum_balance_for_rent_exemption(0)?;
@@ -1131,6 +1155,10 @@ pub fn fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
                 return Err(BenchTpsError::AirdropFailure);
             }
         }
+        let data_size_limit = match skip_tx_account_data_size {
+            true => 0,
+            false => get_transaction_loaded_accounts_data_size(enable_padding),
+        };
 
         fund_keys(
             client,
@@ -1139,7 +1167,7 @@ pub fn fund_keypairs<T: 'static + BenchTpsClient + Send + Sync + ?Sized>(
             total,
             max_fee,
             lamports_per_account,
-            get_transaction_loaded_accounts_data_size(enable_padding),
+            data_size_limit,
         );
     }
     Ok(())
@@ -1181,7 +1209,7 @@ mod tests {
 
         let keypair_count = config.tx_count * config.keypair_multiplier;
         let keypairs =
-            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 20, false)
+            generate_and_fund_keypairs(client.clone(), &config.id, keypair_count, 20, false, false)
                 .unwrap();
 
         do_bench_tps(client, config, keypairs, None);
@@ -1197,7 +1225,7 @@ mod tests {
         let rent = client.get_minimum_balance_for_rent_exemption(0).unwrap();
 
         let keypairs =
-            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false)
+            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false, false)
                 .unwrap();
 
         for kp in &keypairs {
@@ -1222,7 +1250,7 @@ mod tests {
         let rent = client.get_minimum_balance_for_rent_exemption(0).unwrap();
 
         let keypairs =
-            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false)
+            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false, false)
                 .unwrap();
 
         for kp in &keypairs {
@@ -1239,7 +1267,7 @@ mod tests {
         let lamports = 10_000_000;
 
         let authority_keypairs =
-            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false)
+            generate_and_fund_keypairs(client.clone(), &id, keypair_count, lamports, false, false)
                 .unwrap();
 
         let nonce_keypairs = generate_durable_nonce_accounts(client.clone(), &authority_keypairs);

--- a/bench-tps/src/cli.rs
+++ b/bench-tps/src/cli.rs
@@ -69,6 +69,7 @@ pub struct Config {
     pub use_quic: bool,
     pub tpu_connection_pool_size: usize,
     pub compute_unit_price: Option<ComputeUnitPrice>,
+    pub skip_tx_account_data_size: bool,
     pub use_durable_nonce: bool,
     pub instruction_padding_config: Option<InstructionPaddingConfig>,
     pub num_conflict_groups: Option<usize>,
@@ -101,6 +102,7 @@ impl Default for Config {
             use_quic: DEFAULT_TPU_USE_QUIC,
             tpu_connection_pool_size: DEFAULT_TPU_CONNECTION_POOL_SIZE,
             compute_unit_price: None,
+            skip_tx_account_data_size: false,
             use_durable_nonce: false,
             instruction_padding_config: None,
             num_conflict_groups: None,
@@ -359,6 +361,13 @@ pub fn build_args<'a>(version: &'_ str) -> App<'a, '_> {
                 .help("Sets random compute-unit-price in range [0..100] to transfer transactions"),
         )
         .arg(
+            Arg::with_name("skip_tx_account_data_size")
+                .long("skip-tx-account-data-size")
+                .takes_value(false)
+                .conflicts_with("instruction_padding_data_size")
+                .help("Skips setting the account data size for each transaction"),
+        )
+        .arg(
             Arg::with_name("use_durable_nonce")
                 .long("use-durable-nonce")
                 .help("Use durable transaction nonce instead of recent blockhash"),
@@ -535,6 +544,10 @@ pub fn parse_args(matches: &ArgMatches) -> Result<Config, &'static str> {
 
     if matches.is_present("use_randomized_compute_unit_price") {
         args.compute_unit_price = Some(ComputeUnitPrice::Random);
+    }
+
+    if matches.is_present("skip_tx_account_data_size") {
+        args.skip_tx_account_data_size = true;
     }
 
     if matches.is_present("use_durable_nonce") {

--- a/bench-tps/src/keypairs.rs
+++ b/bench-tps/src/keypairs.rs
@@ -16,6 +16,7 @@ pub fn get_keypairs<T>(
     num_lamports_per_account: u64,
     client_ids_and_stake_file: &str,
     read_from_client_file: bool,
+    skip_tx_account_data_size: bool,
     enable_padding: bool,
 ) -> Vec<Keypair>
 where
@@ -57,6 +58,7 @@ where
             &keypairs,
             keypairs.len().saturating_sub(keypair_count) as u64,
             last_balance,
+            skip_tx_account_data_size,
             enable_padding,
         )
         .unwrap_or_else(|e| {
@@ -70,6 +72,7 @@ where
             id,
             keypair_count,
             num_lamports_per_account,
+            skip_tx_account_data_size,
             enable_padding,
         )
         .unwrap_or_else(|e| {

--- a/bench-tps/src/main.rs
+++ b/bench-tps/src/main.rs
@@ -194,6 +194,7 @@ fn main() {
         external_client_type,
         use_quic,
         tpu_connection_pool_size,
+        skip_tx_account_data_size,
         compute_unit_price,
         use_durable_nonce,
         instruction_padding_config,
@@ -267,6 +268,7 @@ fn main() {
         *num_lamports_per_account,
         client_ids_and_stake_file,
         *read_from_client_file,
+        *skip_tx_account_data_size,
         instruction_padding_config.is_some(),
     );
 

--- a/bench-tps/src/send_batch.rs
+++ b/bench-tps/src/send_batch.rs
@@ -368,9 +368,11 @@ impl<'a> FundingTransactions<'a> for FundingContainer<'a> {
     ) {
         self.make(to_fund, |(k, t)| -> (FundingSigners<'a>, Transaction) {
             let mut instructions = system_instruction::transfer_many(&k.pubkey(), t);
-            instructions.push(
-                ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size_limit),
-            );
+            if data_size_limit != 0 {
+                instructions.push(
+                    ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(data_size_limit),
+                );
+            }
             let message = Message::new(&instructions, Some(&k.pubkey()));
             (*k, Transaction::new_unsigned(message))
         });

--- a/bench-tps/tests/bench_tps.rs
+++ b/bench-tps/tests/bench_tps.rs
@@ -106,6 +106,7 @@ fn test_bench_tps_local_cluster(config: Config) {
         keypair_count,
         lamports_per_account,
         false,
+        false,
     )
     .unwrap();
 
@@ -151,6 +152,7 @@ fn test_bench_tps_test_validator(config: Config) {
         &config.id,
         keypair_count,
         lamports_per_account,
+        false,
         false,
     )
     .unwrap();

--- a/dos/src/main.rs
+++ b/dos/src/main.rs
@@ -556,6 +556,7 @@ fn create_payers<T: 'static + BenchTpsClient + Send + Sync>(
             size,
             1_000_000,
             false,
+            false,
         )
         .unwrap_or_else(|e| {
             eprintln!("Error could not fund keys: {e:?}");


### PR DESCRIPTION
#### Problem

Bench TPS needs [this feature](https://github.com/solana-labs/solana/issues/30366) activated on the cluster since all transactions are hardcoded to include the instruction to set the account data size. However, this will not work on a test cluster where this feature is not activated. Moreover, Firedancer currently does not support that instruction.

#### Summary of Changes

This adds a flag `--skip-tx-account-data-size` which when specified, will not add that instruction. This makes Bench TPS work with FIredancer (and Solana clusters without any features activated).

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
