### PR TITLE
Update install.sh was linking to 404 v1.42 for ios couldn't build now linked to v1.41 that has ios-x86_64

### DIFF
--- a/sdk/bpf/scripts/install.sh
+++ b/sdk/bpf/scripts/install.sh
@@ -3,6 +3,7 @@
 mkdir -p "$(dirname "$0")"/../dependencies
 cd "$(dirname "$0")"/../dependencies
 
+# Determine OS and architecture
 unameOut="$(uname -s)"
 case "${unameOut}" in
   Linux*)
@@ -18,6 +19,7 @@ case "${unameOut}" in
     criterion_suffix=
     machine=linux
 esac
+
 unameOut="$(uname -m)"
 case "${unameOut}" in
   arm64*)
@@ -27,61 +29,77 @@ case "${unameOut}" in
 esac
 
 download() {
-  declare url="$1/$2/$3"
-  declare filename=$3
-  declare wget_args=(
-    "$url" -O "$filename"
-    "--progress=dot:giga"
-    "--retry-connrefused"
-    "--read-timeout=30"
-  )
-  declare curl_args=(
-    -L "$url" -o "$filename"
-  )
-  if hash wget 2>/dev/null; then
-    wget_or_curl="wget ${wget_args[*]}"
-  elif hash curl 2>/dev/null; then
-    wget_or_curl="curl ${curl_args[*]}"
-  else
-    echo "Error: Neither curl nor wget were found" >&2
-    return 1
-  fi
+    declare url="$1"
+    declare filename="$2"
 
-  set -x
-  if $wget_or_curl; then
-    tar --strip-components 1 -jxf "$filename" || return 1
-    { set +x; } 2>/dev/null
-    rm -rf "$filename"
-    return 0
-  fi
-  return 1
+    echo "Downloading from: $url"
+    echo "Saving as: $filename"
+
+    set -x
+    if hash wget 2>/dev/null; then
+        echo "Using wget to download..."
+        wget "$url" -O "$filename" || return 1
+    elif hash curl 2>/dev/null; then
+        echo "Using curl to download..."
+        curl -L "$url" -o "$filename" || return 1
+    else
+        echo "Error: Neither curl nor wget were found" >&2
+        return 1
+    fi
 }
 
+# Get function to handle downloading and extraction
 get() {
   declare version=$1
   declare dirname=$2
-  declare job=$3
+  declare url=$3 
+
+  echo "Entered get() function with parameters:"
+  echo "Version: $version"
+  echo "Dirname: $dirname"
+  echo "URL: $url"
+
   declare cache_root=~/.cache/solana
   declare cache_dirname="$cache_root/$version/$dirname"
   declare cache_partial_dirname="$cache_dirname"_partial
 
+  # Create cache directory if it does not exist
   if [[ -r $cache_dirname ]]; then
+    echo "Cache found. Linking..."
     ln -sf "$cache_dirname" "$dirname" || return 1
     return 0
   fi
 
+  # Clean up any existing partial cache
+  echo "Cleaning up any existing partial cache..."
   rm -rf "$cache_partial_dirname" || return 1
   mkdir -p "$cache_partial_dirname" || return 1
   pushd "$cache_partial_dirname"
 
-  if $job; then
+  # Call download function
+  echo "Calling download function..."
+# After the download command in get() function:
+download "$url" "platform-tools-osx-x86_64.tar.bz2"
+
+echo "Checking if the downloaded file exists..."
+if [[ ! -f "platform-tools-osx-x86_64.tar.bz2" ]]; then
+    echo "Download failed or file not found!"
     popd
-    mv "$cache_partial_dirname" "$cache_dirname" || return 1
-    ln -sf "$cache_dirname" "$dirname" || return 1
-    return 0
-  fi
+    return 1
+fi
+
+echo "Extracting platform-tools-osx-x86_64.tar.bz2..."
+if tar --strip-components 1 -jxf "platform-tools-osx-x86_64.tar.bz2"; then
+    echo "Extraction succeeded."
+else
+    echo "Extraction failed! Check the file format."
+    popd
+    return 1
+fi
+
   popd
-  return 1
+  mv "$cache_partial_dirname" "$cache_dirname" || return 1
+  ln -sf "$cache_dirname" "$dirname" || return 1
 }
 
 # Install Criterion
@@ -90,50 +108,54 @@ if [[ $machine == "linux" ]]; then
 else
   version=v2.3.2
 fi
+
 if [[ ! -e criterion-$version.md || ! -e criterion ]]; then
-  (
-    set -e
-    rm -rf criterion*
-    job="download \
-           https://github.com/Snaipe/Criterion/releases/download \
-           $version \
-           criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2 \
-           criterion"
-    get $version criterion "$job"
-  )
+  set -e
+  rm -rf criterion*
+  
+  url="https://github.com/Snaipe/Criterion/releases/download/$version/criterion-$version-$machine$criterion_suffix-x86_64.tar.bz2"
+  
+  echo "Attempting to get Criterion from: $url"
+  
+  get $version criterion "$url"
   exitcode=$?
+  
   if [[ $exitcode -ne 0 ]]; then
+    echo "Failed to download Criterion. Exiting with code: $exitcode"
     exit 1
   fi
+
   touch criterion-$version.md
 fi
 
-# Install Rust-BPF
+# Install platform tools
 version=v1.41
-if [[ ! -e bpf-tools-$version.md || ! -e bpf-tools ]]; then
-  (
+if [[ ! -e platform-tools-$version.md || ! -e platform-tools ]]; then
     set -e
-    rm -rf bpf-tools*
-    rm -rf xargo
-    job="download \
-           https://github.com/anza-xyz/platform-tools/releases/download \
-           $version \
-           platform-tools-${machine}-${arch}.tar.bz2 \
-           bpf-tools"
-    get $version bpf-tools "$job"
-  )
-  exitcode=$?
-  if [[ $exitcode -ne 0 ]]; then
-    exit 1
-  fi
-  touch bpf-tools-$version.md
-  set -ex
-  ./bpf-tools/rust/bin/rustc --version
-  ./bpf-tools/rust/bin/rustc --print sysroot
-  set +e
-  rustup toolchain uninstall bpf
-  set -e
-  rustup toolchain link bpf bpf-tools/rust
+    rm -rf platform-tools*
+    echo "Attempting to download platform tools: https://github.com/anza-xyz/platform-tools/releases/download/v1.41/platform-tools-osx-x86_64.tar.bz2"
+
+    url="https://github.com/anza-xyz/platform-tools/releases/download/v1.41/platform-tools-osx-x86_64.tar.bz2"
+    echo "Attempting to call get() function."
+    
+    get $version platform-tools "$url"
+    
+    exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+        echo "Failed to download platform-tools. Exiting with error code: $exitcode"
+        exit 1
+    fi
+  
+    # Create a symbolic link to the platform-tools directory
+    echo "Linking platform-tools to the expected directory..."
+    ln -sf ~/.cache/solana/v1.41/platform-tools ~/.local/share/solana/install/releases/2.0.16/solana-release/bin/sdk/sbf/dependencies/platform-tools || {
+        echo "Failed to create symbolic link for platform-tools."
+        exit 1
+    }
+
+    touch platform-tools-$version.md
 fi
 
+# Final success message
+echo "Script completed successfully."
 exit 0


### PR DESCRIPTION
forgot to update file... now linking to v1.41 for ios-x86_64 fixed 404 build
that was linking to v1.42 and was 404... added echo comments on download band exctraction, folder creation and so on nit explains what its doing also less boring ni always think its stuck when loading a long time now we know whats going on... changed version for ios-x86_64 intel compatibility 

your welcome! xxx

#### Problem
v 1.42  has no ios-x86_64 intel version file to download link was n404 couln't build now pointing to v1.41  it sends folders to /dependecies folder and crap to cache.. and tells you a lovely echo story of its download adventure of extraction building 

#### Summary of Changes
redirected to corect ios intel version 1.41 instead of 1.42 file fixing 404 downloads  link  and adde coments to download and extraction operations.

Fixes #
<!-- OPTIONAL: Feature Gate Issue: # -->echo comments # and redirect download

<!-- Don't forget to add the "feature-gate" label -->
