### PR TITLE
remove the dependency on the blake3 "digest" feature

### DIFF
--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.75.0" # solana platform-tools rust version
 
 [dependencies]
 bincode = { workspace = true }
-blake3 = { workspace = true, features = ["digest", "traits-preview"] }
+blake3 = { workspace = true, features = ["traits-preview"] }
 borsh = { workspace = true }
 borsh0-10 = { package = "borsh", version = "0.10.3" }
 borsh0-9 = { package = "borsh", version = "0.9.3" }


### PR DESCRIPTION
Solana already depends on the "traits-preview" feature, which is [the intended way](https://github.com/BLAKE3-team/BLAKE3/blob/1170f023bf459ea3d0bedd285d6ae32309ee348c/Cargo.toml#L52) to activate the optional dependency on `digest`. Version 1.5.2 of the `blake3` crate started using the new-ish `dep:` notation in `Cargo.toml`, which removes the unintended "digest" feature. Solana currently pins v1.5.0, but this will be a build break when that pin is updated. I think a user has already run into this here: https://solana.stackexchange.com/q/17787/29050.