### PR TITLE
Update rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.1"


### PR DESCRIPTION
#### Problem

Solana v1.17.28 fails to build when following the manual install / self-compile directions. Updating to the latest rust in this file resolved the issue, which was a package that could not be downloaded. 


#### Summary of Changes

* update to the latest stable version of rust
