### PR TITLE
fix: typos in documentation files 

### DIFF
--- a/docs/src/implemented-proposals/ed_overview/ed_mvp.md
+++ b/docs/src/implemented-proposals/ed_overview/ed_mvp.md
@@ -12,7 +12,7 @@ been described above. We intend to fully engage with network stakeholders
 throughout the implementation phases \(i.e. pre-testnet, testnet, mainnet\)
 to ensure the system supports, and is representative of, the various network
 participants' interests. The first step toward this goal, however, is outlining
-a some desired MVP economic features to be available for early pre-testnet and
+some desired MVP economic features to be available for early pre-testnet and
 testnet participants. Below is a rough sketch outlining basic economic
 functionality from which a more complete and functional system can be developed.
 


### PR DESCRIPTION
Corrected `however, is outlining a some desired...` to `however, is outlining some desired...` the word `a` was removed