### PR TITLE
Remove solana-install support for channels since it is already broken.

### DIFF
--- a/install/src/main.rs
+++ b/install/src/main.rs
@@ -1,3 +1,4 @@
 fn main() -> Result<(), String> {
+    println!("⚠️  solana-install is deprecated and will be discontinued when v1.18 is no longer supported. Please switch to Agave: https://github.com/anza-xyz/agave/wiki/Agave-Transition\n");
     solana_install::main()
 }

--- a/install/src/main.rs
+++ b/install/src/main.rs
@@ -1,4 +1,8 @@
 fn main() -> Result<(), String> {
-    println!("⚠️  solana-install is deprecated and will be discontinued when v1.18 is no longer supported. Please switch to Agave: https://github.com/anza-xyz/agave/wiki/Agave-Transition\n");
+    println!(
+        "⚠️  solana-install is deprecated and will be discontinued when v1.18 is no longer \
+        supported. Please switch to Agave: \
+        https://github.com/anza-xyz/agave/wiki/Agave-Transition\n"
+    );
     solana_install::main()
 }


### PR DESCRIPTION
#### Problem
solana-install is still using v1.17 as stable and v1.18 as beta. Also we don't do channel builds anymore on this repo, so `solana-install init stable` isn't picking up new commits anyway.

#### Summary of Changes
* Remove the channel functionality. Retain the ability to install with explicit release number.
* Add deprecation warning and remind users to switch to Agave