### PR TITLE
Update Dockerfile with apt-get

### DIFF
--- a/sdk/docker-solana/Dockerfile
+++ b/sdk/docker-solana/Dockerfile
@@ -33,7 +33,7 @@ EXPOSE 8008/udp
 # tpu_vote
 EXPOSE 8009/udp
 
-RUN apt update && \
+RUN apt-get update && \
     apt-get install -y bzip2 libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because apt update is deprecated on later versions of linux, it's generally recommended to use apt-get

#### Problem


#### Summary of Changes


Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->
<!-- Don't forget to add the "feature-gate" label -->
