### PR TITLE
fix: Fixed file search in the art/ directory

### DIFF
--- a/docs/convert-ascii-to-svg.sh
+++ b/docs/convert-ascii-to-svg.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 
-# Convert .bob and .msc files in docs/art to .svg files located where the
-# site build will find them.
+# Convert .bob and .msc files in docs/art to .svg and .png files
+# located where the site build will find them.
 
 set -e
 
 cd "$(dirname "$0")"
 output_dir=static/img
+
+# Check if the 'art' directory exists
+if [[ ! -d "art" ]]; then
+  echo "Directory 'art' does not exist."
+  exit 1
+fi
 
 svgbob_cli="$(command -v svgbob_cli || true)"
 if [[ -z "$svgbob_cli" ]]; then
@@ -16,12 +22,14 @@ fi
 
 mkdir -p "$output_dir"
 
+# Convert .bob files to .svg
 while read -r bob_file; do
   out_file=$(basename "${bob_file%.*}".svg)
   "$svgbob_cli" "$bob_file" --output "$output_dir/$out_file"
-done < <(find art/*.bob)
+done < <(find art -name "*.bob")
 
+# Convert .msc files to .png
 while read -r msc_file; do
   out_file=$(basename "${msc_file%.*}".png)
   mscgen -T png -o "$output_dir/$out_file" -i "$msc_file"
-done < <(find art/*.msc)
+done < <(find art -name "*.msc")


### PR DESCRIPTION
#### Summary of Changes

Hey! I’ve made some improvements to the file search logic within the `art/` directory.

Here’s what has been done:
- **Directory existence check**: I added a check to ensure that the `art/` directory exists before attempting any file search. This prevents errors if the directory is missing.
- **Fixed file search**: The search command for `.bob` and `.msc` files now uses the correct syntax (`find art -name "*.bob"`) to accurately search through the `art/` directory and its subdirectories.


