### PR TITLE
configure your server for testnet

### DIFF
--- a/docs/src/operations/setup-a-validator.md
+++ b/docs/src/operations/setup-a-validator.md
@@ -389,6 +389,18 @@ software. Refer again to
 [build from source](../cli/install.md#build-from-source). It is best for
 operators to build from source rather than using the pre built binaries.
 
+## Configure Solona CLI
+
+Configure your server to use your key.
+```
+solana config set --keypair ./validator-keypair.json
+```
+
+Configure your server to use testnet.
+```
+solana config set --url https://api.testnet.solana.com
+```
+
 ## Create A Validator Startup Script
 
 In your sol home directory (e.g. `/home/sol/`), create a folder called `bin`.


### PR DESCRIPTION
#### Problem

Docs are for setting up testnet server, but while they detail configuring local solana cli for testnet, the server is never configured for testnet causing some confusion for new validator operators.

#### Summary of Changes

Add a single step to configure solana on server.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
