### PR TITLE
feat: derive Serialize,Deserialize for more types in transaction-status crate

### DIFF
--- a/transaction-status/src/lib.rs
+++ b/transaction-status/src/lib.rs
@@ -300,7 +300,8 @@ impl From<InnerInstructions> for UiInnerInstructions {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionTokenBalance {
     pub account_index: u8,
     pub mint: String,
@@ -347,7 +348,8 @@ impl From<TransactionTokenBalance> for UiTransactionTokenBalance {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TransactionStatusMeta {
     pub status: TransactionResult<()>,
     pub fee: u64,
@@ -633,7 +635,8 @@ pub enum ConvertBlockError {
     TransactionsMissing(usize, usize),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConfirmedBlock {
     pub previous_blockhash: String,
     pub blockhash: String,
@@ -646,7 +649,8 @@ pub struct ConfirmedBlock {
 
 // Confirmed block with type guarantees that transaction metadata
 // is always present. Used for uploading to BigTable.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct VersionedConfirmedBlock {
     pub previous_blockhash: String,
     pub blockhash: String,
@@ -832,8 +836,9 @@ pub struct EntrySummary {
     pub starting_transaction_index: usize,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
+#[serde(rename_all = "camelCase", untagged)]
 pub enum TransactionWithStatusMeta {
     // Very old transactions may be missing metadata
     MissingMetadata(Transaction),
@@ -841,7 +846,7 @@ pub enum TransactionWithStatusMeta {
     Complete(VersionedTransactionWithStatusMeta),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VersionedTransactionWithStatusMeta {
     pub transaction: VersionedTransaction,
     pub meta: TransactionStatusMeta,
@@ -1018,14 +1023,16 @@ pub struct EncodedTransactionWithStatusMeta {
     pub version: Option<TransactionVersion>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ConfirmedTransactionWithStatusMeta {
     pub slot: Slot,
     pub tx_with_meta: TransactionWithStatusMeta,
     pub block_time: Option<UnixTimestamp>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct VersionedConfirmedTransactionWithStatusMeta {
     pub slot: Slot,
     pub tx_with_meta: VersionedTransactionWithStatusMeta,


### PR DESCRIPTION
#### Problem

It's impossible to serialize/deserialize some of types from transaction-status crate. It can be very useful for example to caching or building specific indexer.

#### Summary of Changes
- derive Serde,Deserialize to some ConfirmedBlock, ConfirmedTransactionWithStatusMeta and other related types

It's almost the same as #26767 but it was closed without reason