### PR TITLE
Feat/no threads feat for zk sdk

### DIFF
--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -41,4 +41,5 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 crate-type = ["cdylib", "rlib"]
 
 [features]
-single-threaded = []
+default = ["enable-threaded"]
+enable-threaded = []

--- a/zk-token-sdk/Cargo.toml
+++ b/zk-token-sdk/Cargo.toml
@@ -39,3 +39,6 @@ zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[features]
+single-threaded = []

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -16,6 +16,8 @@
 
 #![cfg(not(target_os = "solana"))]
 
+#[cfg(feature = "enable-threaded")]
+use std::thread;
 use {
     crate::RISTRETTO_POINT_LEN,
     curve25519_dalek::{
@@ -26,7 +28,7 @@ use {
     },
     itertools::Itertools,
     serde::{Deserialize, Serialize},
-    std::{collections::HashMap, thread},
+    std::collections::HashMap,
     thiserror::Error,
 };
 
@@ -284,12 +286,12 @@ mod tests {
 
         assert_eq!(amount, decoded.unwrap());
 
-        println!("single thread discrete log computation secs: {computation_secs:?} sec");
+        println!("no threads discrete log computation secs: {computation_secs:?} sec");
     }
 
     #[test]
-    #[cfg(feature = "single-threaded")]
-    fn test_decode_correctness_single_threaded_feat() {
+    #[cfg(not(feature = "enable-threaded"))]
+    fn test_decode_correctness_no_threads_feat() {
         // general case
         let amount: u64 = 4294967295;
 

--- a/zk-token-sdk/src/encryption/discrete_log.rs
+++ b/zk-token-sdk/src/encryption/discrete_log.rs
@@ -140,7 +140,7 @@ impl DiscreteLog {
     /// Solves the discrete log problem under the assumption that the solution
     /// is a positive 32-bit number.
     pub fn decode_u32(self) -> Option<u64> {
-        #[cfg(feature = "single_thread")]
+        #[cfg(not(feature = "enable-threaded"))]
         {
             let ristretto_iterator =
                 RistrettoIterator::new((self.target, 0_u64), (-(&self.step_point), 1_u64));
@@ -151,7 +151,7 @@ impl DiscreteLog {
             )
         }
 
-        #[cfg(not(feature = "single_thread"))]
+        #[cfg(feature = "enable-threaded")]
         {
             let mut starting_point = self.target;
             let handles = (0..self.num_threads)
@@ -270,7 +270,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "single-threaded"))]
+    #[cfg(feature = "enable-threaded")]
     fn test_decode_correctness() {
         // general case
         let amount: u64 = 4294967295;
@@ -306,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "single-threaded"))]
+    #[cfg(feature = "enable-threaded")]
     fn test_decode_correctness_threaded() {
         // general case
         let amount: u64 = 55;

--- a/zk-token-sdk/src/encryption/elgamal.rs
+++ b/zk-token-sdk/src/encryption/elgamal.rs
@@ -792,6 +792,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "enable-threaded")]
     fn test_encrypt_decrypt_correctness_multithreaded() {
         let ElGamalKeypair { public, secret } = ElGamalKeypair::new_rand();
         let amount: u32 = 57;


### PR DESCRIPTION
#### Problem

Currently, the spawning of threads makes it impossible to use the zk sdk in a wasm environment.
At the same time, per default it only uses one thread (and is quite fast still) anyway.

I would like to use the zk-sdk in a wasm project without having to fork it or (as I currently have) to copy a big part of the DiscreteLog functionality and replace the little part where it spawns a thread in a similar way as this PR does.

#### Summary of Changes

-     adds a feature called enable-threaded that is enabled by default
-     consequently does what it has done before, unless enable-threaded is disabled: it will do the same but without spawning a thread for it.
-     adds a test that can also be compiled with feature flag as e.g.

cargo test --package solana-zk-token-sdk --no-default-features
